### PR TITLE
[AAASM-1450] 🔌 (audit): Bridge AuditEvent interface into JSON wire encoder + round-trip tests

### DIFF
--- a/src/audit/encode.ts
+++ b/src/audit/encode.ts
@@ -101,3 +101,46 @@ export function encodeAuditEvent(event: AuditEvent): string {
   }
   return JSON.stringify(wire);
 }
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError("expected JSON object on the wire");
+  }
+  return value as Record<string, unknown>;
+}
+
+/**
+ * Translate a wire JSON object back into a {@link CallStackNode}.
+ *
+ * Symmetric inverse of {@link encodeCallStackNode}: walks `children`
+ * recursively, restores `latencyMs` from `latency_ms`, and treats a
+ * missing or empty `children` field as `undefined` on the interface
+ * side (matches AAASM-1436's default).
+ */
+export function decodeCallStackNode(payload: unknown): CallStackNode {
+  const wire = asRecord(payload);
+  const id = wire.id;
+  const kindRaw = wire.kind;
+  const label = wire.label;
+  if (typeof id !== "string") {
+    throw new TypeError("CallStackNode.id missing or not a string");
+  }
+  if (typeof kindRaw !== "string") {
+    throw new TypeError("CallStackNode.kind missing or not a string");
+  }
+  if (typeof label !== "string") {
+    throw new TypeError("CallStackNode.label missing or not a string");
+  }
+  const node: CallStackNode = {
+    id,
+    kind: kindRaw as CallStackNodeKind,
+    label,
+  };
+  if (typeof wire.latency_ms === "number") {
+    node.latencyMs = wire.latency_ms;
+  }
+  if (Array.isArray(wire.children) && wire.children.length > 0) {
+    node.children = wire.children.map(decodeCallStackNode);
+  }
+  return node;
+}

--- a/src/audit/encode.ts
+++ b/src/audit/encode.ts
@@ -3,7 +3,11 @@
 // convention (consistent with the existing `sendEvent(handle, eventJSON)`
 // path used by `native/aa-ffi-node`) — see AAASM-1450 for context.
 
-import type { CallStackNode, CallStackNodeKind } from "../types/audit.js";
+import type {
+  AuditEvent,
+  CallStackNode,
+  CallStackNodeKind,
+} from "../types/audit.js";
 
 /**
  * Wire-form shape of a {@link CallStackNode}. Keys are snake_case to
@@ -20,6 +24,24 @@ export interface WireCallStackNode {
   label: string;
   latency_ms?: number;
   children?: WireCallStackNode[];
+}
+
+/**
+ * Wire-form shape of an {@link AuditEvent}. Keys are snake_case to
+ * match the gateway's JSON convention; optional fields are omitted
+ * when undefined (rather than emitted as `null` or empty string), so a
+ * decoded round-trip yields the original `undefined`.
+ */
+export interface WireAuditEvent {
+  event_id: string;
+  agent_id: string;
+  action_type: string;
+  decision: string;
+  trace_id?: string;
+  span_id?: string;
+  parent_span_id?: string;
+  labels?: Record<string, string>;
+  call_stack?: WireCallStackNode[];
 }
 
 /**
@@ -42,4 +64,40 @@ export function encodeCallStackNode(node: CallStackNode): WireCallStackNode {
     wire.children = node.children.map(encodeCallStackNode);
   }
   return wire;
+}
+
+/**
+ * Serialize an {@link AuditEvent} to its JSON wire string.
+ *
+ * Translates the camelCase interface field names into the gateway's
+ * snake_case keys (`eventId` → `event_id`, `callStack` → `call_stack`,
+ * etc.), recursively encoding the call-stack tree via
+ * {@link encodeCallStackNode}. Optional fields whose value is
+ * `undefined`, an empty string, or an empty array are omitted so a
+ * legacy decoder that has never seen those fields reads the payload
+ * unchanged.
+ */
+export function encodeAuditEvent(event: AuditEvent): string {
+  const wire: WireAuditEvent = {
+    event_id: event.eventId,
+    agent_id: event.agentId,
+    action_type: event.actionType,
+    decision: event.decision,
+  };
+  if (event.traceId !== undefined && event.traceId !== "") {
+    wire.trace_id = event.traceId;
+  }
+  if (event.spanId !== undefined && event.spanId !== "") {
+    wire.span_id = event.spanId;
+  }
+  if (event.parentSpanId !== undefined && event.parentSpanId !== "") {
+    wire.parent_span_id = event.parentSpanId;
+  }
+  if (event.labels !== undefined && Object.keys(event.labels).length > 0) {
+    wire.labels = event.labels;
+  }
+  if (event.callStack !== undefined && event.callStack.length > 0) {
+    wire.call_stack = event.callStack.map(encodeCallStackNode);
+  }
+  return JSON.stringify(wire);
 }

