### PR TITLE
[AAASM-1178] ✅ (test): Integration tests for topology registration in TypeScript SDK

### DIFF
--- a/src/core/init-assembly.ts
+++ b/src/core/init-assembly.ts
@@ -6,6 +6,7 @@ import {
   type WrapToolWithAssemblyOptions
 } from "../adapters/langchain/index.js";
 import { createNoopGatewayClient, type GatewayClient } from "../gateway/client.js";
+import { createNativeClient, type NativeClient } from "../native/client.js";
 import type { AssemblyConfig } from "../types/assembly-config.js";
 import type { AssemblyContext } from "../types/assembly-context.js";
 import type {
@@ -18,6 +19,15 @@ import { hasOpenAIAgentsSDK } from "../hooks/openai-agents-detection.js";
 import { patchOpenAIAgents } from "../hooks/openai-agents.js";
 
 const requireFromCwd = createRequire(`${process.cwd()}/`);
+
+function buildRegistrationEvent(config: AssemblyConfig): Record<string, string> {
+  const event: Record<string, string> = { event_type: "register" };
+  if (config.parentAgentId !== undefined) event.parent_agent_id = config.parentAgentId;
+  if (config.teamId !== undefined) event.team_id = config.teamId;
+  if (config.delegationReason !== undefined) event.delegation_reason = config.delegationReason;
+  if (config.spawnedByTool !== undefined) event.spawned_by_tool = config.spawnedByTool;
+  return event;
+}
 
 export function createClient(config: AssemblyConfig): GatewayClient {
   const mode = config.mode ?? "auto";
@@ -163,6 +173,18 @@ export async function initAssembly(config: AssemblyConfig): Promise<AssemblyCont
 
   await startNetworkLayerIfNeeded(client, config);
 
+  // Send topology registration event through the native transport on every boot
+  // except sdk-only mode (which has no sidecar to register with).
+  let nativeClient: NativeClient | undefined;
+  if (config.mode !== "sdk-only") {
+    nativeClient = createNativeClient({
+      gateway: config.gatewayUrl,
+      apiKey: config.apiKey,
+      mode: config.mode === "napi-inprocess" ? "napi-inprocess" : "grpc-sidecar",
+    });
+    nativeClient.sendEvent(buildRegistrationEvent(config));
+  }
+
   const langChainHandler = registerLangChainHandler(config, client, frameworks);
   const wrappedLangChainTools = wrapLangChainTools(config, client, frameworks);
   const vercelAiSdkPatched = await patchDetectedVercelAiSdk(client, frameworks);
@@ -186,6 +208,7 @@ export async function initAssembly(config: AssemblyConfig): Promise<AssemblyCont
       for (const adapter of adapters) {
         await adapter.shutdown?.();
       }
+      await nativeClient?.close();
       await client.close();
     }
   };

