### PR TITLE
[AAASM-1177] 🐛 (core): Send topology fields in native client registration event on init

### DIFF
--- a/src/core/init-assembly.ts
+++ b/src/core/init-assembly.ts
@@ -6,6 +6,7 @@ import {
   type WrapToolWithAssemblyOptions
 } from "../adapters/langchain/index.js";
 import { createNoopGatewayClient, type GatewayClient } from "../gateway/client.js";
+import { createNativeClient, type NativeClient } from "../native/client.js";
 import type { AssemblyConfig } from "../types/assembly-config.js";
 import type { AssemblyContext } from "../types/assembly-context.js";
 import type {
@@ -18,6 +19,15 @@ import { hasOpenAIAgentsSDK } from "../hooks/openai-agents-detection.js";
 import { patchOpenAIAgents } from "../hooks/openai-agents.js";
 
 const requireFromCwd = createRequire(`${process.cwd()}/`);
+
+function buildRegistrationEvent(config: AssemblyConfig): Record<string, string> {
+  const event: Record<string, string> = { event_type: "register" };
+  if (config.parentAgentId !== undefined) event.parent_agent_id = config.parentAgentId;
+  if (config.teamId !== undefined) event.team_id = config.teamId;
+  if (config.delegationReason !== undefined) event.delegation_reason = config.delegationReason;
+  if (config.spawnedByTool !== undefined) event.spawned_by_tool = config.spawnedByTool;
+  return event;
+}
 
 export function createClient(config: AssemblyConfig): GatewayClient {
   const mode = config.mode ?? "auto";
@@ -163,6 +173,18 @@ export async function initAssembly(config: AssemblyConfig): Promise<AssemblyCont
 
   await startNetworkLayerIfNeeded(client, config);
 
+  // Send topology registration event through the native transport on every boot
+  // except sdk-only mode (which has no sidecar to register with).
+  let nativeClient: NativeClient | undefined;
+  if (config.mode !== "sdk-only") {
+    nativeClient = createNativeClient({
+      gateway: config.gatewayUrl,
+      apiKey: config.apiKey,
+      mode: config.mode === "napi-inprocess" ? "napi-inprocess" : "grpc-sidecar",
+    });
+    nativeClient.sendEvent(buildRegistrationEvent(config));
+  }
+
   const langChainHandler = registerLangChainHandler(config, client, frameworks);
   const wrappedLangChainTools = wrapLangChainTools(config, client, frameworks);
   const vercelAiSdkPatched = await patchDetectedVercelAiSdk(client, frameworks);
@@ -186,6 +208,7 @@ export async function initAssembly(config: AssemblyConfig): Promise<AssemblyCont
       for (const adapter of adapters) {
         await adapter.shutdown?.();
       }
+      await nativeClient?.close();
       await client.close();
     }
   };

