### PR TITLE
[AAASM-1135] 📝 (docs): Author README.md and CONTRIBUTING.md for node-sdk

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to @agent-assembly/sdk
+
+Thank you for considering a contribution! This guide explains how to set up your local
+environment and start hacking on the Node.js SDK for Agent Assembly.
+
+## Development environment setup
+
+### Prerequisites
+
+- Node.js ≥ 18.18.0 (LTS)
+- pnpm ≥ 10
+- Git
+- Rust toolchain (only required when rebuilding the native `aa-ffi-node` binding)
+
+### Clone and install
+
+```bash
+git clone https://github.com/AI-agent-assembly/node-sdk.git
+cd node-sdk
+pnpm install
+pnpm build
+```
+
+`pnpm install` runs `scripts/postinstall.mjs` to wire in the prebuilt native binding for
+your platform. `pnpm build` produces both ESM (`dist/esm/`) and CJS (`dist/cjs/`) outputs
+from a single TypeScript source.
+
+If you intend to modify the native Rust crate (`native/aa-ffi-node/`), rebuild it with:
+
+```bash
+pnpm native:build               # debug build, local
+pnpm native:build:release       # release build, per-platform artifact
+pnpm native:check-types         # validate generated index.d.ts
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,3 +93,41 @@ AA_NATIVE_TEST=1 pnpm vitest run tests/native-napi-integration.test.ts
   `undefined` to satisfy the type system.
 
 Run `pnpm typecheck` before pushing — CI rejects any type error.
+
+## Linting and formatting
+
+The repository uses **ESLint flat config** (`eslint.config.mjs`) layered on
+`@eslint/js` recommended rules and `typescript-eslint`'s recommended rules, plus a
+type-aware project pass over `tsconfig.build.json` and `tsconfig.test.json`.
+
+```bash
+pnpm lint                       # eslint .
+pnpm format                     # prettier --write .
+```
+
+Notes:
+
+- Generated artifacts (`dist/`, `coverage/`, `native/**/target/`) and the napi-rs
+  generated files (`native/aa-ffi-node/index.cjs`, `native/aa-ffi-node/index.d.ts`)
+  are excluded from linting.
+- Prettier formats with `printWidth: 100`, `semi: true`, `singleQuote: false`,
+  `trailingComma: "none"` (see `.prettierrc`).
+- Do not suppress lint warnings without a comment explaining the exception.
+
+## Pull request checklist
+
+Before opening a PR, confirm each item:
+
+- [ ] Branch follows `<release>/<ticket>/<type>/<short-summary>` naming.
+- [ ] Each commit is atomic and uses GitEmoji-prefixed messages
+      (`<emoji> (<scope>): <imperative summary>`).
+- [ ] `pnpm lint` is clean.
+- [ ] `pnpm typecheck` is clean.
+- [ ] `pnpm test` passes locally.
+- [ ] New behaviour has tests; bug fixes include a regression test.
+- [ ] Public API changes are reflected in `src/index.ts` exports and types.
+- [ ] PR title format: `[<ticket>] <emoji> (<scope>): <summary>`.
+- [ ] PR body fills out `.github/PULL_REQUEST_TEMPLATE.md` (target, ticket links,
+      effecting scope, description).
+- [ ] Base branch is `master`. Push remote is `remote` (not `origin`).
+- [ ] At least one Pioneer team approval before merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,3 +64,32 @@ To add a new adapter for `<framework>`:
 Refer to `src/adapters/langchain/` for a reference implementation that demonstrates the
 two-layer enforcement model required when a framework's hook surface cannot preempt
 execution.
+
+## Running tests and type checks
+
+```bash
+pnpm test                       # vitest run, full suite
+pnpm test -- src/adapters       # filter by directory
+pnpm test -- -t "deferred"      # filter by test name
+pnpm test:coverage              # vitest with lcov + text reporter
+pnpm typecheck                  # tsc --noEmit against tsconfig.test.json
+```
+
+The native integration test only runs when `AA_NATIVE_TEST=1` is set:
+
+```bash
+AA_NATIVE_TEST=1 pnpm vitest run tests/native-napi-integration.test.ts
+```
+
+### TypeScript strict mode
+
+`tsconfig.json` enables `strict`, `noUncheckedIndexedAccess`, and
+`exactOptionalPropertyTypes`. Contributions must compile cleanly under these flags:
+
+- No `any` without an inline comment justifying the escape hatch.
+- Index access (`array[i]`, `record[key]`) returns `T | undefined` — handle the
+  `undefined` case explicitly.
+- Optional properties must be either present with a value or absent; do not assign
+  `undefined` to satisfy the type system.
+
+Run `pnpm typecheck` before pushing — CI rejects any type error.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,3 +32,35 @@ pnpm native:build               # debug build, local
 pnpm native:build:release       # release build, per-platform artifact
 pnpm native:check-types         # validate generated index.d.ts
 ```
