### PR TITLE
[AAASM-190] 🐛 (wrappers): Implement withAssembly governance wrapping

### DIFF
--- a/src/wrappers/with-assembly.ts
+++ b/src/wrappers/with-assembly.ts
@@ -7,6 +7,18 @@ export interface WithAssemblyOptions {
   approvalTimeoutMs?: number;
 }
 
+function hasExecute(
+  tool: Record<string, unknown>
+): tool is Record<string, unknown> & { execute: (...args: unknown[]) => unknown } {
+  return typeof tool.execute === "function";
+}
+
+function hasInvoke(
+  tool: Record<string, unknown>
+): tool is Record<string, unknown> & { invoke: (...args: unknown[]) => unknown } {
+  return typeof tool.invoke === "function";
+}
+
 export function withAssembly<TTool, TTools extends ToolMap<TTool>>(
   tools: TTools,
   options: WithAssemblyOptions

--- a/src/wrappers/with-assembly.ts
+++ b/src/wrappers/with-assembly.ts
@@ -7,6 +7,32 @@ export interface WithAssemblyOptions {
   approvalTimeoutMs?: number;
 }
 
+const DEFAULT_APPROVAL_TIMEOUT_MS = 30_000;
+
+async function waitForApprovalWithTimeout(
+  gateway: GatewayClient,
+  toolName: string,
+  runId: string,
+  timeoutMs: number
+): Promise<{ denied?: boolean; reason?: string }> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const timeoutPromise = new Promise<{ denied: true; reason: string }>((resolve) => {
+    timeoutId = setTimeout(() => {
+      resolve({ denied: true, reason: `Approval timeout after ${timeoutMs}ms` });
+    }, timeoutMs);
+  });
+
+  try {
+    const approvalPromise = gateway.waitForApproval(toolName, runId, timeoutMs);
+    return await Promise.race([approvalPromise, timeoutPromise]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
 function hasExecute(
   tool: Record<string, unknown>
 ): tool is Record<string, unknown> & { execute: (...args: unknown[]) => unknown } {

--- a/src/wrappers/with-assembly.ts
+++ b/src/wrappers/with-assembly.ts
@@ -1,8 +1,10 @@
+import type { GatewayClient } from "../gateway/client.js";
 import type { ToolMap } from "../types/tool-map.js";
 
 export interface WithAssemblyOptions {
+  gatewayClient: GatewayClient;
   agentId?: string;
-  gatewayUrl?: string;
+  approvalTimeoutMs?: number;
 }
 
 export function withAssembly<TTool, TTools extends ToolMap<TTool>>(

--- a/src/wrappers/with-assembly.ts
+++ b/src/wrappers/with-assembly.ts
@@ -122,6 +122,8 @@ export function withAssembly<TTool, TTools extends ToolMap<TTool>>(
   tools: TTools,
   options: WithAssemblyOptions
 ): TTools {
-  void options;
+  for (const [name, tool] of Object.entries(tools)) {
+    wrapSingleTool(name, tool as Record<string, unknown>, options.gatewayClient, options);
+  }
   return tools;
 }

--- a/src/wrappers/with-assembly.ts
+++ b/src/wrappers/with-assembly.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+import { PolicyViolationError } from "../errors/policy-violation-error.js";
 import type { GatewayClient } from "../gateway/client.js";
 import type { ToolMap } from "../types/tool-map.js";
 
@@ -43,6 +45,77 @@ function hasInvoke(
   tool: Record<string, unknown>
 ): tool is Record<string, unknown> & { invoke: (...args: unknown[]) => unknown } {
   return typeof tool.invoke === "function";
+}
+
+function wrapSingleTool(
+  name: string,
+  tool: Record<string, unknown>,
+  gateway: GatewayClient,
+  options: WithAssemblyOptions
+): void {
+  const approvalTimeoutMs = options.approvalTimeoutMs ?? DEFAULT_APPROVAL_TIMEOUT_MS;
+
+  if (hasExecute(tool)) {
+    const originalExecute = tool.execute;
+    tool.execute = async (...args: unknown[]) => {
+      const runId = `run_${randomUUID()}`;
+      const decision = await gateway.check({
+        action: "tool_call",
+        toolName: name,
+        args,
+        runId
+      });
+
+      if (decision.denied) {
+        throw new PolicyViolationError(
+          `Tool '${name}' blocked: ${decision.reason ?? "Denied"}`
+        );
+      }
+
+      if (decision.pending) {
+        const finalDecision = await waitForApprovalWithTimeout(
+          gateway, name, runId, approvalTimeoutMs
+        );
+        if (finalDecision.denied) {
+          throw new PolicyViolationError(
+            `Approval rejected for '${name}': ${finalDecision.reason ?? "Rejected"}`
+          );
+        }
+      }
+
+      return originalExecute(...args);
+    };
+  } else if (hasInvoke(tool)) {
+    const originalInvoke = tool.invoke;
+    tool.invoke = async (...args: unknown[]) => {
+      const runId = `run_${randomUUID()}`;
+      const decision = await gateway.check({
+        action: "tool_call",
+        toolName: name,
+        args,
+        runId
+      });
+
+      if (decision.denied) {
+        throw new PolicyViolationError(
+          `Tool '${name}' blocked: ${decision.reason ?? "Denied"}`
+        );
+      }
+
+      if (decision.pending) {
+        const finalDecision = await waitForApprovalWithTimeout(
+          gateway, name, runId, approvalTimeoutMs
+        );
+        if (finalDecision.denied) {
+          throw new PolicyViolationError(
+            `Approval rejected for '${name}': ${finalDecision.reason ?? "Rejected"}`
+          );
+        }
+      }
+
+      return originalInvoke(...args);
+    };
+  }
 }
 
 export function withAssembly<TTool, TTools extends ToolMap<TTool>>(

--- a/tests/architecture/with-assembly-types.test.ts
+++ b/tests/architecture/with-assembly-types.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createNoopGatewayClient } from "../../src/gateway/client.js";
 import { withAssembly } from "../../src/wrappers/with-assembly.js";
 
 type Equal<A, B> =
@@ -18,7 +19,10 @@ describe("withAssembly", () => {
       }
     };
 
-    const wrapped = withAssembly(tools, { agentId: "agent-1" });
+    const wrapped = withAssembly(tools, {
+      gatewayClient: createNoopGatewayClient("sdk-only"),
+      agentId: "agent-1"
+    });
 
     type _ExactTypePreserved = Expect<Equal<typeof wrapped, typeof tools>>;
     const _typeAssertion: _ExactTypePreserved = true;

--- a/tests/with-assembly-governance.test.ts
+++ b/tests/with-assembly-governance.test.ts
@@ -33,4 +33,20 @@ describe("withAssembly governance", () => {
     expect(executeFn).toHaveBeenCalledWith({ query: "hello" });
     expect(result).toBe("result:hello");
   });
+
+  it("DENY: throws PolicyViolationError when gateway denies", async () => {
+    const gateway = createMockGateway({
+      check: vi.fn(async () => ({ denied: true, pending: false, reason: "policy X" }))
+    });
+    const executeFn = vi.fn(async () => "should not run");
+    const tools = {
+      dangerous: { description: "Dangerous tool", execute: executeFn }
+    };
+
+    withAssembly(tools, { gatewayClient: gateway });
+
+    await expect(tools.dangerous.execute()).rejects.toThrow(PolicyViolationError);
+    await expect(tools.dangerous.execute()).rejects.toThrow("Tool 'dangerous' blocked: policy X");
+    expect(executeFn).not.toHaveBeenCalled();
+  });
 });

--- a/tests/with-assembly-governance.test.ts
+++ b/tests/with-assembly-governance.test.ts
@@ -113,7 +113,7 @@ describe("withAssembly governance", () => {
     const gateway = createMockGateway({
       check: vi.fn(async () => ({ denied: true, pending: false, reason: "blocked" }))
     });
-    const invokeFn = vi.fn(async () => "should not run");
+    const invokeFn: (input: string) => Promise<string> = vi.fn(async () => "should not run");
     const tools = {
       lcTool: { name: "lcTool", invoke: invokeFn }
     };

--- a/tests/with-assembly-governance.test.ts
+++ b/tests/with-assembly-governance.test.ts
@@ -141,4 +141,25 @@ describe("withAssembly governance", () => {
     expect(tools.config.setting).toBe(originalTool.setting);
     expect(gateway.check).not.toHaveBeenCalled();
   });
+
+  it("mixed tool map: handles execute, invoke, and plain tools together", async () => {
+    const gateway = createMockGateway();
+    const executeFn = vi.fn(async () => "execute-result");
+    const invokeFn = vi.fn(async () => "invoke-result");
+    const tools = {
+      vercelTool: { description: "Vercel tool", execute: executeFn },
+      langchainTool: { name: "langchainTool", invoke: invokeFn },
+      plainTool: { description: "No callable method", data: 42 }
+    };
+
+    withAssembly(tools, { gatewayClient: gateway });
+
+    const executeResult = await tools.vercelTool.execute();
+    const invokeResult = await tools.langchainTool.invoke();
+
+    expect(executeResult).toBe("execute-result");
+    expect(invokeResult).toBe("invoke-result");
+    expect(tools.plainTool.data).toBe(42);
+    expect(gateway.check).toHaveBeenCalledTimes(2);
+  });
 });

--- a/tests/with-assembly-governance.test.ts
+++ b/tests/with-assembly-governance.test.ts
@@ -49,4 +49,23 @@ describe("withAssembly governance", () => {
     await expect(tools.dangerous.execute()).rejects.toThrow("Tool 'dangerous' blocked: policy X");
     expect(executeFn).not.toHaveBeenCalled();
   });
+
+  it("PENDING→approve: waits for approval then executes", async () => {
+    const gateway = createMockGateway({
+      check: vi.fn(async () => ({ denied: false, pending: true })),
+      waitForApproval: vi.fn(async () => ({ denied: false }))
+    });
+    const executeFn = vi.fn(async () => "approved-result");
+    const tools = {
+      sensitive: { description: "Sensitive tool", execute: executeFn }
+    };
+
+    withAssembly(tools, { gatewayClient: gateway });
+
+    const result = await tools.sensitive.execute();
+
+    expect(gateway.waitForApproval).toHaveBeenCalledOnce();
+    expect(executeFn).toHaveBeenCalledOnce();
+    expect(result).toBe("approved-result");
+  });
 });

--- a/tests/with-assembly-governance.test.ts
+++ b/tests/with-assembly-governance.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import { PolicyViolationError } from "../src/errors/policy-violation-error.js";
+import type { GatewayClient } from "../src/gateway/client.js";
+import { withAssembly } from "../src/wrappers/with-assembly.js";
+
+function createMockGateway(overrides: Partial<GatewayClient> = {}): GatewayClient {
+  return {
+    mode: "sdk-only",
+    start: vi.fn(async () => undefined),
+    close: vi.fn(async () => undefined),
+    check: vi.fn(async () => ({ denied: false, pending: false })),
+    waitForApproval: vi.fn(async () => ({ denied: false })),
+    record: vi.fn(async () => undefined),
+    recordResult: vi.fn(async () => undefined),
+    scanPrompts: vi.fn(async () => undefined),
+    ...overrides
+  };
+}
+
+describe("withAssembly governance", () => {
+  it("ALLOW: passes through to original execute when gateway allows", async () => {
+    const gateway = createMockGateway();
+    const executeFn = vi.fn(async (args: { query: string }) => `result:${args.query}`);
+    const tools = {
+      search: { description: "Search", execute: executeFn }
+    };
+
+    withAssembly(tools, { gatewayClient: gateway });
+
+    const result = await tools.search.execute({ query: "hello" });
+
+    expect(gateway.check).toHaveBeenCalledOnce();
+    expect(executeFn).toHaveBeenCalledWith({ query: "hello" });
+    expect(result).toBe("result:hello");
+  });
+});

--- a/tests/with-assembly-governance.test.ts
+++ b/tests/with-assembly-governance.test.ts
@@ -68,4 +68,23 @@ describe("withAssembly governance", () => {
     expect(executeFn).toHaveBeenCalledOnce();
     expect(result).toBe("approved-result");
   });
+
+  it("PENDING→deny: throws PolicyViolationError when approval is rejected", async () => {
+    const gateway = createMockGateway({
+      check: vi.fn(async () => ({ denied: false, pending: true })),
+      waitForApproval: vi.fn(async () => ({ denied: true, reason: "Manager rejected" }))
+    });
+    const executeFn = vi.fn(async () => "should not run");
+    const tools = {
+      sensitive: { description: "Sensitive tool", execute: executeFn }
+    };
+
+    withAssembly(tools, { gatewayClient: gateway });
+
+    await expect(tools.sensitive.execute()).rejects.toThrow(PolicyViolationError);
+    await expect(tools.sensitive.execute()).rejects.toThrow(
+      "Approval rejected for 'sensitive': Manager rejected"
+    );
+    expect(executeFn).not.toHaveBeenCalled();
+  });
 });