--- a/tests/topology-registration.test.ts
+++ b/tests/topology-registration.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+
+interface MockBinding {
+  connect: ReturnType<typeof vi.fn>;
+  sendEvent: ReturnType<typeof vi.fn>;
+  queryPolicy: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+}
+
+function makeMockBinding(): MockBinding {
+  return {
+    connect: vi.fn(async () => ({ id: "reg-handle" })),
+    sendEvent: vi.fn(() => undefined),
+    queryPolicy: vi.fn(async () => ({ denied: false, pending: false })),
+    disconnect: vi.fn(async () => undefined),
+  };
+}
+
+async function loadInitAssemblyWithBinding(binding: MockBinding) {
+  vi.resetModules();
+  vi.doMock("node:module", () => ({
+    createRequire: () => () => binding,
+  }));
+  return import("../src/index.js");
+}
+
+describe("topology registration on initAssembly", () => {
+  it("sends registration event with all topology fields in napi-inprocess mode", async () => {
+    const binding = makeMockBinding();
+    const { initAssembly } = await loadInitAssemblyWithBinding(binding);
+
+    const ctx = await initAssembly({
+      gatewayUrl: "/tmp/aa.sock",
+      apiKey: "test-key",
+      mode: "napi-inprocess",
+      parentAgentId: "parent-agent-001",
+      teamId: "team-alpha",
+      delegationReason: "sub-task delegation",
+      spawnedByTool: "search_tool",
+    });
+
+    await ctx.shutdown();
+
+    expect(binding.sendEvent).toHaveBeenCalledWith(
+      expect.any(Object),
+      {
+        event_type: "register",
+        parent_agent_id: "parent-agent-001",
+        team_id: "team-alpha",
+        delegation_reason: "sub-task delegation",
+        spawned_by_tool: "search_tool",
+      }
+    );
+  });
+
+  it("sends bare register event when no topology fields are provided", async () => {
+    const binding = makeMockBinding();
+    const { initAssembly } = await loadInitAssemblyWithBinding(binding);
+
+    const ctx = await initAssembly({
+      gatewayUrl: "/tmp/aa.sock",
+      apiKey: "test-key",
+      mode: "napi-inprocess",
+    });
+
+    await ctx.shutdown();
+
+    const registrationCall = binding.sendEvent.mock.calls.find(
+      ([, event]) => (event as Record<string, string>).event_type === "register"
+    );
+
+    expect(registrationCall).toBeDefined();
+    const [, event] = registrationCall!;
+    expect(event).toEqual({ event_type: "register" });
+  });
+
+  it("sends registration event in grpc-sidecar mode (noop path)", async () => {
+    const binding = makeMockBinding();
+    const { initAssembly } = await loadInitAssemblyWithBinding(binding);
+
+    const ctx = await initAssembly({
+      gatewayUrl: "https://gateway.example.com",
+      apiKey: "test-key",
+      mode: "grpc-sidecar",
+      parentAgentId: "parent-sidecar-001",
+    });
+
+    await ctx.shutdown();
+
+    // grpc-sidecar is a noop NativeClient — sendEvent is ignored, binding never called
+    expect(binding.connect).not.toHaveBeenCalled();
+    expect(binding.sendEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not send registration event in sdk-only mode", async () => {
+    const binding = makeMockBinding();
+    const { initAssembly } = await loadInitAssemblyWithBinding(binding);
+
+    const ctx = await initAssembly({
+      gatewayUrl: "https://gateway.example.com",
+      apiKey: "test-key",
+      mode: "sdk-only",
+      parentAgentId: "parent-sdk-only",
+    });
+
+    await ctx.shutdown();
+
+    expect(binding.connect).not.toHaveBeenCalled();
+    expect(binding.sendEvent).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What changed

Wires the four topology fields — `parentAgentId`, `teamId`, `delegationReason`, `spawnedByTool` — into a `{"event_type":"register",...}` event sent to the native transport immediately when `initAssembly` is called. Previously these fields were stored in `AssemblyConfig` and surfaced on `AssemblyContext` but never forwarded to the sidecar/gateway.

## Why it changed

AAASM-1177: Post-merge audit of AAASM-211 found that the TypeScript SDK accepted topology options but silently discarded them — the gateway never received topology metadata for TypeScript agents.

## How it works

- `src/core/init-assembly.ts`:
  - `buildRegistrationEvent(config)` — builds the registration payload from `AssemblyConfig` topology fields, omitting undefined ones.
  - `initAssembly` creates a `NativeClient` (skipped in `sdk-only` mode) and calls `nativeClient.sendEvent(buildRegistrationEvent(config))` right after `startNetworkLayerIfNeeded`. For `napi-inprocess` mode the event is queued and sent after the lazy connect; for other modes the noop path discards it harmlessly.
  - `shutdown` closes the native client via `nativeClient?.close()`.

## How to verify

```bash
pnpm test -- tests/topology-registration.test.ts
```

Four new tests cover: all topology fields in `napi-inprocess`, bare register event with no topology fields, grpc-sidecar noop path, sdk-only skipped path.

Closes #AAASM-1177

🤖 Generated with [Claude Code](https://claude.com/claude-code)