--- a/tests/integration/topology-registration.test.ts
+++ b/tests/integration/topology-registration.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Integration tests for topology field forwarding via native client registration event (AAASM-1178).
+ *
+ * These tests use a mock native binding to intercept sendEvent payloads so they
+ * run without a live sidecar. They exercise the full initAssembly → NativeClient →
+ * sendEvent path, verifying all 4 topology fields reach the registration payload.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+interface MockBinding {
+  connect: ReturnType<typeof vi.fn>;
+  sendEvent: ReturnType<typeof vi.fn>;
+  queryPolicy: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+}
+
+function makeMockBinding(): MockBinding {
+  return {
+    connect: vi.fn(async () => ({ id: "integration-handle" })),
+    sendEvent: vi.fn(() => undefined),
+    queryPolicy: vi.fn(async () => ({ denied: false, pending: false })),
+    disconnect: vi.fn(async () => undefined),
+  };
+}
+
+async function loadInitAssemblyWithBinding(binding: MockBinding) {
+  vi.resetModules();
+  vi.doMock("node:module", () => ({
+    createRequire: () => () => binding,
+  }));
+  return import("../../src/index.js");
+}
+
+describe("integration: topology registration via native client", () => {
+  it("sends all 4 topology fields in the registration event", async () => {
+    const binding = makeMockBinding();
+    const { initAssembly } = await loadInitAssemblyWithBinding(binding);
+
+    const ctx = await initAssembly({
+      gatewayUrl: "/tmp/aa-integration.sock",
+      apiKey: "integration-api-key",
+      mode: "napi-inprocess",
+      parentAgentId: "parent-agent-integration",
+      teamId: "team-integration",
+      delegationReason: "integration delegation",
+      spawnedByTool: "integration_tool",
+    });
+
+    await ctx.shutdown();
+
+    const registrationCall = binding.sendEvent.mock.calls.find(
+      ([, event]) =>
+        (event as Record<string, string>).event_type === "register"
+    );
+    expect(registrationCall).toBeDefined();
+
+    const [, event] = registrationCall!;
+    expect(event).toMatchObject({
+      event_type: "register",
+      parent_agent_id: "parent-agent-integration",
+      team_id: "team-integration",
+      delegation_reason: "integration delegation",
+      spawned_by_tool: "integration_tool",
+    });
+  });
+
+  it("sends only event_type when no topology fields are provided", async () => {
+    const binding = makeMockBinding();
+    const { initAssembly } = await loadInitAssemblyWithBinding(binding);
+
+    const ctx = await initAssembly({
+      gatewayUrl: "/tmp/aa-integration-bare.sock",
+      apiKey: "integration-api-key",
+      mode: "napi-inprocess",
+    });
+
+    await ctx.shutdown();
+
+    const registrationCall = binding.sendEvent.mock.calls.find(
+      ([, event]) =>
+        (event as Record<string, string>).event_type === "register"
+    );
+    expect(registrationCall).toBeDefined();
+
+    const [, event] = registrationCall! as [object, Record<string, string>];
+    expect(event.event_type).toBe("register");
+    expect(event.parent_agent_id).toBeUndefined();
+    expect(event.team_id).toBeUndefined();
+    expect(event.delegation_reason).toBeUndefined();
+    expect(event.spawned_by_tool).toBeUndefined();
+  });
+
+  it("sends partial topology when only some fields are provided", async () => {
+    const binding = makeMockBinding();
+    const { initAssembly } = await loadInitAssemblyWithBinding(binding);
+
+    const ctx = await initAssembly({
+      gatewayUrl: "/tmp/aa-integration-partial.sock",
+      apiKey: "integration-api-key",
+      mode: "napi-inprocess",
+      teamId: "team-partial",
+      spawnedByTool: "partial_tool",
+    });
+
+    await ctx.shutdown();
+
+    const registrationCall = binding.sendEvent.mock.calls.find(
+      ([, event]) =>
+        (event as Record<string, string>).event_type === "register"
+    );
+    expect(registrationCall).toBeDefined();
+
+    const [, event] = registrationCall! as [object, Record<string, string>];
+    expect(event.team_id).toBe("team-partial");
+    expect(event.spawned_by_tool).toBe("partial_tool");
+    expect(event.parent_agent_id).toBeUndefined();
+    expect(event.delegation_reason).toBeUndefined();
+  });
+
+  it("skips registration event entirely in sdk-only mode", async () => {
+    const binding = makeMockBinding();
+    const { initAssembly } = await loadInitAssemblyWithBinding(binding);
+
+    const ctx = await initAssembly({
+      gatewayUrl: "https://gateway.example.com",
+      apiKey: "integration-api-key",
+      mode: "sdk-only",
+      parentAgentId: "should-not-be-sent",
+    });
+
+    await ctx.shutdown();
+
+    expect(binding.connect).not.toHaveBeenCalled();
+    expect(binding.sendEvent).not.toHaveBeenCalled();
+  });
+});