--- a/tests/with-assembly-governance.test.ts
+++ b/tests/with-assembly-governance.test.ts
@@ -108,4 +108,22 @@ describe("withAssembly governance", () => {
     await expect(tools.slow.execute()).rejects.toThrow("Approval timeout after 50ms");
     expect(executeFn).not.toHaveBeenCalled();
   });
+
+  it("invoke method: wraps LangChain-style invoke with governance", async () => {
+    const gateway = createMockGateway({
+      check: vi.fn(async () => ({ denied: true, pending: false, reason: "blocked" }))
+    });
+    const invokeFn = vi.fn(async () => "should not run");
+    const tools = {
+      lcTool: { name: "lcTool", invoke: invokeFn }
+    };
+
+    withAssembly(tools, { gatewayClient: gateway });
+
+    await expect(tools.lcTool.invoke("input")).rejects.toThrow(PolicyViolationError);
+    await expect(tools.lcTool.invoke("input")).rejects.toThrow(
+      "Tool 'lcTool' blocked: blocked"
+    );
+    expect(invokeFn).not.toHaveBeenCalled();
+  });
 });

--- a/tests/with-assembly-governance.test.ts
+++ b/tests/with-assembly-governance.test.ts
@@ -126,4 +126,19 @@ describe("withAssembly governance", () => {
     );
     expect(invokeFn).not.toHaveBeenCalled();
   });
