### PR TITLE
[AAASM-124] ✨ (hooks): Add OpenAI Agents SDK _runTool governance adapter

### DIFF
--- a/src/core/init-assembly.ts
+++ b/src/core/init-assembly.ts
@@ -13,6 +13,7 @@ import type {
   LangChainToolLike
 } from "../types/langchain-adapter.js";
 import { hasOpenAIAgentsSDK } from "../hooks/openai-agents-detection.js";
+import { patchOpenAIAgents } from "../hooks/openai-agents.js";
 
 const requireFromCwd = createRequire(`${process.cwd()}/`);
 
@@ -128,6 +129,17 @@ function wrapLangChainTools(
   return Object.keys(tools);
 }
 
+async function patchDetectedOpenAIAgents(
+  client: GatewayClient,
+  frameworks: readonly string[]
+): Promise<boolean> {
+  if (!frameworks.includes("openai-agents")) {
+    return false;
+  }
+
+  return patchOpenAIAgents({ gatewayClient: client });
+}
+
 export async function initAssembly(config: AssemblyConfig): Promise<AssemblyContext> {
   const client = createClient(config);
   const frameworks = detectFrameworks();
@@ -137,13 +149,15 @@ export async function initAssembly(config: AssemblyConfig): Promise<AssemblyCont
 
   const langChainHandler = registerLangChainHandler(config, client, frameworks);
   const wrappedLangChainTools = wrapLangChainTools(config, client, frameworks);
+  const openAIAgentsPatched = await patchDetectedOpenAIAgents(client, frameworks);
 
   return {
     activeAdapters: [
       ...new Set([
         ...adapters.map((adapter) => adapter.id),
         ...(langChainHandler ? ["langchain-js"] : []),
-        ...(wrappedLangChainTools.length > 0 ? ["langchain-js"] : [])
+        ...(wrappedLangChainTools.length > 0 ? ["langchain-js"] : []),
+        ...(openAIAgentsPatched ? ["openai-agents"] : [])
       ])
     ],
     shutdown: async () => {

--- a/src/core/init-assembly.ts
+++ b/src/core/init-assembly.ts
@@ -12,6 +12,7 @@ import type {
   LangChainCallbackHandlerLike,
   LangChainToolLike
 } from "../types/langchain-adapter.js";
+import { hasOpenAIAgentsSDK } from "../hooks/openai-agents-detection.js";
 
 const requireFromCwd = createRequire(`${process.cwd()}/`);
 
@@ -42,7 +43,7 @@ export function detectFrameworks(): string[] {
   if (isPackageInstalled("ai")) {
     detected.push("vercel-ai-sdk");
   }
-  if (isPackageInstalled("@openai/agents")) {
+  if (hasOpenAIAgentsSDK()) {
     detected.push("openai-agents");
   }
 

--- a/src/hooks/openai-agents-detection.ts
+++ b/src/hooks/openai-agents-detection.ts
@@ -1,0 +1,12 @@
+import { createRequire } from "node:module";
+
+const requireFromCwd = createRequire(`${process.cwd()}/`);
+
+export function hasOpenAIAgentsSDK(): boolean {
+  try {
+    requireFromCwd.resolve("@openai/agents");
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/hooks/openai-agents.ts
+++ b/src/hooks/openai-agents.ts
@@ -1,7 +1,8 @@
 import type {
   OpenAIAgentsRunContext,
   OpenAIAgentsRunTool,
-  OpenAIAgentsToolCall
+  OpenAIAgentsToolCall,
+  OpenAIAgentsToolCallOutput
 } from "../types/openai-agents-adapter.js";
 
 export interface OpenAIAgentsAgentClass {
@@ -55,4 +56,12 @@ export function extractToolCallContextMetadata(
     agentId: context?.agentId ?? undefined,
     runId: context?.runId ?? undefined
   };
+}
+
+export function formatDeniedToolCallOutput(
+  reason: string | undefined,
+  prefix: string
+): OpenAIAgentsToolCallOutput {
+  const detail = reason?.trim() ? reason : "denied";
+  return { error: `${prefix}: ${detail}` };
 }

--- a/src/hooks/openai-agents.ts
+++ b/src/hooks/openai-agents.ts
@@ -49,8 +49,8 @@ export function parseToolCallArguments(toolCall: OpenAIAgentsToolCall): unknown 
 }
 
 export interface OpenAIAgentsToolCallContextMetadata {
-  agentId?: string;
-  runId?: string;
+  agentId: string | undefined;
+  runId: string | undefined;
 }
 
 export function extractToolCallContextMetadata(
@@ -111,7 +111,11 @@ export function createPatchedRunTool(
   gatewayClient: GatewayClient,
   options: CreatePatchedRunToolOptions
 ): OpenAIAgentsRunTool {
-  return async function patchedRunTool(toolCall, context) {
+  return async function patchedRunTool(
+    this: unknown,
+    toolCall: OpenAIAgentsToolCall,
+    context: OpenAIAgentsRunContext
+  ) {
     const toolName = toolCall.function.name;
     const args = parseToolCallArguments(toolCall);
     const metadata = extractToolCallContextMetadata(context);

--- a/src/hooks/openai-agents.ts
+++ b/src/hooks/openai-agents.ts
@@ -1,4 +1,7 @@
-import type { OpenAIAgentsRunTool } from "../types/openai-agents-adapter.js";
+import type {
+  OpenAIAgentsRunTool,
+  OpenAIAgentsToolCall
+} from "../types/openai-agents-adapter.js";
 
 export interface OpenAIAgentsAgentClass {
   prototype: {
@@ -29,4 +32,12 @@ export function captureOriginalRunTool(
   }
 
   return openAIAgentsPatchState.originalRunTool;
+}
+
+export function parseToolCallArguments(toolCall: OpenAIAgentsToolCall): unknown {
+  try {
+    return JSON.parse(toolCall.function.arguments);
+  } catch {
+    return toolCall.function.arguments;
+  }
 }

--- a/src/hooks/openai-agents.ts
+++ b/src/hooks/openai-agents.ts
@@ -1,4 +1,5 @@
 import type {
+  OpenAIAgentsRunContext,
   OpenAIAgentsRunTool,
   OpenAIAgentsToolCall
 } from "../types/openai-agents-adapter.js";
@@ -40,4 +41,18 @@ export function parseToolCallArguments(toolCall: OpenAIAgentsToolCall): unknown 
   } catch {
     return toolCall.function.arguments;
   }
+}
+
+export interface OpenAIAgentsToolCallContextMetadata {
+  agentId?: string;
+  runId?: string;
+}
+
+export function extractToolCallContextMetadata(
+  context: OpenAIAgentsRunContext | undefined
+): OpenAIAgentsToolCallContextMetadata {
+  return {
+    agentId: context?.agentId ?? undefined,
+    runId: context?.runId ?? undefined
+  };
 }

--- a/src/hooks/openai-agents.ts
+++ b/src/hooks/openai-agents.ts
@@ -16,11 +16,13 @@ export interface OpenAIAgentsAgentClass {
 export interface OpenAIAgentsPatchState {
   isPatched: boolean;
   originalRunTool: OpenAIAgentsRunTool | undefined;
+  patchedAgentClass: OpenAIAgentsAgentClass | undefined;
 }
 
 export const openAIAgentsPatchState: OpenAIAgentsPatchState = {
   isPatched: false,
-  originalRunTool: undefined
+  originalRunTool: undefined,
+  patchedAgentClass: undefined
 };
 
 export function captureOriginalRunTool(
@@ -209,5 +211,24 @@ export async function patchOpenAIAgents(
     }
   );
   openAIAgentsPatchState.isPatched = true;
+  openAIAgentsPatchState.patchedAgentClass = agentClass;
+  return true;
+}
+
+export function unpatchOpenAIAgents(): boolean {
+  if (!openAIAgentsPatchState.isPatched) {
+    return false;
+  }
+  if (!openAIAgentsPatchState.patchedAgentClass) {
+    return false;
+  }
+  if (!openAIAgentsPatchState.originalRunTool) {
+    return false;
+  }
+
+  openAIAgentsPatchState.patchedAgentClass.prototype._runTool =
+    openAIAgentsPatchState.originalRunTool;
+  openAIAgentsPatchState.isPatched = false;
+  openAIAgentsPatchState.patchedAgentClass = undefined;
   return true;
 }

--- a/src/hooks/openai-agents.ts
+++ b/src/hooks/openai-agents.ts
@@ -97,3 +97,52 @@ export function recordToolResultNonBlocking(
 ): void {
   void gatewayClient.recordResult({ runId, output }).catch(() => undefined);
 }
+
+export interface CreatePatchedRunToolOptions {
+  fallbackRunId: string;
+  approvalTimeoutMs: number;
+}
+
+export function createPatchedRunTool(
+  originalRunTool: OpenAIAgentsRunTool,
+  gatewayClient: GatewayClient,
+  options: CreatePatchedRunToolOptions
+): OpenAIAgentsRunTool {
+  return async function patchedRunTool(toolCall, context) {
+    const toolName = toolCall.function.name;
+    const args = parseToolCallArguments(toolCall);
+    const metadata = extractToolCallContextMetadata(context);
+    const runId = metadata.runId ?? options.fallbackRunId;
+
+    const decision = await gatewayClient.check({
+      action: "tool_call",
+      toolName,
+      args,
+      runId
+    });
+
+    if (decision.denied) {
+      return formatDeniedToolCallOutput(decision.reason, "Blocked by governance policy");
+    }
+
+    if (decision.pending) {
+      const pendingOutput = await handlePendingApproval(gatewayClient, {
+        toolName,
+        runId,
+        timeoutMs: options.approvalTimeoutMs
+      });
+      if (pendingOutput) {
+        return pendingOutput;
+      }
+    }
+
+    const result = await originalRunTool.call(this, toolCall, context);
+    recordToolResultNonBlocking(gatewayClient, runId, {
+      toolName,
+      args,
+      result,
+      agentId: metadata.agentId
+    });
+    return result;
+  };
+}

--- a/src/hooks/openai-agents.ts
+++ b/src/hooks/openai-agents.ts
@@ -179,9 +179,13 @@ async function loadAgentClassFromSdk(): Promise<OpenAIAgentsAgentClass | undefin
     return undefined;
   }
 
-  const moduleName = "@openai/agents";
-  const module = (await import(moduleName)) as { Agent?: OpenAIAgentsAgentClass };
-  return module.Agent;
+  try {
+    const moduleName = "@openai/agents";
+    const module = (await import(moduleName)) as { Agent?: OpenAIAgentsAgentClass };
+    return module.Agent;
+  } catch {
+    return undefined;
+  }
 }
 
 export async function patchOpenAIAgents(

--- a/src/hooks/openai-agents.ts
+++ b/src/hooks/openai-agents.ts
@@ -89,3 +89,11 @@ export async function handlePendingApproval(
 
   return formatDeniedToolCallOutput(approval.reason, "Approval denied");
 }
+
+export function recordToolResultNonBlocking(
+  gatewayClient: GatewayClient,
+  runId: string,
+  output: unknown
+): void {
+  void gatewayClient.recordResult({ runId, output }).catch(() => undefined);
+}

--- a/src/hooks/openai-agents.ts
+++ b/src/hooks/openai-agents.ts
@@ -4,6 +4,7 @@ import type {
   OpenAIAgentsToolCall,
   OpenAIAgentsToolCallOutput
 } from "../types/openai-agents-adapter.js";
+import type { GatewayClient } from "../gateway/client.js";
 
 export interface OpenAIAgentsAgentClass {
   prototype: {
@@ -64,4 +65,27 @@ export function formatDeniedToolCallOutput(
 ): OpenAIAgentsToolCallOutput {
   const detail = reason?.trim() ? reason : "denied";
   return { error: `${prefix}: ${detail}` };
+}
+
+export interface AwaitApprovalOptions {
+  toolName: string;
+  runId: string;
+  timeoutMs: number;
+}
+
+export async function handlePendingApproval(
+  gatewayClient: GatewayClient,
+  options: AwaitApprovalOptions
+): Promise<OpenAIAgentsToolCallOutput | undefined> {
+  const approval = await gatewayClient.waitForApproval(
+    options.toolName,
+    options.runId,
+    options.timeoutMs
+  );
+
+  if (!approval.denied) {
+    return undefined;
+  }
+
+  return formatDeniedToolCallOutput(approval.reason, "Approval denied");
 }

--- a/src/hooks/openai-agents.ts
+++ b/src/hooks/openai-agents.ts
@@ -5,6 +5,7 @@ import type {
   OpenAIAgentsToolCallOutput
 } from "../types/openai-agents-adapter.js";
 import type { GatewayClient } from "../gateway/client.js";
+import { hasOpenAIAgentsSDK } from "./openai-agents-detection.js";
 
 export interface OpenAIAgentsAgentClass {
   prototype: {
@@ -162,4 +163,51 @@ export function createPatchedRunTool(
 
     return executeOriginal();
   };
+}
+
+export interface PatchOpenAIAgentsOptions {
+  gatewayClient: GatewayClient;
+  approvalTimeoutMs?: number;
+  fallbackRunId?: string;
+  loadAgentClass?: () => Promise<OpenAIAgentsAgentClass | undefined>;
+}
+
+async function loadAgentClassFromSdk(): Promise<OpenAIAgentsAgentClass | undefined> {
+  if (!hasOpenAIAgentsSDK()) {
+    return undefined;
+  }
+
+  const moduleName = "@openai/agents";
+  const module = (await import(moduleName)) as { Agent?: OpenAIAgentsAgentClass };
+  return module.Agent;
+}
+
+export async function patchOpenAIAgents(
+  options: PatchOpenAIAgentsOptions
+): Promise<boolean> {
+  if (openAIAgentsPatchState.isPatched) {
+    return true;
+  }
+
+  const loadAgentClass = options.loadAgentClass ?? loadAgentClassFromSdk;
+  const agentClass = await loadAgentClass();
+  if (!agentClass) {
+    return false;
+  }
+
+  const originalRunTool = captureOriginalRunTool(agentClass);
+  if (!originalRunTool) {
+    return false;
+  }
+
+  agentClass.prototype._runTool = createPatchedRunTool(
+    originalRunTool,
+    options.gatewayClient,
+    {
+      approvalTimeoutMs: options.approvalTimeoutMs ?? 30_000,
+      fallbackRunId: options.fallbackRunId ?? "openai-agents"
+    }
+  );
+  openAIAgentsPatchState.isPatched = true;
+  return true;
 }

--- a/src/hooks/openai-agents.ts
+++ b/src/hooks/openai-agents.ts
@@ -1,0 +1,32 @@
+import type { OpenAIAgentsRunTool } from "../types/openai-agents-adapter.js";
+
+export interface OpenAIAgentsAgentClass {
+  prototype: {
+    _runTool?: OpenAIAgentsRunTool;
+  };
+}
+
+export interface OpenAIAgentsPatchState {
+  isPatched: boolean;
+  originalRunTool: OpenAIAgentsRunTool | undefined;
+}
+
+export const openAIAgentsPatchState: OpenAIAgentsPatchState = {
+  isPatched: false,
+  originalRunTool: undefined
+};
+
+export function captureOriginalRunTool(
+  agentClass: OpenAIAgentsAgentClass
+): OpenAIAgentsRunTool | undefined {
+  const candidate = agentClass.prototype._runTool;
+  if (!candidate) {
+    return undefined;
+  }
+
+  if (!openAIAgentsPatchState.originalRunTool) {
+    openAIAgentsPatchState.originalRunTool = candidate;
+  }
+
+  return openAIAgentsPatchState.originalRunTool;
+}

--- a/src/hooks/openai-agents.ts
+++ b/src/hooks/openai-agents.ts
@@ -114,35 +114,52 @@ export function createPatchedRunTool(
     const metadata = extractToolCallContextMetadata(context);
     const runId = metadata.runId ?? options.fallbackRunId;
 
-    const decision = await gatewayClient.check({
-      action: "tool_call",
-      toolName,
-      args,
-      runId
-    });
+    const executeOriginal = async (): Promise<OpenAIAgentsToolCallOutput> => {
+      const result = await originalRunTool.call(this, toolCall, context);
+      recordToolResultNonBlocking(gatewayClient, runId, {
+        toolName,
+        args,
+        result,
+        agentId: metadata.agentId
+      });
+      return result;
+    };
+
+    let decision;
+    try {
+      decision = await gatewayClient.check({
+        action: "tool_call",
+        toolName,
+        args,
+        runId
+      });
+    } catch {
+      return executeOriginal();
+    }
 
     if (decision.denied) {
-      return formatDeniedToolCallOutput(decision.reason, "Blocked by governance policy");
+      return formatDeniedToolCallOutput(
+        decision.reason,
+        "Blocked by governance policy"
+      );
     }
 
     if (decision.pending) {
-      const pendingOutput = await handlePendingApproval(gatewayClient, {
-        toolName,
-        runId,
-        timeoutMs: options.approvalTimeoutMs
-      });
+      let pendingOutput;
+      try {
+        pendingOutput = await handlePendingApproval(gatewayClient, {
+          toolName,
+          runId,
+          timeoutMs: options.approvalTimeoutMs
+        });
+      } catch {
+        return executeOriginal();
+      }
       if (pendingOutput) {
         return pendingOutput;
       }
     }
 
-    const result = await originalRunTool.call(this, toolCall, context);
-    recordToolResultNonBlocking(gatewayClient, runId, {
-      toolName,
-      args,
-      result,
-      agentId: metadata.agentId
-    });
-    return result;
+    return executeOriginal();
   };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,3 +16,9 @@ export type {
   LangChainRunConfig,
   LangChainToolLike
 } from "./langchain-adapter.js";
+export type {
+  OpenAIAgentsRunContext,
+  OpenAIAgentsRunTool,
+  OpenAIAgentsToolCall,
+  OpenAIAgentsToolCallOutput
+} from "./openai-agents-adapter.js";

--- a/src/types/openai-agents-adapter.ts
+++ b/src/types/openai-agents-adapter.ts
@@ -1,0 +1,20 @@
+export interface OpenAIAgentsToolCall {
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
+export interface OpenAIAgentsRunContext {
+  agentId?: string;
+  runId?: string;
+}
+
+export interface OpenAIAgentsToolCallOutput {
+  error?: string;
+}
+
+export type OpenAIAgentsRunTool = (
+  toolCall: OpenAIAgentsToolCall,
+  context: OpenAIAgentsRunContext
+) => Promise<OpenAIAgentsToolCallOutput>;

--- a/src/types/openai-agents-adapter.ts
+++ b/src/types/openai-agents-adapter.ts
@@ -8,10 +8,12 @@ export interface OpenAIAgentsToolCall {
 export interface OpenAIAgentsRunContext {
   agentId?: string;
   runId?: string;
+  [key: string]: unknown;
 }
 
 export interface OpenAIAgentsToolCallOutput {
   error?: string;
+  [key: string]: unknown;
 }
 
 export type OpenAIAgentsRunTool = (

--- a/tests/openai-agents-hook.test.ts
+++ b/tests/openai-agents-hook.test.ts
@@ -219,6 +219,24 @@ describe("openai agents adapter", () => {
       runId: undefined
     });
   });
+
+  it("records results in fire-and-forget mode without surfacing recorder failures", async () => {
+    const gateway = createGatewayClientMock();
+    gateway.recordResult = vi.fn(async () => {
+      throw new Error("recording failed");
+    });
+    const hooks = await import("../src/hooks/openai-agents.js");
+
+    expect(() =>
+      hooks.recordToolResultNonBlocking(gateway, "run-5", { ok: true })
+    ).not.toThrow();
+
+    await Promise.resolve();
+    expect(gateway.recordResult).toHaveBeenCalledWith({
+      runId: "run-5",
+      output: { ok: true }
+    });
+  });
 });
 async function resetPatchState() {
   const hooks = await import("../src/hooks/openai-agents.js");

--- a/tests/openai-agents-hook.test.ts
+++ b/tests/openai-agents-hook.test.ts
@@ -104,6 +104,39 @@ describe("openai agents adapter", () => {
     expect(originalRunTool).not.toHaveBeenCalled();
   });
 
+  it("executes original tool on ALLOW decision", async () => {
+    const gateway = createGatewayClientMock();
+    gateway.check = vi.fn(async () => ({ denied: false, pending: false }));
+    const originalRunTool = vi.fn(async () => ({ ok: "allow-path" }));
+
+    const hooks = await import("../src/hooks/openai-agents.js");
+    const patchedRunTool = hooks.createPatchedRunTool(originalRunTool, gateway, {
+      fallbackRunId: "fallback-run",
+      approvalTimeoutMs: 5_000
+    });
+
+    const result = await patchedRunTool(
+      {
+        function: {
+          name: "safe_tool",
+          arguments: "{\"count\":1}"
+        }
+      },
+      {
+        runId: "run-allow"
+      }
+    );
+
+    expect(result).toEqual({ ok: "allow-path" });
+    expect(gateway.check).toHaveBeenCalledWith({
+      action: "tool_call",
+      toolName: "safe_tool",
+      args: { count: 1 },
+      runId: "run-allow"
+    });
+    expect(originalRunTool).toHaveBeenCalledTimes(1);
+  });
+
   it("continues execution when PENDING is approved", async () => {
     const gateway = createGatewayClientMock();
     gateway.check = vi.fn(async () => ({ pending: true, denied: false }));

--- a/tests/openai-agents-hook.test.ts
+++ b/tests/openai-agents-hook.test.ts
@@ -169,6 +169,37 @@ describe("openai agents adapter", () => {
     });
     expect(originalRunTool).not.toHaveBeenCalled();
   });
+
+  it("falls back to raw argument string when JSON parsing fails", async () => {
+    const gateway = createGatewayClientMock();
+    gateway.check = vi.fn(async () => ({ denied: false, pending: false }));
+    const originalRunTool = vi.fn(async () => ({ ok: true }));
+
+    const hooks = await import("../src/hooks/openai-agents.js");
+    const patchedRunTool = hooks.createPatchedRunTool(originalRunTool, gateway, {
+      fallbackRunId: "fallback-run",
+      approvalTimeoutMs: 2_000
+    });
+
+    await patchedRunTool(
+      {
+        function: {
+          name: "malformed_payload_tool",
+          arguments: "{bad-json"
+        }
+      },
+      {
+        runId: "run-4"
+      }
+    );
+
+    expect(gateway.check).toHaveBeenCalledWith({
+      action: "tool_call",
+      toolName: "malformed_payload_tool",
+      args: "{bad-json",
+      runId: "run-4"
+    });
+  });
 });
 async function resetPatchState() {
   const hooks = await import("../src/hooks/openai-agents.js");

--- a/tests/openai-agents-hook.test.ts
+++ b/tests/openai-agents-hook.test.ts
@@ -103,6 +103,39 @@ describe("openai agents adapter", () => {
     });
     expect(originalRunTool).not.toHaveBeenCalled();
   });
+
+  it("continues execution when PENDING is approved", async () => {
+    const gateway = createGatewayClientMock();
+    gateway.check = vi.fn(async () => ({ pending: true, denied: false }));
+    gateway.waitForApproval = vi.fn(async () => ({ denied: false }));
+    const originalRunTool = vi.fn(async () => ({ ok: "approved" }));
+
+    const hooks = await import("../src/hooks/openai-agents.js");
+    const patchedRunTool = hooks.createPatchedRunTool(originalRunTool, gateway, {
+      fallbackRunId: "fallback-run",
+      approvalTimeoutMs: 8_000
+    });
+
+    const result = await patchedRunTool(
+      {
+        function: {
+          name: "transfer_funds",
+          arguments: "{\"amount\":100}"
+        }
+      },
+      {
+        runId: "run-2"
+      }
+    );
+
+    expect(result).toEqual({ ok: "approved" });
+    expect(gateway.waitForApproval).toHaveBeenCalledWith(
+      "transfer_funds",
+      "run-2",
+      8_000
+    );
+    expect(originalRunTool).toHaveBeenCalledTimes(1);
+  });
 });
 async function resetPatchState() {
   const hooks = await import("../src/hooks/openai-agents.js");

--- a/tests/openai-agents-hook.test.ts
+++ b/tests/openai-agents-hook.test.ts
@@ -266,6 +266,29 @@ describe("openai agents adapter", () => {
     expect(result).toEqual({ ok: "fallback-path" });
     expect(originalRunTool).toHaveBeenCalledTimes(1);
   });
+
+  it("restores original _runTool when unpatch is called", async () => {
+    const gateway = createGatewayClientMock();
+    const originalRunTool = vi.fn(async () => ({ ok: true }));
+    const fakeAgentClass: FakeAgentClass = {
+      prototype: {
+        _runTool: originalRunTool
+      }
+    };
+
+    const hooks = await import("../src/hooks/openai-agents.js");
+    const patched = await hooks.patchOpenAIAgents({
+      gatewayClient: gateway,
+      loadAgentClass: async () => fakeAgentClass
+    });
+
+    expect(patched).toBe(true);
+    expect(fakeAgentClass.prototype._runTool).not.toBe(originalRunTool);
+
+    const restored = hooks.unpatchOpenAIAgents();
+    expect(restored).toBe(true);
+    expect(fakeAgentClass.prototype._runTool).toBe(originalRunTool);
+  });
 });
 async function resetPatchState() {
   const hooks = await import("../src/hooks/openai-agents.js");

--- a/tests/openai-agents-hook.test.ts
+++ b/tests/openai-agents-hook.test.ts
@@ -73,6 +73,36 @@ describe("openai agents adapter", () => {
       hooks.openAIAgentsPatchState.originalRunTool
     );
   });
+
+  it("returns error output on DENY without throwing or executing original tool", async () => {
+    const gateway = createGatewayClientMock();
+    gateway.check = vi.fn(async () => ({ denied: true, reason: "policy-blocked" }));
+    const originalRunTool = vi.fn(async () => ({ ok: true }));
+
+    const hooks = await import("../src/hooks/openai-agents.js");
+    const patchedRunTool = hooks.createPatchedRunTool(originalRunTool, gateway, {
+      fallbackRunId: "fallback-run",
+      approvalTimeoutMs: 5_000
+    });
+
+    const result = await patchedRunTool(
+      {
+        function: {
+          name: "send_email",
+          arguments: "{\"to\":\"user@example.com\"}"
+        }
+      },
+      {
+        runId: "run-1",
+        agentId: "agent-1"
+      }
+    );
+
+    expect(result).toEqual({
+      error: "Blocked by governance policy: policy-blocked"
+    });
+    expect(originalRunTool).not.toHaveBeenCalled();
+  });
 });
 async function resetPatchState() {
   const hooks = await import("../src/hooks/openai-agents.js");

--- a/tests/openai-agents-hook.test.ts
+++ b/tests/openai-agents-hook.test.ts
@@ -200,6 +200,25 @@ describe("openai agents adapter", () => {
       runId: "run-4"
     });
   });
+
+  it("extracts agentId and runId from context with optional chaining", async () => {
+    const hooks = await import("../src/hooks/openai-agents.js");
+
+    expect(
+      hooks.extractToolCallContextMetadata({
+        agentId: "agent-42",
+        runId: "run-42"
+      })
+    ).toEqual({
+      agentId: "agent-42",
+      runId: "run-42"
+    });
+
+    expect(hooks.extractToolCallContextMetadata(undefined)).toEqual({
+      agentId: undefined,
+      runId: undefined
+    });
+  });
 });
 async function resetPatchState() {
   const hooks = await import("../src/hooks/openai-agents.js");

--- a/tests/openai-agents-hook.test.ts
+++ b/tests/openai-agents-hook.test.ts
@@ -136,6 +136,39 @@ describe("openai agents adapter", () => {
     );
     expect(originalRunTool).toHaveBeenCalledTimes(1);
   });
