### PR TITLE
[AAASM-1436] 🔌 (types): Add AuditEvent + CallStackNode to TypeScript SDK

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,13 @@
 export { initAssembly } from "./core/init-assembly.js";
 export { withAssembly } from "./wrappers/index.js";
 export type { WithAssemblyOptions } from "./wrappers/index.js";
-export type { AssemblyConfig, AssemblyContext, AssemblyMode, ToolMap } from "./types/index.js";
+export type {
+  AssemblyConfig,
+  AssemblyContext,
+  AssemblyMode,
+  AuditEvent,
+  CallStackNode,
+  CallStackNodeKind,
+  ToolMap,
+} from "./types/index.js";
 export { currentAgentId, runWithAgentId } from "./lineage/index.js";

--- a/src/types/audit.ts
+++ b/src/types/audit.ts
@@ -1,0 +1,81 @@
+// Mirrors the wire-protocol shape of `assembly.audit.v1.AuditEvent` +
+// `assembly.audit.v1.CallStackNode` as of agent-assembly commit
+// `ed4aa11a8c1d1ce1e6f96b08cf2179fd772099b2` (AAASM-1419 / PR #467).
+
+/**
+ * Discriminator for a {@link CallStackNode} — open-ended on the wire
+ * (proto uses `string kind`) but typed here as a union for the three
+ * values the dashboard currently renders.
+ */
+export type CallStackNodeKind = "llm" | "tool" | "result";
+
+/**
+ * One node in the hierarchical call stack attached to an
+ * {@link AuditEvent}. Renders inline beneath an expanded Live Ops row
+ * in the dashboard.
+ *
+ * Field names are camelCase per the SDK's TypeScript convention; the
+ * wire JSON uses snake_case (`latency_ms`) and the gateway-side mapper
+ * translates between the two.
+ */
+export interface CallStackNode {
+  /** Stable identifier for this node within the call stack. */
+  id: string;
+  /** Node category — one of `"llm"`, `"tool"`, or `"result"`. */
+  kind: CallStackNodeKind;
+  /** Human-readable label rendered by downstream UI. */
+  label: string;
+  /**
+   * Step-local latency in milliseconds, or `undefined` when the producer
+   * did not record a duration. The wire field is `latency_ms`.
+   */
+  latencyMs?: number;
+  /**
+   * Recursive descent — nested calls produced by this step. Omitted (or
+   * empty array) when the node has no children.
+   */
+  children?: CallStackNode[];
+}
+
+/**
+ * A single governance-relevant occurrence in the gateway audit trail.
+ *
+ * Focused subset of the proto `assembly.audit.v1.AuditEvent` message —
+ * exposes the scalar identifying fields, labels, and the new
+ * `callStack` field added in AAASM-1419. The proto's `detail` oneof
+ * (LLM / tool / file-op / network / process / violation / approval
+ * variants) and the full lineage block are intentionally out of scope
+ * here; they will land as separate follow-up Tasks if a Node consumer
+ * needs them.
+ */
+export interface AuditEvent {
+  /** Unique identifier for this audit record (UUID v7). */
+  eventId: string;
+  /** Identity string of the agent that produced this event. */
+  agentId: string;
+  /**
+   * High-level action category — e.g. `"llm_call"`, `"tool_call"`,
+   * `"file_op"`. Open-ended on the wire (proto enum, surfaced as a
+   * normalized string).
+   */
+  actionType: string;
+  /**
+   * Policy engine verdict — e.g. `"allow"`, `"deny"`, `"redact"`.
+   * Open-ended on the wire.
+   */
+  decision: string;
+  /** Distributed tracing run-level identifier. Empty string when unset. */
+  traceId?: string;
+  /** Distributed tracing action-level identifier. Empty string when unset. */
+  spanId?: string;
+  /** Distributed tracing parent span identifier. Empty when this is a root span. */
+  parentSpanId?: string;
+  /** Arbitrary key/value labels attached at event creation. */
+  labels?: Record<string, string>;
+  /**
+   * Hierarchical record of LLM / tool / result steps that led to this
+   * event. Empty array (or undefined) when the producer did not record
+   * a stack. Renders inline beneath an expanded Live Ops row.
+   */
+  callStack?: CallStackNode[];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export type { AssemblyMode } from "./assembly-mode.js";
 export type { AssemblyConfig } from "./assembly-config.js";
 export type { AssemblyContext } from "./assembly-context.js";
 export type { ToolMap } from "./tool-map.js";
+export type { AuditEvent, CallStackNode, CallStackNodeKind } from "./audit.js";
 export type {
   GatewayApprovalResult,
   GatewayCheckRequest,

--- a/tests/types/audit.test.ts
+++ b/tests/types/audit.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type {
+  AuditEvent,
+  CallStackNode,
+  CallStackNodeKind
+} from "../../src/types/audit.js";
+
+describe("CallStackNode", () => {
+  it("accepts the required fields with all optionals omitted", () => {
+    const node: CallStackNode = { id: "n0", kind: "llm", label: "gpt-4o" };
+    expect(node.id).toBe("n0");
+    expect(node.kind).toBe("llm");
+    expect(node.label).toBe("gpt-4o");
+    expect(node.latencyMs).toBeUndefined();
+    expect(node.children).toBeUndefined();
+  });
+
+  it("carries latencyMs and a nested children tree", () => {
+    const child: CallStackNode = {
+      id: "n1",
+      kind: "tool",
+      label: "gmail.send",
+      latencyMs: 120
+    };
+    const parent: CallStackNode = {
+      id: "n0",
+      kind: "llm",
+      label: "gpt-4o",
+      latencyMs: 300,
+      children: [child]
+    };
+    expect(parent.children?.[0]).toBe(child);
+    expect(parent.children?.[0]?.latencyMs).toBe(120);
+  });
+
+  it("supports a three-level call stack tree (LLM → tool → result)", () => {
+    const tree: CallStackNode = {
+      id: "n0",
+      kind: "llm",
+      label: "gpt-4o",
+      latencyMs: 300,
+      children: [
+        {
+          id: "n1",
+          kind: "tool",
+          label: "gmail.send",
+          latencyMs: 120,
+          children: [{ id: "n2", kind: "result", label: "200 OK" }]
+        }
+      ]
+    };
+    expect(tree.children?.[0]?.children?.[0]?.kind).toBe("result");
+    expect(tree.children?.[0]?.children?.[0]?.latencyMs).toBeUndefined();
+  });
+
+  it("constrains `kind` to the three known values at the type level", () => {
+    expectTypeOf<CallStackNodeKind>().toEqualTypeOf<"llm" | "tool" | "result">();
+  });
+});
+
+describe("AuditEvent", () => {
+  it("constructs with required fields and leaves callStack undefined by default", () => {
+    const event: AuditEvent = {
+      eventId: "evt-1",
+      agentId: "support-agent",
+      actionType: "llm_call",
+      decision: "allow"
+    };
+    expect(event.eventId).toBe("evt-1");
+    expect(event.callStack).toBeUndefined();
+    expect(event.labels).toBeUndefined();
+    expect(event.traceId).toBeUndefined();
+  });
+
+  it("carries a populated callStack with tracing fields and labels", () => {
+    const event: AuditEvent = {
+      eventId: "evt-1",
+      agentId: "support-agent",
+      actionType: "llm_call",
+      decision: "allow",
+      traceId: "trace-1",
+      spanId: "span-1",
+      labels: { env: "prod" },
+      callStack: [
+        {
+          id: "n0",
+          kind: "llm",
+          label: "gpt-4o",
+          latencyMs: 300,
+          children: [{ id: "n1", kind: "tool", label: "gmail.send", latencyMs: 120 }]
+        }
+      ]
+    };
+    expect(event.callStack?.[0]?.kind).toBe("llm");
+    expect(event.callStack?.[0]?.children?.[0]?.label).toBe("gmail.send");
+    expect(event.labels?.env).toBe("prod");
+  });
+
+  it("resolves from the top-level @agent-assembly/sdk re-export", async () => {
+    // AuditEvent + CallStackNode are exported as `type` only, so they don't
+    // appear on the runtime module — but the type re-export chain must
+    // compile: src/index.ts → src/types/index.ts → src/types/audit.ts.
+    // Type-only `import type` keeps this check fully erasable.
+    type SdkPublic = typeof import("../../src/index.js");
+    expectTypeOf<SdkPublic>().toHaveProperty("withAssembly");
+    const sample: AuditEvent = {
+      eventId: "evt",
+      agentId: "a",
+      actionType: "llm_call",
+      decision: "allow"
+    };
+    expect(sample.eventId).toBe("evt");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `AuditEvent`, `CallStackNode`, and `CallStackNodeKind` TypeScript interfaces / union to a new `src/types/audit.ts` module — mirroring the wire-protocol shape of the proto messages added in agent-assembly **AAASM-1419 / PR #467** (commit `ed4aa11a8c1d1ce1e6f96b08cf2179fd772099b2`).
- Re-exports all three from the top-level `@agent-assembly/sdk` package via the existing barrel chain (`src/types/index.ts` → `src/index.ts`).

## Scope per Option A (TS-only types module)

| Commit | Scope | Path |
|---|---|---|
| ✨ | `types`: Add `AuditEvent` + `CallStackNode` TS interfaces | `src/types/audit.ts` |
| ✨ | `public-api`: Re-export from top level | `src/types/index.ts` + `src/index.ts` |
| ✅ | `types`: Vitest unit tests | `tests/types/audit.test.ts` (7 tests) |

### Why Option A (no Rust / napi-rs work)

The `native/aa-ffi-node` crate is **standalone today** — it does not depend on `aa-proto` or any prost-bound types. There are no prost bindings to regenerate, and adding `aa-proto` as a new Rust dep would introduce architectural coupling that node-sdk has deliberately avoided. The ticket's "regenerate napi-rs bindings" phrasing doesn't quite match the repo — the actual user-visible promise is *surface `AuditEvent.callStack` to TS consumers*, which is what Option A delivers via handwritten TypeScript interfaces (the same source-of-truth pattern used today for `GatewayCheckRequest`, `GatewayDecision`, etc.).

### How the "pin to AAASM-1419 revision" DoD is satisfied

A header comment in `src/types/audit.ts` cites agent-assembly commit `ed4aa11a8c1d1ce1e6f96b08cf2179fd772099b2` as the wire-shape source-of-truth. No Cargo pin to bump since the native crate doesn't depend on `aa-proto`.

`AuditEvent` is a focused subset of the proto — scalar identifying fields (`eventId`, `agentId`, `actionType`, `decision`, tracing IDs, `labels`) + the new `callStack`. The proto's `detail` oneof and full lineage block are intentionally out of scope; they'll be filed as separate follow-up Tasks if a Node consumer needs them.

`CallStackNode` matches the proto verbatim, with camelCase TS naming (`latencyMs` ↔ wire `latency_ms`); `kind` is typed as `"llm" | "tool" | "result"` to match the dashboard's existing renderer.

## Verification

- `pnpm test --run` — **126 passed**, 2 skipped, 0 failed
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm native:build` — succeeds (untouched by this PR but verified per DoD)

## DoD check

| | |
|---|---|
| Regenerated bindings pinned to AAASM-1419 revision | ✅ Header comment in `src/types/audit.ts` cites `ed4aa11a8c1d1ce1e6f96b08cf2179fd772099b2`. No Cargo pin to bump (native crate has no `aa-proto` dep). |
| `CallStackNode` exported from `@agent-assembly/sdk` | ✅ — also exports `AuditEvent` + `CallStackNodeKind` |
| `pnpm test` green | ✅ |
| `pnpm typecheck` clean | ✅ |
| `pnpm native:build` succeeds | ✅ |

## Follow-up

A wire round-trip test (the second half of ticket scope item #4) requires bridging the TS interface into a serializer that node-sdk's gateway client can consume — same architectural gap as AAASM-1442 covers for python-sdk. Worth filing analogously if/when a consumer needs producer-side construction; the dataclass / interface surface today is consumer-side-friendly (receive event → expose as typed object).

🤖 Generated with [Claude Code](https://claude.com/claude-code)