--- a/tests/topology-registration.test.ts
+++ b/tests/topology-registration.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+
+interface MockBinding {
+  connect: ReturnType<typeof vi.fn>;
+  sendEvent: ReturnType<typeof vi.fn>;
+  queryPolicy: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+}
+
+function makeMockBinding(): MockBinding {
+  return {
+    connect: vi.fn(async () => ({ id: "reg-handle" })),
+    sendEvent: vi.fn(() => undefined),
+    queryPolicy: vi.fn(async () => ({ denied: false, pending: false })),
+    disconnect: vi.fn(async () => undefined),
+  };
+}
+
+async function loadInitAssemblyWithBinding(binding: MockBinding) {
+  vi.resetModules();
+  vi.doMock("node:module", () => ({
+    createRequire: () => () => binding,
+  }));
+  return import("../src/index.js");
+}
+
+describe("topology registration on initAssembly", () => {
+  it("sends registration event with all topology fields in napi-inprocess mode", async () => {
+    const binding = makeMockBinding();
+    const { initAssembly } = await loadInitAssemblyWithBinding(binding);
+
+    const ctx = await initAssembly({
+      gatewayUrl: "/tmp/aa.sock",
+      apiKey: "test-key",
+      mode: "napi-inprocess",
+      parentAgentId: "parent-agent-001",
+      teamId: "team-alpha",
+      delegationReason: "sub-task delegation",
+      spawnedByTool: "search_tool",
+    });
+
+    await ctx.shutdown();
+
+    expect(binding.sendEvent).toHaveBeenCalledWith(
+      expect.any(Object),
+      {
+        event_type: "register",
+        parent_agent_id: "parent-agent-001",
+        team_id: "team-alpha",
+        delegation_reason: "sub-task delegation",
+        spawned_by_tool: "search_tool",
+      }
+    );
+  });
+
+  it("sends bare register event when no topology fields are provided", async () => {
+    const binding = makeMockBinding();
+    const { initAssembly } = await loadInitAssemblyWithBinding(binding);
+
+    const ctx = await initAssembly({
+      gatewayUrl: "/tmp/aa.sock",
+      apiKey: "test-key",
+      mode: "napi-inprocess",
+    });
+
+    await ctx.shutdown();
+
+    const registrationCall = binding.sendEvent.mock.calls.find(
+      ([, event]) => (event as Record<string, string>).event_type === "register"
+    );
+
+    expect(registrationCall).toBeDefined();
+    const [, event] = registrationCall!;
+    expect(event).toEqual({ event_type: "register" });
+  });
+
+  it("sends registration event in grpc-sidecar mode (noop path)", async () => {
+    const binding = makeMockBinding();
+    const { initAssembly } = await loadInitAssemblyWithBinding(binding);
+
+    const ctx = await initAssembly({
+      gatewayUrl: "https://gateway.example.com",
+      apiKey: "test-key",
+      mode: "grpc-sidecar",
+      parentAgentId: "parent-sidecar-001",
+    });
+
+    await ctx.shutdown();
+
+    // grpc-sidecar is a noop NativeClient — sendEvent is ignored, binding never called
+    expect(binding.connect).not.toHaveBeenCalled();
+    expect(binding.sendEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not send registration event in sdk-only mode", async () => {
+    const binding = makeMockBinding();
+    const { initAssembly } = await loadInitAssemblyWithBinding(binding);
+
+    const ctx = await initAssembly({
+      gatewayUrl: "https://gateway.example.com",
+      apiKey: "test-key",
+      mode: "sdk-only",
+      parentAgentId: "parent-sdk-only",
+    });
+
+    await ctx.shutdown();
+
+    expect(binding.connect).not.toHaveBeenCalled();
+    expect(binding.sendEvent).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What changed

Adds `tests/integration/topology-registration.test.ts` with 4 integration tests verifying that topology fields reach the native client's `sendEvent` registration payload in `initAssembly`.

## Why it changed

AAASM-1178: AC4 of AAASM-211 — no integration test existed for TypeScript SDK topology registration. These tests exercise the full `initAssembly → NativeClient → sendEvent` path for the registration event.

## Dependency note

This branch includes the AAASM-1177 commits (which wire `buildRegistrationEvent` + `nativeClient.sendEvent` into `initAssembly`). This PR should be merged after AAASM-1177 (PR #29) or rebased onto master after that merge.

## Test cases

- All 4 topology fields in registration event (`napi-inprocess` mode)
- No topology → bare `{"event_type":"register"}` only
- Partial topology → only set fields present
- `sdk-only` mode → no sendEvent call at all

## How to verify

```bash
pnpm test -- tests/integration/topology-registration.test.ts
```

Expected: 4 passed.

Closes AAASM-1178 (TypeScript SDK AC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)