+
+  it("returns approval error output when PENDING is denied", async () => {
+    const gateway = createGatewayClientMock();
+    gateway.check = vi.fn(async () => ({ pending: true, denied: false }));
+    gateway.waitForApproval = vi.fn(async () => ({
+      denied: true,
+      reason: "manual reviewer rejected"
+    }));
+    const originalRunTool = vi.fn(async () => ({ ok: true }));
+
+    const hooks = await import("../src/hooks/openai-agents.js");
+    const patchedRunTool = hooks.createPatchedRunTool(originalRunTool, gateway, {
+      fallbackRunId: "fallback-run",
+      approvalTimeoutMs: 1_000
+    });
+
+    const result = await patchedRunTool(
+      {
+        function: {
+          name: "delete_account",
+          arguments: "{\"id\":\"u1\"}"
+        }
+      },
+      {
+        runId: "run-3"
+      }
+    );
+
+    expect(result).toEqual({
+      error: "Approval denied: manual reviewer rejected"
+    });
+    expect(originalRunTool).not.toHaveBeenCalled();
+  });
 });
 async function resetPatchState() {
   const hooks = await import("../src/hooks/openai-agents.js");

--- a/tests/openai-agents-hook.test.ts
+++ b/tests/openai-agents-hook.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayClient } from "../src/gateway/client.js";
+
+interface FakeAgentInstance {
+  calls: number;
+}
+
+interface FakeAgentClass {
+  prototype: {
+    _runTool: (
+      this: FakeAgentInstance,
+      toolCall: { function: { name: string; arguments: string } },
+      context: { runId?: string; agentId?: string }
+    ) => Promise<unknown>;
+  };
+}
+
+function createGatewayClientMock(): GatewayClient {
+  return {
+    mode: "sdk-only",
+    start: vi.fn(async () => undefined),
+    close: vi.fn(async () => undefined),
+    check: vi.fn(async () => ({ denied: false, pending: false })),
+    waitForApproval: vi.fn(async () => ({ denied: false })),
+    record: vi.fn(async () => undefined),
+    recordResult: vi.fn(async () => undefined),
+    scanPrompts: vi.fn(async () => undefined)
+  };
+}
+
+afterEach(() => {
+  return resetPatchState().finally(() => {
+    vi.resetModules();
+    vi.unmock("@openai/agents");
+  });
+});
+
+describe("openai agents adapter", () => {
+  it("activates patching during initAssembly when @openai/agents is detected", async () => {
+    const gateway = createGatewayClientMock();
+    const fakeAgentClass: FakeAgentClass = {
+      prototype: {
+        _runTool: vi.fn(async function (this: FakeAgentInstance) {
+          this.calls += 1;
+          return { ok: true };
+        })
+      }
+    };
+
+    vi.doMock("@openai/agents", () => ({ Agent: fakeAgentClass }));
+    vi.doMock("node:module", () => ({
+      createRequire: () => ({
+        resolve: (packageName: string) => {
+          if (packageName === "@openai/agents") {
+            return packageName;
+          }
+          throw new Error("MODULE_NOT_FOUND");
+        }
+      })
+    }));
+
+    const { initAssembly } = await import("../src/core/init-assembly.js");
+    await initAssembly({
+      gatewayUrl: "https://gateway.example.com",
+      apiKey: "test-key",
+      mode: "sdk-only",
+      gatewayClient: gateway
+    });
+
+    const hooks = await import("../src/hooks/openai-agents.js");
+    expect(hooks.openAIAgentsPatchState.isPatched).toBe(true);
+    expect(fakeAgentClass.prototype._runTool).not.toBe(
+      hooks.openAIAgentsPatchState.originalRunTool
+    );
+  });
+});
+async function resetPatchState() {
+  const hooks = await import("../src/hooks/openai-agents.js");
+  hooks.unpatchOpenAIAgents();
+  hooks.openAIAgentsPatchState.originalRunTool = undefined;
+  hooks.openAIAgentsPatchState.patchedAgentClass = undefined;
+  hooks.openAIAgentsPatchState.isPatched = false;
+}