+
+  it("passthrough: tools without execute or invoke are left unchanged", () => {
+    const gateway = createMockGateway();
+    const tools = {
+      config: { description: "Config-only tool", setting: "value" }
+    };
+
+    const originalTool = { ...tools.config };
+
+    withAssembly(tools, { gatewayClient: gateway });
+
+    expect(tools.config.description).toBe(originalTool.description);
+    expect(tools.config.setting).toBe(originalTool.setting);
+    expect(gateway.check).not.toHaveBeenCalled();
+  });
 });

--- a/tests/with-assembly-governance.test.ts
+++ b/tests/with-assembly-governance.test.ts
@@ -87,4 +87,25 @@ describe("withAssembly governance", () => {
     );
     expect(executeFn).not.toHaveBeenCalled();
   });
+
+  it("PENDING→timeout: throws PolicyViolationError on approval timeout", async () => {
+    const gateway = createMockGateway({
+      check: vi.fn(async () => ({ denied: false, pending: true })),
+      waitForApproval: vi.fn(
+        () => new Promise<{ denied: boolean }>((resolve) => {
+          setTimeout(() => resolve({ denied: false }), 5000);
+        })
+      )
+    });
+    const executeFn = vi.fn(async () => "should not run");
+    const tools = {
+      slow: { description: "Slow approval tool", execute: executeFn }
+    };
+
+    withAssembly(tools, { gatewayClient: gateway, approvalTimeoutMs: 50 });
+
+    await expect(tools.slow.execute()).rejects.toThrow(PolicyViolationError);
+    await expect(tools.slow.execute()).rejects.toThrow("Approval timeout after 50ms");
+    expect(executeFn).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Replace the no-op `withAssembly()` pass-through with real governance wrapping logic. The function now iterates over all tools in a tool map and wraps each tool's `execute` (Vercel AI SDK) or `invoke` (LangChain) method with gateway policy checks — DENY throws `PolicyViolationError`, PENDING blocks until approval or timeout.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: [AAASM-190](https://lightning-dust-mite.atlassian.net/browse/AAASM-190)
    * Relative task IDs:
        * [x] [AAASM-6](https://lightning-dust-mite.atlassian.net/browse/AAASM-6) (Epic: Node.js / TypeScript SDK)
        * [x] [AAASM-58](https://lightning-dust-mite.atlassian.net/browse/AAASM-58) (F27: withAssembly pattern spec)
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    **As-is:** `withAssembly()` returns tools unchanged — no governance enforcement.

    **To-be:** `withAssembly()` mutates each tool's `execute`/`invoke` in-place with gateway policy checks:
    - ALLOW → original method runs
    - DENY → throws `PolicyViolationError`
    - PENDING → waits for approval with configurable timeout

    `gatewayClient` is now a **required** field in `WithAssemblyOptions` (explicit DI, fail-fast).

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [ ] ✨ Adding new something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [x] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [x] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [ ] 🤖 Framework hooks
    * [x] 🫀 Data model and types
    * [x] ⛑️ Error handling
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [ ] 🚀 Building
        * [ ] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
    * [ ] 📚 Documentation
* Additional description:
    - `WithAssemblyOptions.gatewayClient` is now **required** (breaking change to the interface)
    - In-place mutation approach (consistent with existing `wrapToolWithAssembly` in LangChain adapter)
    - Tools without `execute` or `invoke` are passed through unchanged
    - Zero `any` casts in implementation
    - 8 new governance test cases, all 72 tests pass

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Made `gatewayClient` required in `WithAssemblyOptions`, added `approvalTimeoutMs` option
* Added tool shape detection helpers (`hasExecute`, `hasInvoke`)
* Added `waitForApprovalWithTimeout` with configurable timeout (default 30s)
* Added `wrapSingleTool` — core governance wrapping for a single tool
* Replaced `withAssembly()` no-op body with governance iteration loop
* Added 8 unit tests: ALLOW passthrough, DENY blocks, PENDING→approve, PENDING→deny, PENDING→timeout, invoke-method wrapping, passthrough for plain tools, mixed tool map
* Updated existing type preservation test to satisfy new required `gatewayClient` field

[AAASM-190]: https://lightning-dust-mite.atlassian.net/browse/AAASM-190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-6]: https://lightning-dust-mite.atlassian.net/browse/AAASM-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-58]: https://lightning-dust-mite.atlassian.net/browse/AAASM-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