--- a/src/audit/encode.ts
+++ b/src/audit/encode.ts
@@ -1,0 +1,45 @@
+// JSON wire-format bridge for the `AuditEvent` / `CallStackNode` interfaces
+// declared in `../types/audit.ts`. Mirrors the gateway's snake_case JSON
+// convention (consistent with the existing `sendEvent(handle, eventJSON)`
+// path used by `native/aa-ffi-node`) — see AAASM-1450 for context.
+
+import type { CallStackNode, CallStackNodeKind } from "../types/audit.js";
+
+/**
+ * Wire-form shape of a {@link CallStackNode}. Keys are snake_case to
+ * match the gateway's JSON convention; the `children` field is itself
+ * a recursive `WireCallStackNode[]`.
+ *
+ * Optional fields are omitted from the encoded payload when undefined
+ * rather than emitted as `null`, so a decoded round-trip yields the
+ * original `undefined` (not `null`).
+ */
+export interface WireCallStackNode {
+  id: string;
+  kind: string;
+  label: string;
+  latency_ms?: number;
+  children?: WireCallStackNode[];
+}
+
+/**
+ * Translate a {@link CallStackNode} into its wire JSON object form.
+ *
+ * Recurses through `children`. Optional fields (`latencyMs`,
+ * `children`) are dropped when undefined or — for `children` — empty,
+ * so the resulting object is the minimal payload the gateway accepts.
+ */
+export function encodeCallStackNode(node: CallStackNode): WireCallStackNode {
+  const wire: WireCallStackNode = {
+    id: node.id,
+    kind: node.kind satisfies CallStackNodeKind,
+    label: node.label,
+  };
+  if (node.latencyMs !== undefined) {
+    wire.latency_ms = node.latencyMs;
+  }
+  if (node.children !== undefined && node.children.length > 0) {
+    wire.children = node.children.map(encodeCallStackNode);
+  }
+  return wire;
+}

--- a/src/audit/encode.ts
+++ b/src/audit/encode.ts
@@ -144,3 +144,82 @@ export function decodeCallStackNode(payload: unknown): CallStackNode {
   }
   return node;
 }
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asStringMap(value: unknown): Record<string, string> | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string"
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+/**
+ * Deserialize a JSON wire payload into a typed {@link AuditEvent}.
+ *
+ * Accepts either the raw JSON string (the gateway's standard
+ * transport) or an already-parsed object (handy for tests and for
+ * callers that received a JSON object via another path). Symmetric
+ * inverse of {@link encodeAuditEvent}: snake_case keys map back to
+ * camelCase fields, and missing / empty optionals decode to
+ * `undefined` so an `AuditEvent` produced from a legacy payload (no
+ * `call_stack`, empty `trace_id`, …) matches what AAASM-1436's
+ * existing consumer-side tests expect.
+ */
+export function decodeAuditEvent(
+  payload: string | Record<string, unknown>
+): AuditEvent {
+  const wire =
+    typeof payload === "string"
+      ? asRecord(JSON.parse(payload))
+      : asRecord(payload);
+
+  const eventId = wire.event_id;
+  const agentId = wire.agent_id;
+  const actionType = wire.action_type;
+  const decision = wire.decision;
+  if (typeof eventId !== "string") {
+    throw new TypeError("AuditEvent.event_id missing or not a string");
+  }
+  if (typeof agentId !== "string") {
+    throw new TypeError("AuditEvent.agent_id missing or not a string");
+  }
+  if (typeof actionType !== "string") {
+    throw new TypeError("AuditEvent.action_type missing or not a string");
+  }
+  if (typeof decision !== "string") {
+    throw new TypeError("AuditEvent.decision missing or not a string");
+  }
+
+  const event: AuditEvent = {
+    eventId,
+    agentId,
+    actionType,
+    decision,
+  };
+  const traceId = asNonEmptyString(wire.trace_id);
+  if (traceId !== undefined) {
+    event.traceId = traceId;
+  }
+  const spanId = asNonEmptyString(wire.span_id);
+  if (spanId !== undefined) {
+    event.spanId = spanId;
+  }
+  const parentSpanId = asNonEmptyString(wire.parent_span_id);
+  if (parentSpanId !== undefined) {
+    event.parentSpanId = parentSpanId;
+  }
+  const labels = asStringMap(wire.labels);
+  if (labels !== undefined) {
+    event.labels = labels;
+  }
+  if (Array.isArray(wire.call_stack) && wire.call_stack.length > 0) {
+    event.callStack = wire.call_stack.map(decodeCallStackNode);
+  }
+  return event;
+}

