### PR TITLE
[AAASM-1408] 🐛 (ci): Exclude docs-only changes from code CI workflows

### DIFF
--- a/.github/workflows/build-addon.yml
+++ b/.github/workflows/build-addon.yml
@@ -3,7 +3,15 @@ name: build-addon
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
   push:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
     branches:
       - master
 

--- a/.github/workflows/module-system-smoke.yml
+++ b/.github/workflows/module-system-smoke.yml
@@ -2,7 +2,15 @@ name: module-system-smoke
 
 on:
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
   push:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
     branches:
       - master
 

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -2,7 +2,15 @@ name: pre-commit-checks
 
 on:
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
   push:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
     branches:
       - master
 

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -2,7 +2,15 @@ name: quality-report
 
 on:
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
   push:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
     branches:
       - master
 

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -2,7 +2,15 @@ name: test-matrix
 
 on:
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
   push:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
     branches:
       - master
 


### PR DESCRIPTION
## Summary

Adds `paths-ignore` for documentation patterns (`**/*.md`, `docs/**`, `LICENSE`) to all 5 code-CI workflows in this repo. Previously every workflow ran on every change because none had a `paths:` filter — markdown-only PRs were triggering the full test matrix.

## Why

Sibling issue identified during review of agent-assembly PR #421 (a `README.md`-only PR triggered full CI). Same systemic problem exists in node-sdk: no `paths:` filter at all → every PR triggers every workflow, including doc-only PRs.

## Files changed

| Workflow | Purpose |
|---|---|
| `test-matrix.yml` | Node.js test matrix (4 versions × 3 OS) |
| `quality-report.yml` | Coverage + SonarCloud |
| `precommit.yml` | pre-commit hooks |
| `build-addon.yml` | napi-rs native addon build |
| `module-system-smoke.yml` | ESM/CJS module-system smoke test |

Each `pull_request:` and `push:` trigger gains:
```yaml
paths-ignore:
  - "**/*.md"
  - "docs/**"
  - "LICENSE"
```

## Out of scope

`publish-docs.yml` is unchanged — it legitimately runs on docs changes.
`release.yml` is unchanged — it triggers on tag push only.
`regression.yml` is unchanged — it triggers on schedule/dispatch only.

## How to verify

Open a PR touching only a `.md` file. None of the 5 code-CI workflows should appear in the checks list.

Closes AAASM-1408