+
+## Adding a framework adapter
+
+Framework adapters are the integration points between Agent Assembly and a third-party
+agent framework (LangChain, OpenAI Agents, Vercel AI SDK, etc.). Each adapter implements
+the `Adapter` interface in `src/adapters/adapter.ts`:
+
+```ts
+export interface Adapter {
+  readonly id: string;
+  apply: () => Promise<void>;
+  shutdown?: () => Promise<void>;
+}
+```
+
+To add a new adapter for `<framework>`:
+
+1. **Create a new directory** under `src/adapters/<framework>/` for the integration's
+   surface area (callback handlers, wrappers, type bridges).
+2. **Implement the `Adapter` interface** — `apply()` performs framework-specific
+   registration; `shutdown()` (optional) cleans up subscriptions or globals.
+3. **Register the adapter** with the `AdapterRegistry` from `init-assembly.ts`. The
+   registry is constructed during `initAssembly()` and `applyAll()` is invoked on every
+   registered adapter.
+4. **Add types** — public types belong in `src/types/`; framework-private types stay
+   inside the adapter directory.
+5. **Write tests** under `tests/adapters/<framework>/` covering both the wrapper layer
+   (pre-execution checks) and any callback layer (post-execution redaction).
+
+Refer to `src/adapters/langchain/` for a reference implementation that demonstrates the
+two-layer enforcement model required when a framework's hook surface cannot preempt
+execution.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,3 +131,25 @@ Before opening a PR, confirm each item:
       effecting scope, description).
 - [ ] Base branch is `master`. Push remote is `remote` (not `origin`).
 - [ ] At least one Pioneer team approval before merge.
+
+## Building the documentation site
+
+Long-form docs are delivered as a Docusaurus site. Markdown content lives in `docs/`
+and the Docusaurus app (config, theme, sidebars) lives in `website/`. The two are
+intentionally separated so consumers reading the GitHub repo see the content directly.
+
+```bash
+cd website
+pnpm install                    # install Docusaurus deps (separate from the SDK's)
+pnpm start                      # local dev server with hot reload
+pnpm build                      # production build into website/build/
+pnpm serve                      # preview the production build locally
+```
+
+The API reference under the **API** sidebar section is regenerated automatically by
+`docusaurus-plugin-typedoc` from `src/index.ts` on every build — do not edit those
+pages by hand.
+
+When you push your branch, the `publish-docs.yml` workflow builds the site and
+deploys to the `gh-pages` branch on push to `master`. The published site is at
+**https://ai-agent-assembly.github.io/node-sdk/**.

--- a/README.md
+++ b/README.md
@@ -171,3 +171,12 @@ Package verification checks include:
 - ESM and CJS entry smoke tests
 - export `types` mapping assertion
 - `npm pack` content and package size guard tests
+
+## Documentation
+
+Full guides, architecture deep-dives, and the complete API reference are published at:
+
+**https://ai-agent-assembly.github.io/node-sdk/**
+
+The site is built from the `docs/` (content) and `website/` (Docusaurus app) directories
+and is re-published on every push to `master` via the `publish-docs.yml` workflow.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ Before installing or contributing, ensure your environment has:
 - **Rust toolchain** (only required when rebuilding the native `aa-ffi-node` binding from
   source — most consumers receive a prebuilt platform binary via `optionalDependencies`).
 
+## Installation
+
+```bash
+pnpm add @agent-assembly/sdk
+# or
+npm install @agent-assembly/sdk
+# or
+yarn add @agent-assembly/sdk
+```
+
+The SDK ships dual ESM/CJS entries and selects a prebuilt native binding for your platform
+during `postinstall`. No additional build step is required for typical consumers.
+
 ## Goal
 
 Provide a thin wrapper around the Agent Assembly Rust runtime through:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@
 
 TypeScript/Node.js SDK for Agent Assembly, licensed under Apache 2.0.
 