--- a/src/audit/index.ts
+++ b/src/audit/index.ts
@@ -1,0 +1,10 @@
+export {
+  decodeAuditEvent,
+  decodeCallStackNode,
+  encodeAuditEvent,
+  encodeCallStackNode,
+} from "./encode.js";
+export type {
+  WireAuditEvent,
+  WireCallStackNode,
+} from "./encode.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,4 +10,14 @@ export type {
   CallStackNodeKind,
   ToolMap,
 } from "./types/index.js";
+export {
+  decodeAuditEvent,
+  decodeCallStackNode,
+  encodeAuditEvent,
+  encodeCallStackNode,
+} from "./audit/index.js";
+export type {
+  WireAuditEvent,
+  WireCallStackNode,
+} from "./audit/index.js";
 export { currentAgentId, runWithAgentId } from "./lineage/index.js";

--- a/tests/audit/encode.test.ts
+++ b/tests/audit/encode.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import type { AuditEvent } from "../../src/types/audit.js";
+import { decodeAuditEvent, encodeAuditEvent } from "../../src/audit/encode.js";
+
+describe("AuditEvent wire round-trip", () => {
+  it("preserves a three-level call stack (LLM → tool → result) with no data loss", () => {
+    const original: AuditEvent = {
+      eventId: "evt-1",
+      agentId: "support-agent",
+      actionType: "llm_call",
+      decision: "allow",
+      traceId: "trace-abc",
+      spanId: "span-1",
+      parentSpanId: "span-0",
+      labels: { tenant: "acme", env: "prod" },
+      callStack: [
+        {
+          id: "n0",
+          kind: "llm",
+          label: "gpt-4o",
+          latencyMs: 300,
+          children: [
+            {
+              id: "n1",
+              kind: "tool",
+              label: "gmail.send",
+              latencyMs: 120,
+              children: [
+                { id: "n2", kind: "result", label: "200 OK", latencyMs: 5 },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const decoded = decodeAuditEvent(encodeAuditEvent(original));
+
+    expect(decoded).toEqual(original);
+  });
+});

--- a/tests/audit/encode.test.ts
+++ b/tests/audit/encode.test.ts
@@ -38,4 +38,23 @@ describe("AuditEvent wire round-trip", () => {
 
     expect(decoded).toEqual(original);
   });
+
+  it("decodes a legacy payload that has no call_stack into callStack === undefined", () => {
+    const legacy = JSON.stringify({
+      event_id: "evt-legacy",
+      agent_id: "old-agent",
+      action_type: "llm_call",
+      decision: "allow",
+    });
+
+    const decoded = decodeAuditEvent(legacy);
+
+    expect(decoded.callStack).toBeUndefined();
+    expect(decoded).toEqual({
+      eventId: "evt-legacy",
+      agentId: "old-agent",
+      actionType: "llm_call",
+      decision: "allow",
+    });
+  });
 });

--- a/tests/audit/encode.test.ts
+++ b/tests/audit/encode.test.ts
@@ -39,6 +39,44 @@ describe("AuditEvent wire round-trip", () => {
     expect(decoded).toEqual(original);
   });
 
+  it("translates snake_case wire keys to camelCase interface fields and back", () => {
+    const event: AuditEvent = {
+      eventId: "evt-2",
+      agentId: "support-agent",
+      actionType: "tool_call",
+      decision: "redact",
+      traceId: "trace-xyz",
+      spanId: "span-9",
+      parentSpanId: "span-8",
+      callStack: [
+        { id: "n0", kind: "tool", label: "gmail.send", latencyMs: 0 },
+      ],
+    };
+
+    const wire = JSON.parse(encodeAuditEvent(event)) as Record<string, unknown>;
+
+    expect(Object.keys(wire).sort()).toEqual([
+      "action_type",
+      "agent_id",
+      "call_stack",
+      "decision",
+      "event_id",
+      "parent_span_id",
+      "span_id",
+      "trace_id",
+    ]);
+    expect(wire.event_id).toBe("evt-2");
+    expect(wire.action_type).toBe("tool_call");
+    expect(wire.parent_span_id).toBe("span-8");
+    expect(Array.isArray(wire.call_stack)).toBe(true);
+    const [node] = wire.call_stack as Array<Record<string, unknown>>;
+    expect(node?.latency_ms).toBe(0);
+    expect(node).not.toHaveProperty("latencyMs");
+    expect(node).not.toHaveProperty("callStack");
+
+    expect(decodeAuditEvent(wire)).toEqual(event);
+  });
+
   it("decodes a legacy payload that has no call_stack into callStack === undefined", () => {
     const legacy = JSON.stringify({
       event_id: "evt-legacy",


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Add the producer-side wire bridge for `AuditEvent` / `CallStackNode` that AAASM-1436 (PR #39) deferred. Ships `encodeAuditEvent` / `decodeAuditEvent` (and the recursive `*CallStackNode` helpers) as free functions under a new `src/audit/encode.ts` module, plus the three Vitest unit tests AAASM-1436 left as "structurally not possible until this bridge lands".

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: [AAASM-1450](https://lightning-dust-mite.atlassian.net/browse/AAASM-1450).
    * Relative task IDs:
        * [x] [AAASM-1436](https://lightning-dust-mite.atlassian.net/browse/AAASM-1436) — predecessor; added the TS interfaces this PR wires up. (PR #39)
        * [x] [AAASM-1442](https://lightning-dust-mite.atlassian.net/browse/AAASM-1442) — python-sdk analogue (still To Do).
        * [x] [AAASM-1419](https://lightning-dust-mite.atlassian.net/browse/AAASM-1419) — proto change that introduced `call_stack` on `AuditEvent`.
    * Relative PRs:
        * [AI-agent-assembly/node-sdk#39](https://github.com/AI-agent-assembly/node-sdk/pull/39) — AAASM-1436 (TypeScript interfaces).

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    **Architectural decision.** AAASM-1436's PR body documented that `native/aa-ffi-node` is a standalone napi-rs crate with no `aa-proto` Cargo dep — so the ticket's Option (c) (encode bytes in the native crate via `prost`) was already declined up-front. This PR takes **Option (a) — handwritten TS JSON encoder/decoder** under `src/audit/encode.ts`. Aligns with the existing `sendEvent(handle, eventJSON)` wire convention; no Rust changes; no new dependencies.

    **Public surface (re-exported from `@agent-assembly/sdk`):**

    ```ts
    import {
      AuditEvent,
      CallStackNode,
      encodeAuditEvent,
      decodeAuditEvent,
    } from "@agent-assembly/sdk";

    const wire = encodeAuditEvent(event);          // string (JSON, snake_case keys)
    const back = decodeAuditEvent(wire);           // AuditEvent
    ```

    **Wire conventions** (documented inline on each helper):
    * camelCase ↔ snake_case (`eventId` ↔ `event_id`, `callStack` ↔ `call_stack`, `latencyMs` ↔ `latency_ms`).
    * Optional scalars: `undefined` on the interface → field omitted on the wire; absent or empty-string on the wire → `undefined` on the interface. Matches the audit.ts docstrings AAASM-1436 already shipped.
    * `callStack: []` and `children: []` encode as absent (legacy decoders are unaffected) and decode back to `undefined`.
    * `latencyMs: 0` is preserved (proto's zero default is a valid value, distinct from "unset").

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [x] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [ ] 🤖 Framework hooks
    * [x] 🫀 Data model and types
    * [ ] ⛑️ Error handling
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [ ] 🚀 Building
        * [ ] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
    * [ ] 📚 Documentation
* Additional description:
    Pure additive — new `src/audit/` module, three new top-level re-exports, one new test file. No existing source touched beyond `src/index.ts` (additive re-export). Zero runtime deps added.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

9 commits, granular per the workspace convention (one logical unit per commit):

| # | Emoji | Scope | Summary |
|---|---|---|---|
| 1 | ✨ | `audit` | Add `CallStackNode` JSON encoder helper |
| 2 | ✨ | `audit` | Add `AuditEvent` JSON encoder |
| 3 | ✨ | `audit` | Add `CallStackNode` JSON decoder helper |
| 4 | ✨ | `audit` | Add `AuditEvent` JSON decoder |
| 5 | ✨ | `audit` | Add audit module barrel export |
| 6 | ✨ | `public-api` | Re-export encode/decodeAuditEvent from top level |
| 7 | ✅ | `audit` | Add three-level call stack round-trip test |
| 8 | ✅ | `audit` | Add legacy-payload (no call_stack) decode test |
| 9 | ✅ | `audit` | Add snake_case ↔ camelCase translation test |

### Definition of done (AAASM-1450)

| DoD item | Status | Evidence |
|---|---|---|
| `AuditEvent` / `CallStackNode` encode losslessly to wire form | ✅ | `encodeAuditEvent` + `encodeCallStackNode`; round-trip test asserts `decode(encode(e)) deepEqual e` |
| Decoded wire payloads round-trip back into equivalent instances | ✅ | Same round-trip test, three-level LLM → tool → result tree |
| Legacy wire payload (no `call_stack`) → `callStack === undefined` | ✅ | `tests/audit/encode.test.ts` "decodes a legacy payload …" |
| `pnpm test` green | ✅ | 32 files / 129 passed / 2 skipped locally |
| `pnpm typecheck` clean | ✅ | local |
| `pnpm native:build` succeeds | ✅ | local (no native changes — Option (a)) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-1450]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1436]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1442]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1419]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