### PR TITLE
[AAASM-189] 🐛 (hooks): Implement Vercel AI SDK tool governance enforcement

### DIFF
--- a/src/core/init-assembly.ts
+++ b/src/core/init-assembly.ts
@@ -12,6 +12,8 @@ import type {
   LangChainCallbackHandlerLike,
   LangChainToolLike
 } from "../types/langchain-adapter.js";
+import { hasVercelAiSdk } from "../hooks/ai-sdk-detection.js";
+import { patchVercelAiSdk } from "../hooks/ai-sdk.js";
 import { hasOpenAIAgentsSDK } from "../hooks/openai-agents-detection.js";
 import { patchOpenAIAgents } from "../hooks/openai-agents.js";
 
@@ -41,7 +43,7 @@ export function detectFrameworks(): string[] {
   if (isPackageInstalled("@langchain/core")) {
     detected.push("langchain-js");
   }
-  if (isPackageInstalled("ai")) {
+  if (hasVercelAiSdk()) {
     detected.push("vercel-ai-sdk");
   }
   if (hasOpenAIAgentsSDK()) {
@@ -129,6 +131,17 @@ function wrapLangChainTools(
   return Object.keys(tools);
 }
 
+async function patchDetectedVercelAiSdk(
+  client: GatewayClient,
+  frameworks: readonly string[]
+): Promise<boolean> {
+  if (!frameworks.includes("vercel-ai-sdk")) {
+    return false;
+  }
+
+  return patchVercelAiSdk({ gatewayClient: client });
+}
+
 async function patchDetectedOpenAIAgents(
   client: GatewayClient,
   frameworks: readonly string[]
@@ -149,6 +162,7 @@ export async function initAssembly(config: AssemblyConfig): Promise<AssemblyCont
 
   const langChainHandler = registerLangChainHandler(config, client, frameworks);
   const wrappedLangChainTools = wrapLangChainTools(config, client, frameworks);
+  const vercelAiSdkPatched = await patchDetectedVercelAiSdk(client, frameworks);
   const openAIAgentsPatched = await patchDetectedOpenAIAgents(client, frameworks);
 
   return {
@@ -157,6 +171,7 @@ export async function initAssembly(config: AssemblyConfig): Promise<AssemblyCont
         ...adapters.map((adapter) => adapter.id),
         ...(langChainHandler ? ["langchain-js"] : []),
         ...(wrappedLangChainTools.length > 0 ? ["langchain-js"] : []),
+        ...(vercelAiSdkPatched ? ["vercel-ai-sdk"] : []),
         ...(openAIAgentsPatched ? ["openai-agents"] : [])
       ])
     ],

--- a/src/hooks/adapter-registry.ts
+++ b/src/hooks/adapter-registry.ts
@@ -1,8 +1,6 @@
 import type { NativeClient } from "../native/client.js";
 import { patchLangChain } from "./langchain.js";
-import { patchVercelAiSdk } from "./ai-sdk.js";
 
 export async function registerFrameworkHooks(client: NativeClient): Promise<void> {
   await patchLangChain(client);
-  await patchVercelAiSdk(client);
 }

--- a/src/hooks/ai-sdk-detection.ts
+++ b/src/hooks/ai-sdk-detection.ts
@@ -1,0 +1,12 @@
+import { createRequire } from "node:module";
+
+const requireFromCwd = createRequire(`${process.cwd()}/`);
+
+export function hasVercelAiSdk(): boolean {
+  try {
+    requireFromCwd.resolve("ai");
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/hooks/ai-sdk.ts
+++ b/src/hooks/ai-sdk.ts
@@ -188,3 +188,21 @@ export async function patchVercelAiSdk(
   vercelAiSdkPatchState.patchedModule = module;
   return true;
 }
+
+export function unpatchVercelAiSdk(): boolean {
+  if (!vercelAiSdkPatchState.isPatched) {
+    return false;
+  }
+  if (!vercelAiSdkPatchState.patchedModule) {
+    return false;
+  }
+  if (!vercelAiSdkPatchState.originalToolFactory) {
+    return false;
+  }
+
+  vercelAiSdkPatchState.patchedModule.tool =
+    vercelAiSdkPatchState.originalToolFactory;
+  vercelAiSdkPatchState.isPatched = false;
+  vercelAiSdkPatchState.patchedModule = undefined;
+  return true;
+}

--- a/src/hooks/ai-sdk.ts
+++ b/src/hooks/ai-sdk.ts
@@ -1,8 +1,32 @@
-import type { NativeClient } from "../native/client.js";
+import type { VercelAiToolFactory } from "../types/vercel-ai-adapter.js";
 
-export async function patchVercelAiSdk(client: NativeClient): Promise<boolean> {
-  if (client.mode === "grpc-sidecar" || client.mode === "napi-inprocess") {
-    return false;
+export interface VercelAiSdkModule {
+  tool: VercelAiToolFactory;
+}
+
+export interface VercelAiSdkPatchState {
+  isPatched: boolean;
+  originalToolFactory: VercelAiToolFactory | undefined;
+  patchedModule: VercelAiSdkModule | undefined;
+}
+
+export const vercelAiSdkPatchState: VercelAiSdkPatchState = {
+  isPatched: false,
+  originalToolFactory: undefined,
+  patchedModule: undefined
+};
+
+export function captureOriginalToolFactory(
+  module: VercelAiSdkModule
+): VercelAiToolFactory | undefined {
+  const candidate = module.tool;
+  if (typeof candidate !== "function") {
+    return undefined;
   }
-  return false;
+
+  if (!vercelAiSdkPatchState.originalToolFactory) {
+    vercelAiSdkPatchState.originalToolFactory = candidate;
+  }
+
+  return vercelAiSdkPatchState.originalToolFactory;
 }

--- a/src/hooks/ai-sdk.ts
+++ b/src/hooks/ai-sdk.ts
@@ -140,3 +140,51 @@ export function createPatchedToolFactory(
     };
   };
 }
+
+export interface PatchVercelAiSdkOptions {
+  gatewayClient: GatewayClient;
+  approvalTimeoutMs?: number;
+  fallbackRunId?: string;
+  loadModule?: () => Promise<VercelAiSdkModule | undefined>;
+}
+
+async function loadVercelAiSdkModule(): Promise<VercelAiSdkModule | undefined> {
+  try {
+    const moduleName = "ai";
+    const module = (await import(moduleName)) as VercelAiSdkModule;
+    return module;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function patchVercelAiSdk(
+  options: PatchVercelAiSdkOptions
+): Promise<boolean> {
+  if (vercelAiSdkPatchState.isPatched) {
+    return true;
+  }
+
+  const loadModule = options.loadModule ?? loadVercelAiSdkModule;
+  const module = await loadModule();
+  if (!module) {
+    return false;
+  }
+
+  const originalToolFactory = captureOriginalToolFactory(module);
+  if (!originalToolFactory) {
+    return false;
+  }
+
+  module.tool = createPatchedToolFactory(
+    originalToolFactory,
+    options.gatewayClient,
+    {
+      approvalTimeoutMs: options.approvalTimeoutMs ?? 30_000,
+      fallbackRunId: options.fallbackRunId ?? "vercel-ai-sdk"
+    }
+  );
+  vercelAiSdkPatchState.isPatched = true;
+  vercelAiSdkPatchState.patchedModule = module;
+  return true;
+}

--- a/src/hooks/ai-sdk.ts
+++ b/src/hooks/ai-sdk.ts
@@ -1,4 +1,10 @@
-import type { VercelAiToolFactory } from "../types/vercel-ai-adapter.js";
+import type {
+  VercelAiToolDefinition,
+  VercelAiToolExecutionOptions,
+  VercelAiToolFactory
+} from "../types/vercel-ai-adapter.js";
+import type { GatewayClient } from "../gateway/client.js";
+import { PolicyViolationError } from "../errors/policy-violation-error.js";
 
 export interface VercelAiSdkModule {
   tool: VercelAiToolFactory;
@@ -29,4 +35,75 @@ export function captureOriginalToolFactory(
   }
 
   return vercelAiSdkPatchState.originalToolFactory;
+}
+
+export interface CreateWrappedExecuteOptions {
+  approvalTimeoutMs: number;
+  fallbackRunId: string;
+}
+
+export function recordToolResultNonBlocking(
+  gatewayClient: GatewayClient,
+  runId: string,
+  output: unknown
+): void {
+  void gatewayClient.recordResult({ runId, output }).catch(() => undefined);
+}
+
+export function createWrappedExecute<TArgs, TResult>(
+  originalExecute: (args: TArgs, options: VercelAiToolExecutionOptions) => Promise<TResult>,
+  description: string,
+  gatewayClient: GatewayClient,
+  options: CreateWrappedExecuteOptions
+): (args: TArgs, executionOptions: VercelAiToolExecutionOptions) => Promise<TResult> {
+  return async function wrappedExecute(
+    args: TArgs,
+    executionOptions: VercelAiToolExecutionOptions
+  ): Promise<TResult> {
+    const runId = executionOptions.toolCallId ?? options.fallbackRunId;
+
+    const executeOriginal = async (): Promise<TResult> => {
+      const result = await originalExecute(args, executionOptions);
+      recordToolResultNonBlocking(gatewayClient, runId, result);
+      return result;
+    };
+
+    let decision;
+    try {
+      decision = await gatewayClient.check({
+        action: "tool_call",
+        toolName: description,
+        args: args as Record<string, unknown>,
+        runId
+      });
+    } catch {
+      return executeOriginal();
+    }
+
+    if (decision.denied) {
+      throw new PolicyViolationError(
+        `Tool blocked by governance policy: ${decision.reason ?? "Denied"}`
+      );
+    }
+
+    if (decision.pending) {
+      let approval;
+      try {
+        approval = await gatewayClient.waitForApproval(
+          description,
+          runId,
+          options.approvalTimeoutMs
+        );
+      } catch {
+        return executeOriginal();
+      }
+      if (approval.denied) {
+        throw new PolicyViolationError(
+          `Approval rejected: ${approval.reason ?? "Rejected"}`
+        );
+      }
+    }
+
+    return executeOriginal();
+  };
 }

--- a/src/hooks/ai-sdk.ts
+++ b/src/hooks/ai-sdk.ts
@@ -107,3 +107,36 @@ export function createWrappedExecute<TArgs, TResult>(
     return executeOriginal();
   };
 }
+
+export interface CreatePatchedToolFactoryOptions {
+  approvalTimeoutMs: number;
+  fallbackRunId: string;
+}
+
+export function createPatchedToolFactory(
+  originalToolFactory: VercelAiToolFactory,
+  gatewayClient: GatewayClient,
+  options: CreatePatchedToolFactoryOptions
+): VercelAiToolFactory {
+  return function patchedTool<TArgs, TResult>(
+    definition: VercelAiToolDefinition<TArgs, TResult>
+  ): VercelAiToolDefinition<TArgs, TResult> {
+    const toolResult = originalToolFactory(definition);
+
+    if (!toolResult.execute) {
+      return toolResult;
+    }
+
+    const description = toolResult.description ?? "unknown_tool";
+
+    return {
+      ...toolResult,
+      execute: createWrappedExecute(
+        toolResult.execute,
+        description,
+        gatewayClient,
+        options
+      )
+    };
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,3 +22,8 @@ export type {
   OpenAIAgentsToolCall,
   OpenAIAgentsToolCallOutput
 } from "./openai-agents-adapter.js";
+export type {
+  VercelAiToolDefinition,
+  VercelAiToolExecutionOptions,
+  VercelAiToolFactory
+} from "./vercel-ai-adapter.js";

--- a/src/types/vercel-ai-adapter.ts
+++ b/src/types/vercel-ai-adapter.ts
@@ -1,0 +1,15 @@
+export interface VercelAiToolExecutionOptions {
+  toolCallId?: string;
+  messages?: readonly unknown[];
+  abortSignal?: AbortSignal;
+}
+
+export interface VercelAiToolDefinition<TArgs = unknown, TResult = unknown> {
+  description?: string;
+  parameters?: unknown;
+  execute?: (args: TArgs, options: VercelAiToolExecutionOptions) => Promise<TResult>;
+}
+
+export type VercelAiToolFactory = <TArgs, TResult>(
+  definition: VercelAiToolDefinition<TArgs, TResult>
+) => VercelAiToolDefinition<TArgs, TResult>;

--- a/tests/hooks-patch.test.ts
+++ b/tests/hooks-patch.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { patchVercelAiSdk } from "../src/hooks/ai-sdk.js";
 import { patchLangChain } from "../src/hooks/langchain.js";
 import type { NativeClient } from "../src/native/client.js";
+import type { GatewayClient } from "../src/gateway/client.js";
 
 function createClient(mode: NativeClient["mode"]): NativeClient {
   return {
@@ -12,21 +13,32 @@ function createClient(mode: NativeClient["mode"]): NativeClient {
   };
 }
 
+function createGatewayClientMock(): GatewayClient {
+  return {
+    mode: "sdk-only",
+    start: vi.fn(async () => undefined),
+    close: vi.fn(async () => undefined),
+    check: vi.fn(async () => ({ denied: false, pending: false })),
+    waitForApproval: vi.fn(async () => ({ denied: false })),
+    record: vi.fn(async () => undefined),
+    recordResult: vi.fn(async () => undefined),
+    scanPrompts: vi.fn(async () => undefined)
+  };
+}
+
 describe("framework patch hooks", () => {
-  it("returns false for native modes while patching is not implemented", async () => {
-    await expect(patchVercelAiSdk(createClient("grpc-sidecar"))).resolves.toBe(false);
-    await expect(patchVercelAiSdk(createClient("napi-inprocess"))).resolves.toBe(false);
+  it("patchLangChain returns false for native modes while patching is not implemented", async () => {
     await expect(patchLangChain(createClient("grpc-sidecar"))).resolves.toBe(false);
     await expect(patchLangChain(createClient("napi-inprocess"))).resolves.toBe(false);
   });
 
-  it("returns false for runtime-invalid modes from JavaScript callers", async () => {
-    const invalidClient = {
-      ...createClient("grpc-sidecar"),
-      mode: "sdk-only"
-    } as unknown as NativeClient;
-
-    await expect(patchVercelAiSdk(invalidClient)).resolves.toBe(false);
-    await expect(patchLangChain(invalidClient)).resolves.toBe(false);
+  it("patchVercelAiSdk returns false when module cannot be loaded", async () => {
+    const gateway = createGatewayClientMock();
+    await expect(
+      patchVercelAiSdk({
+        gatewayClient: gateway,
+        loadModule: async () => undefined
+      })
+    ).resolves.toBe(false);
   });
 });

--- a/tests/vercel-ai-hook.test.ts
+++ b/tests/vercel-ai-hook.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayClient } from "../src/gateway/client.js";
+
+function createGatewayClientMock(): GatewayClient {
+  return {
+    mode: "sdk-only",
+    start: vi.fn(async () => undefined),
+    close: vi.fn(async () => undefined),
+    check: vi.fn(async () => ({ denied: false, pending: false })),
+    waitForApproval: vi.fn(async () => ({ denied: false })),
+    record: vi.fn(async () => undefined),
+    recordResult: vi.fn(async () => undefined),
+    scanPrompts: vi.fn(async () => undefined)
+  };
+}
+
+afterEach(() => {
+  return resetPatchState().finally(() => {
+    vi.resetModules();
+  });
+});
+
+describe("vercel ai sdk adapter", () => {
+  it("executes original tool on ALLOW decision", async () => {
+    const gateway = createGatewayClientMock();
+    gateway.check = vi.fn(async () => ({ denied: false, pending: false }));
+    const originalExecute = vi.fn(async () => ({ ok: "allow-path" }));
+
+    const hooks = await import("../src/hooks/ai-sdk.js");
+    const wrappedExecute = hooks.createWrappedExecute(
+      originalExecute,
+      "a weather tool",
+      gateway,
+      { approvalTimeoutMs: 5_000, fallbackRunId: "fallback" }
+    );
+
+    const result = await wrappedExecute(
+      { city: "Tokyo" },
+      { toolCallId: "call-1" }
+    );
+
+    expect(result).toEqual({ ok: "allow-path" });
+    expect(gateway.check).toHaveBeenCalledWith({
+      action: "tool_call",
+      toolName: "a weather tool",
+      args: { city: "Tokyo" },
+      runId: "call-1"
+    });
+    expect(originalExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws PolicyViolationError on DENY without executing original tool", async () => {
+    const gateway = createGatewayClientMock();
+    gateway.check = vi.fn(async () => ({ denied: true, reason: "policy-blocked" }));
+    const originalExecute = vi.fn(async () => ({ ok: true }));
+
+    const hooks = await import("../src/hooks/ai-sdk.js");
+    const wrappedExecute = hooks.createWrappedExecute(
+      originalExecute,
+      "send email tool",
+      gateway,
+      { approvalTimeoutMs: 5_000, fallbackRunId: "fallback" }
+    );
+
+    const error = await wrappedExecute(
+      { to: "user@example.com" },
+      { toolCallId: "call-2" }
+    ).catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).name).toBe("PolicyViolationError");
+    expect((error as Error).message).toBe(
+      "Tool blocked by governance policy: policy-blocked"
+    );
+
+    expect(originalExecute).not.toHaveBeenCalled();
+  });
+
+  it("continues execution when PENDING is approved", async () => {
+    const gateway = createGatewayClientMock();
+    gateway.check = vi.fn(async () => ({ pending: true, denied: false }));
+    gateway.waitForApproval = vi.fn(async () => ({ denied: false }));
+    const originalExecute = vi.fn(async () => ({ ok: "approved" }));
+
+    const hooks = await import("../src/hooks/ai-sdk.js");
+    const wrappedExecute = hooks.createWrappedExecute(
+      originalExecute,
+      "transfer funds",
+      gateway,
+      { approvalTimeoutMs: 8_000, fallbackRunId: "fallback" }
+    );
+
+    const result = await wrappedExecute(
+      { amount: 100 },
+      { toolCallId: "call-3" }
+    );
+
+    expect(result).toEqual({ ok: "approved" });
+    expect(gateway.waitForApproval).toHaveBeenCalledWith(
+      "transfer funds",
+      "call-3",
+      8_000
+    );
+    expect(originalExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws PolicyViolationError when PENDING is denied", async () => {
+    const gateway = createGatewayClientMock();
+    gateway.check = vi.fn(async () => ({ pending: true, denied: false }));
+    gateway.waitForApproval = vi.fn(async () => ({
+      denied: true,
+      reason: "manual reviewer rejected"
+    }));
+    const originalExecute = vi.fn(async () => ({ ok: true }));
+
+    const hooks = await import("../src/hooks/ai-sdk.js");
+    const wrappedExecute = hooks.createWrappedExecute(
+      originalExecute,
+      "delete account",
+      gateway,
+      { approvalTimeoutMs: 1_000, fallbackRunId: "fallback" }
+    );
+
+    const error = await wrappedExecute(
+      { id: "u1" },
+      { toolCallId: "call-4" }
+    ).catch((e: Error) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).name).toBe("PolicyViolationError");
+    expect((error as Error).message).toBe(
+      "Approval rejected: manual reviewer rejected"
+    );
+
+    expect(originalExecute).not.toHaveBeenCalled();
+  });
+});
+
+async function resetPatchState(): Promise<void> {
+  const hooks = await import("../src/hooks/ai-sdk.js");
+  hooks.unpatchVercelAiSdk();
+  hooks.vercelAiSdkPatchState.originalToolFactory = undefined;
+  hooks.vercelAiSdkPatchState.patchedModule = undefined;
+  hooks.vercelAiSdkPatchState.isPatched = false;
+}

--- a/tests/vercel-ai-hook.test.ts
+++ b/tests/vercel-ai-hook.test.ts
@@ -134,6 +134,158 @@ describe("vercel ai sdk adapter", () => {
 
     expect(originalExecute).not.toHaveBeenCalled();
   });
+
+  it("uses description for toolName in gateway check", async () => {
+    const gateway = createGatewayClientMock();
+    gateway.check = vi.fn(async () => ({ denied: false, pending: false }));
+    const originalExecute = vi.fn(async () => ({ ok: true }));
+
+    const hooks = await import("../src/hooks/ai-sdk.js");
+    const wrappedExecute = hooks.createWrappedExecute(
+      originalExecute,
+      "Get current weather for a city",
+      gateway,
+      { approvalTimeoutMs: 5_000, fallbackRunId: "fallback" }
+    );
+
+    await wrappedExecute({ city: "Paris" }, { toolCallId: "call-5" });
+
+    expect(gateway.check).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolName: "Get current weather for a city"
+      })
+    );
+  });
+
+  it("fails open and executes original tool when gateway check throws", async () => {
+    const gateway = createGatewayClientMock();
+    gateway.check = vi.fn(async () => {
+      throw new Error("gateway unavailable");
+    });
+    const originalExecute = vi.fn(async () => ({ ok: "fallback-path" }));
+
+    const hooks = await import("../src/hooks/ai-sdk.js");
+    const wrappedExecute = hooks.createWrappedExecute(
+      originalExecute,
+      "critical tool",
+      gateway,
+      { approvalTimeoutMs: 4_000, fallbackRunId: "fallback" }
+    );
+
+    const result = await wrappedExecute(
+      { x: 1 },
+      { toolCallId: "call-6" }
+    );
+
+    expect(result).toEqual({ ok: "fallback-path" });
+    expect(originalExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("records results in fire-and-forget mode without surfacing recorder failures", async () => {
+    const gateway = createGatewayClientMock();
+    gateway.recordResult = vi.fn(async () => {
+      throw new Error("recording failed");
+    });
+    const hooks = await import("../src/hooks/ai-sdk.js");
+
+    expect(() =>
+      hooks.recordToolResultNonBlocking(gateway, "run-7", { ok: true })
+    ).not.toThrow();
+
+    await Promise.resolve();
+    expect(gateway.recordResult).toHaveBeenCalledWith({
+      runId: "run-7",
+      output: { ok: true }
+    });
+  });
+
+  it("uses fallbackRunId when toolCallId is not provided", async () => {
+    const gateway = createGatewayClientMock();
+    gateway.check = vi.fn(async () => ({ denied: false, pending: false }));
+    const originalExecute = vi.fn(async () => ({ ok: true }));
+
+    const hooks = await import("../src/hooks/ai-sdk.js");
+    const wrappedExecute = hooks.createWrappedExecute(
+      originalExecute,
+      "some tool",
+      gateway,
+      { approvalTimeoutMs: 5_000, fallbackRunId: "vercel-ai-sdk" }
+    );
+
+    await wrappedExecute({ data: "test" }, {});
+
+    expect(gateway.check).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "vercel-ai-sdk"
+      })
+    );
+  });
+
+  it("restores original tool factory when unpatch is called", async () => {
+    const gateway = createGatewayClientMock();
+    const originalTool = vi.fn((def: Record<string, unknown>) => def);
+    const fakeModule = { tool: originalTool };
+
+    const hooks = await import("../src/hooks/ai-sdk.js");
+    const patched = await hooks.patchVercelAiSdk({
+      gatewayClient: gateway,
+      loadModule: async () => fakeModule
+    });
+
+    expect(patched).toBe(true);
+    expect(fakeModule.tool).not.toBe(originalTool);
+
+    const restored = hooks.unpatchVercelAiSdk();
+    expect(restored).toBe(true);
+    expect(fakeModule.tool).toBe(originalTool);
+  });
+
+  it("passes through tools without execute unchanged", async () => {
+    const gateway = createGatewayClientMock();
+    const toolWithoutExecute = { description: "a schema-only tool", parameters: {} };
+    const originalTool = vi.fn((def: Record<string, unknown>) => ({ ...def }));
+    const fakeModule = { tool: originalTool };
+
+    const hooks = await import("../src/hooks/ai-sdk.js");
+    await hooks.patchVercelAiSdk({
+      gatewayClient: gateway,
+      loadModule: async () => fakeModule
+    });
+
+    const result = fakeModule.tool(toolWithoutExecute);
+    expect(result.execute).toBeUndefined();
+    expect(result.description).toBe("a schema-only tool");
+  });
+
+  it("activates patching during initAssembly when ai package is detected", async () => {
+    const gateway = createGatewayClientMock();
+    const originalTool = vi.fn((def: Record<string, unknown>) => def);
+
+    vi.doMock("ai", () => ({ tool: originalTool }));
+    vi.doMock("node:module", () => ({
+      createRequire: () => ({
+        resolve: (packageName: string) => {
+          if (packageName === "ai") {
+            return packageName;
+          }
+          throw new Error("MODULE_NOT_FOUND");
+        }
+      })
+    }));
+
+    const { initAssembly } = await import("../src/core/init-assembly.js");
+    const context = await initAssembly({
+      gatewayUrl: "https://gateway.example.com",
+      apiKey: "test-key",
+      mode: "sdk-only",
+      gatewayClient: gateway
+    });
+
+    expect(context.activeAdapters).toContain("vercel-ai-sdk");
+
+    const hooks = await import("../src/hooks/ai-sdk.js");
+    expect(hooks.vercelAiSdkPatchState.isPatched).toBe(true);
+  });
 });
 
 async function resetPatchState(): Promise<void> {

--- a/tests/vercel-ai-hook.test.ts
+++ b/tests/vercel-ai-hook.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayClient } from "../src/gateway/client.js";
+import type { VercelAiToolDefinition, VercelAiToolFactory } from "../src/types/vercel-ai-adapter.js";
+import type { VercelAiSdkModule } from "../src/hooks/ai-sdk.js";
 
 function createGatewayClientMock(): GatewayClient {
   return {
@@ -223,8 +225,8 @@ describe("vercel ai sdk adapter", () => {
 
   it("restores original tool factory when unpatch is called", async () => {
     const gateway = createGatewayClientMock();
-    const originalTool = vi.fn((def: Record<string, unknown>) => def);
-    const fakeModule = { tool: originalTool };
+    const originalTool = vi.fn((def: VercelAiToolDefinition) => def) as unknown as VercelAiToolFactory;
+    const fakeModule: VercelAiSdkModule = { tool: originalTool };
 
     const hooks = await import("../src/hooks/ai-sdk.js");
     const patched = await hooks.patchVercelAiSdk({
@@ -242,9 +244,9 @@ describe("vercel ai sdk adapter", () => {
 
   it("passes through tools without execute unchanged", async () => {
     const gateway = createGatewayClientMock();
-    const toolWithoutExecute = { description: "a schema-only tool", parameters: {} };
-    const originalTool = vi.fn((def: Record<string, unknown>) => ({ ...def }));
-    const fakeModule = { tool: originalTool };
+    const toolWithoutExecute: VercelAiToolDefinition = { description: "a schema-only tool", parameters: {} };
+    const originalTool = vi.fn((def: VercelAiToolDefinition) => ({ ...def })) as unknown as VercelAiToolFactory;
+    const fakeModule: VercelAiSdkModule = { tool: originalTool };
 
     const hooks = await import("../src/hooks/ai-sdk.js");
     await hooks.patchVercelAiSdk({
@@ -259,7 +261,7 @@ describe("vercel ai sdk adapter", () => {
 
   it("activates patching during initAssembly when ai package is detected", async () => {
     const gateway = createGatewayClientMock();
-    const originalTool = vi.fn((def: Record<string, unknown>) => def);
+    const originalTool = vi.fn((def: VercelAiToolDefinition) => def) as unknown as VercelAiToolFactory;
 
     vi.doMock("ai", () => ({ tool: originalTool }));
     vi.doMock("node:module", () => ({


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Replace the stub `patchVercelAiSdk()` with a full governance hook that monkey-patches the Vercel AI SDK `tool()` factory. Every tool created after patching has its `execute` function wrapped with gateway policy checks (DENY/PENDING/ALLOW), consistent with the existing OpenAI Agents adapter pattern.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: AAASM-189
    * Relative task IDs:
        * [x] AAASM-6 (Epic: Node.js / TypeScript SDK)
        * [x] AAASM-58 (F27 — Vercel AI SDK section)
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    **As-is:** `patchVercelAiSdk()` is a stub that unconditionally returns `false`. No governance enforcement for Vercel AI SDK users.

    **To-be:** `patchVercelAiSdk()` monkey-patches the `tool()` export from the `ai` package. All tools created after patching have their `execute` wrapped with:
    - DENY → throws `PolicyViolationError` before execution
    - PENDING → waits for approval via `gateway.waitForApproval()`, throws on rejection
    - ALLOW → executes original, records result non-blocking
    - Gateway error → fails open (executes original)
    - Uses `description` (not `name`) for policy matching — Vercel AI SDK quirk

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [x] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [x] 🤖 Framework hooks
    * [x] 🫀 Data model and types
    * [x] ⛑️ Error handling
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [ ] 🚀 Building
        * [ ] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
    * [ ] 📚 Documentation
* Additional description:
    N/A.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Added `src/types/vercel-ai-adapter.ts` — type definitions for Vercel AI SDK tool interfaces
* Added `src/hooks/ai-sdk-detection.ts` — `hasVercelAiSdk()` package detection helper
* Replaced stub in `src/hooks/ai-sdk.ts` with full implementation:
  - `vercelAiSdkPatchState` — global patch state tracking
  - `captureOriginalToolFactory()` — captures original `tool` export
  - `createWrappedExecute()` — wraps `execute` with gateway governance
  - `createPatchedToolFactory()` — creates patched `tool()` factory
  - `patchVercelAiSdk()` — main entry point
  - `unpatchVercelAiSdk()` — cleanup for test isolation
* Updated `src/core/init-assembly.ts` — wires Vercel AI SDK patching alongside OpenAI Agents
* Updated `src/hooks/adapter-registry.ts` — removed legacy `patchVercelAiSdk` call (now wired through `init-assembly.ts`)
* Added 11 unit tests in `tests/vercel-ai-hook.test.ts` covering all decision paths and edge cases
* Updated `tests/hooks-patch.test.ts` for new function signature