--- a/tests/openai-agents-hook.test.ts
+++ b/tests/openai-agents-hook.test.ts
@@ -11,7 +11,7 @@ interface FakeAgentClass {
       this: FakeAgentInstance,
       toolCall: { function: { name: string; arguments: string } },
       context: { runId?: string; agentId?: string }
-    ) => Promise<unknown>;
+    ) => Promise<Record<string, unknown>>;
   };
 }
 

--- a/tests/openai-agents-hook.test.ts
+++ b/tests/openai-agents-hook.test.ts
@@ -237,6 +237,35 @@ describe("openai agents adapter", () => {
       output: { ok: true }
     });
   });
+
+  it("fails open and executes original tool when gateway check throws", async () => {
+    const gateway = createGatewayClientMock();
+    gateway.check = vi.fn(async () => {
+      throw new Error("gateway unavailable");
+    });
+    const originalRunTool = vi.fn(async () => ({ ok: "fallback-path" }));
+
+    const hooks = await import("../src/hooks/openai-agents.js");
+    const patchedRunTool = hooks.createPatchedRunTool(originalRunTool, gateway, {
+      fallbackRunId: "fallback-run",
+      approvalTimeoutMs: 4_000
+    });
+
+    const result = await patchedRunTool(
+      {
+        function: {
+          name: "critical_tool",
+          arguments: "{\"x\":1}"
+        }
+      },
+      {
+        runId: "run-6"
+      }
+    );
+
+    expect(result).toEqual({ ok: "fallback-path" });
+    expect(originalRunTool).toHaveBeenCalledTimes(1);
+  });
 });
 async function resetPatchState() {
   const hooks = await import("../src/hooks/openai-agents.js");


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Implement AAASM-124 OpenAI Agents SDK governance adapter for Node.js by patching `Agent.prototype._runTool` with deny/pending gating, fail-open safety, trace metadata extraction, and non-blocking result recording.

* ### Task tickets:

    * Task ID: AAASM-124.
    * Relative task IDs:
        * [x] AAASM-58
        * [x] AAASM-59
        * [x] AAASM-61
    * Relative PRs:
        * https://github.com/AI-agent-assembly/node-sdk/pull/7
        * https://github.com/AI-agent-assembly/node-sdk/pull/8
        * https://github.com/AI-agent-assembly/node-sdk/pull/10

* ### Key point change (optional):

    Added a dedicated OpenAI Agents runtime hook that intercepts all tool calls via `_runTool`, enforces governance decisions with contract-safe `{ error: ... }` returns, and preserves runtime reliability via fail-open behavior and fire-and-forget recording.

## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [x] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [x] 🤖 Framework hooks
    * [x] 🫀 Data model and types
    * [x] ⛑️ Error handling
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [ ] 🚀 Building
        * [ ] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
    * [ ] 📚 Documentation
* Additional description:
    OpenAI Agents hook activation is detection-based (`@openai/agents` only), with explicit `patchOpenAIAgents()` / `unpatchOpenAIAgents()` lifecycle for deterministic test isolation.

## _Description_

* Added `src/hooks/openai-agents.ts` with:
  * patch state container + original `_runTool` capture
  * JSON argument parsing with malformed-input fallback
  * context metadata extraction (`agentId`, `runId`)
  * deny/approval error output formatter
  * pending approval handler (`waitForApproval`)
  * non-blocking result recorder (`.catch(() => undefined)`)
  * patched `_runTool` wrapper supporting ALLOW / DENY / PENDING and fail-open on gateway errors
  * public `patchOpenAIAgents()` and `unpatchOpenAIAgents()`
* Added `src/hooks/openai-agents-detection.ts` and wired `detectFrameworks()` to use it.
* Added OpenAI adapter types in `src/types/openai-agents-adapter.ts` and exports in `src/types/index.ts`.
* Wired patch activation in `initAssembly()` when `openai-agents` is detected.
* Added `tests/openai-agents-hook.test.ts` covering:
  * detection-based patch activation
  * ALLOW passthrough
  * DENY contract-safe error return
  * PENDING approve/deny flows
  * JSON parse fallback
  * context metadata extraction
  * fire-and-forget recording behavior
  * gateway fail-open behavior
  * unpatch restore behavior
* Local validation passed:
  * `pnpm lint`
  * `pnpm typecheck`
  * `pnpm test`
  * `pnpm test:coverage`