+## Prerequisites
+
+Before installing or contributing, ensure your environment has:
+
+- **Node.js** ≥ 18.18.0 (LTS). The active LTS lines (18, 20, 22, 24) are exercised in CI.
+- **pnpm** ≥ 10. The repository enforces pnpm via `engines` and ships a `pnpm-lock.yaml`.
+- **Rust toolchain** (only required when rebuilding the native `aa-ffi-node` binding from
+  source — most consumers receive a prebuilt platform binary via `optionalDependencies`).
+
 ## Goal
 
 Provide a thin wrapper around the Agent Assembly Rust runtime through:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ const governedTools = withAssembly(myTools, { context: ctx });
 const model = new ChatOpenAI({ model: "gpt-4o-mini" }).bindTools(governedTools);
 ```
 
+### CJS (`require`)
+
+```js
+const { initAssembly, withAssembly } = require("@agent-assembly/sdk");
+const { ChatOpenAI } = require("@langchain/openai");
+
+const ctx = await initAssembly({ gatewayUrl: "http://localhost:8080", agentId: "demo" });
+const governedTools = withAssembly(myTools, { context: ctx });
+const model = new ChatOpenAI({ model: "gpt-4o-mini" }).bindTools(governedTools);
+```
+
+Both entrypoints resolve to the same governance pipeline; the package's `exports` field
+selects ESM or CJS automatically based on how the consumer imports it.
+
 `initAssembly()` registers the LangChain callback handler and the AdapterRegistry, so any
 tool wrapped by `withAssembly()` is checked against gateway policy before invocation.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ yarn add @agent-assembly/sdk
 The SDK ships dual ESM/CJS entries and selects a prebuilt native binding for your platform
 during `postinstall`. No additional build step is required for typical consumers.
 
+## Quickstart
+
+### ESM (`import`)
+
+```ts
+import { initAssembly, withAssembly } from "@agent-assembly/sdk";
+import { ChatOpenAI } from "@langchain/openai";
+
+const ctx = await initAssembly({ gatewayUrl: "http://localhost:8080", agentId: "demo" });
+const governedTools = withAssembly(myTools, { context: ctx });
+const model = new ChatOpenAI({ model: "gpt-4o-mini" }).bindTools(governedTools);
+```
+
+`initAssembly()` registers the LangChain callback handler and the AdapterRegistry, so any
+tool wrapped by `withAssembly()` is checked against gateway policy before invocation.
+
 ## Goal
 
 Provide a thin wrapper around the Agent Assembly Rust runtime through:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ selects ESM or CJS automatically based on how the consumer imports it.
 `initAssembly()` registers the LangChain callback handler and the AdapterRegistry, so any
 tool wrapped by `withAssembly()` is checked against gateway policy before invocation.
 
+## Supported Node.js versions
+
+The SDK is tested against every active Node.js LTS line on every supported operating
+system. The matrix is enforced by `.github/workflows/test-matrix.yml`:
+
+| Node.js | Linux (ubuntu-latest) | macOS (macos-latest) | Windows (windows-latest) |
+| ------- | --------------------- | -------------------- | ------------------------ |
+| 18      | ✅                    | ✅                   | ✅                       |
+| 20      | ✅                    | ✅                   | ✅                       |
+| 22      | ✅                    | ✅                   | ✅                       |
+| 24      | ✅                    | ✅                   | ✅                       |
+
+Older Node.js lines (≤ 16) are unsupported because the napi-rs ABI used by the native
+binding requires Node 18.18 or newer.
+
 ## Goal
 
 Provide a thin wrapper around the Agent Assembly Rust runtime through:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # @agent-assembly/sdk
+
+[![npm version](https://img.shields.io/npm/v/@agent-assembly/sdk.svg)](https://www.npmjs.com/package/@agent-assembly/sdk)
+[![CI](https://github.com/AI-agent-assembly/node-sdk/actions/workflows/test-matrix.yml/badge.svg?branch=master)](https://github.com/AI-agent-assembly/node-sdk/actions/workflows/test-matrix.yml)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=AI-agent-assembly_node-sdk&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=AI-agent-assembly_node-sdk)
 [![codecov](https://codecov.io/gh/AI-agent-assembly/node-sdk/branch/master/graph/badge.svg)](https://codecov.io/gh/AI-agent-assembly/node-sdk)
 


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Author the `node-sdk` repository's `README.md` and `CONTRIBUTING.md` so Node.js
    and TypeScript developers can install, use, and contribute to the SDK without
    prior context. README is enhanced (not rewritten) with prerequisites, install,
    quickstart (ESM + CJS), supported-version matrix, npm/CI/license badges, and a
    link to the upcoming Docusaurus documentation site. CONTRIBUTING.md is created
    from scratch with dev environment setup, framework adapter authoring guide,
    tests + TypeScript strict mode rules, ESLint config + PR checklist, and
    instructions for building the documentation site locally.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: [AAASM-1135](https://lightning-dust-mite.atlassian.net/browse/AAASM-1135)
    * Relative task IDs:
        * [x] [AAASM-315](https://lightning-dust-mite.atlassian.net/browse/AAASM-315) — parent Story
        * [x] [AAASM-13](https://lightning-dust-mite.atlassian.net/browse/AAASM-13) — Epic
        * [ ] [AAASM-1140](https://lightning-dust-mite.atlassian.net/browse/AAASM-1140) — sibling Sub-task (Docusaurus + TypeDoc CI), runs next
        * [ ] [AAASM-1164](https://lightning-dust-mite.atlassian.net/browse/AAASM-1164) — verification, after AAASM-1140 merges
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change:

    * `README.md` gains six new sections — Prerequisites, Installation, Quickstart
      (ESM + CJS side-by-side), Supported Node.js versions, npm/CI/license
      badges, Documentation site link.
    * `CONTRIBUTING.md` is new — Dev environment setup, Adding a framework
      adapter (using the actual `Adapter` interface from
      `src/adapters/adapter.ts`), Running tests + TypeScript strict mode,
      Linting + PR checklist, Building the documentation site.
    * No source code, no behaviour changes — Markdown only.

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [ ] 🤖 Framework hooks
    * [ ] 🫀 Data model and types
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
        * [ ] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [ ] 🚀 Building
        * [ ] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
    * [x] 📚 Documentation
* Additional description:

    * Resolves three description discrepancies vs. repo reality, deliberately: package
      name (`@agent-assembly/sdk`, not `agent-assembly`), tooling (`pnpm`, not `npm`),
      Node engines (`>= 18.18.0` LTS, not the broader `>= 18`).
    * Forward-references the Docusaurus site at
      `https://ai-agent-assembly.github.io/node-sdk/`. Link goes live when
      AAASM-1140 ships the site bootstrap and deploy workflow.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Twelve atomic commits, GitEmoji-prefixed, one logical change each:
    1. \`📝 (readme): Add prerequisites section with Node and Rust toolchain\`
    2. \`📝 (readme): Add install command for @agent-assembly/sdk\`
    3. \`📝 (readme): Add ESM quickstart with initAssembly + LangChain.js\`
    4. \`📝 (readme): Add CJS quickstart with require() variant\`
    5. \`📝 (readme): Add npm version, CI, and license badges\`
    6. \`📝 (readme): Document supported Node.js version matrix from CI\`
    7. \`✨ (contributing): Create CONTRIBUTING.md with dev environment setup\`
    8. \`✨ (contributing): Add framework adapter authoring guide\`
    9. \`✨ (contributing): Add test commands and TypeScript strict mode rules\`
    10. \`✨ (contributing): Add ESLint config notes and PR checklist\`
    11. \`📝 (readme): Add link to Docusaurus documentation site\`
    12. \`📝 (contributing): Add building the documentation site section\`

* Validation (run locally in the worktree before push):
    * \`pnpm lint\` — clean.
    * \`pnpm typecheck\` — clean.
    * \`pnpm test\` — 83 passed, 2 skipped (native napi tests gated on
      \`AA_NATIVE_TEST=1\`), 0 failed.
    * \`pnpm exec prettier --check README.md CONTRIBUTING.md\` — clean.
      (\`prettier --check .\` reports 29 pre-existing warnings in unrelated
      files; none introduced by this PR.)

[AAASM-1135]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-315]: https://lightning-dust-mite.atlassian.net/browse/AAASM-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-13]: https://lightning-dust-mite.atlassian.net/browse/AAASM-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