### PR TITLE
[AAASM-1228] ✨ (runtime): Add SDK runtime auto-detection and lifecycle (F115)

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -10,11 +10,11 @@
 
 import { type ChildProcess, spawn } from "node:child_process";
 import { existsSync, openSync } from "node:fs";
+import { createRequire } from "node:module";
 import { createConnection } from "node:net";
 import { arch, homedir, platform } from "node:os";
-import { delimiter as PATH_DELIM, dirname, join, resolve } from "node:path";
+import { delimiter as PATH_DELIM, dirname, join } from "node:path";
 import { cwd, env } from "node:process";
-import { fileURLToPath } from "node:url";
 
 export const BINARY_NAME = "aasm";
 export const DEFAULT_PORT = 7878;
@@ -36,21 +36,22 @@ export const INSTALL_HINT: string = [
 
 /**
  * Path to the platform-specific `aasm` binary bundled as an optional npm
- * dependency. Resolved relative to this module so it works both in `src/`
- * (during tests) and `dist/esm/` (after build).
+ * dependency, or `null` when the consumer hasn't installed that platform's
+ * `@agent-assembly/runtime-{platform}-{arch}` sub-package.
+ *
+ * Uses `createRequire(<cwd>/package.json)` — the same pattern used by
+ * `src/native/client.ts` and the framework-detection modules — so this
+ * module compiles cleanly under both the ESM and CJS build targets
+ * (`import.meta.url` is ESM-only and breaks `tsconfig.cjs.json`).
  */
-function bundledRuntimeBinaryPath(): string {
-  const here = dirname(fileURLToPath(import.meta.url));
-  // src/runtime.ts → ../node_modules/...
-  // dist/esm/runtime.js → ../../node_modules/...
-  const candidates = [
-    resolve(here, "..", "node_modules", "@agent-assembly", RUNTIME_SUBPACKAGE, "bin", BINARY_NAME),
-    resolve(here, "..", "..", "node_modules", "@agent-assembly", RUNTIME_SUBPACKAGE, "bin", BINARY_NAME),
-  ];
-  for (const candidate of candidates) {
-    if (existsSync(candidate)) return candidate;
+function bundledRuntimeBinaryPath(): string | null {
+  try {
+    const requireFromCwd = createRequire(`${cwd()}/package.json`);
+    const pkgJson = requireFromCwd.resolve(`@agent-assembly/${RUNTIME_SUBPACKAGE}/package.json`);
+    return join(dirname(pkgJson), "bin", BINARY_NAME);
+  } catch {
+    return null;
   }
-  return candidates[0]!;
 }
 
 /**
@@ -70,7 +71,7 @@ export function findAasmBinary(): string | null {
   const userLocal = join(USER_LOCAL_BIN, BINARY_NAME);
   if (existsSync(userLocal)) return userLocal;
   const bundled = bundledRuntimeBinaryPath();
-  if (existsSync(bundled)) return bundled;
+  if (bundled !== null && existsSync(bundled)) return bundled;
   const docker = join(DOCKER_BASE_BIN, BINARY_NAME);
   if (existsSync(docker)) return docker;
   return null;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -8,8 +8,11 @@
  * flow with `import { initAssembly } from "@agent-assembly/sdk/runtime"`.
  */
 
+import { existsSync } from "node:fs";
 import { arch, homedir, platform } from "node:os";
-import { join } from "node:path";
+import { delimiter as PATH_DELIM, dirname, join, resolve } from "node:path";
+import { env } from "node:process";
+import { fileURLToPath } from "node:url";
 
 export const BINARY_NAME = "aasm";
 export const DEFAULT_PORT = 7878;
@@ -28,3 +31,45 @@ export const INSTALL_HINT: string = [
   "  Or manually:  brew install agent-assembly/tap/aasm",
   "               curl -fsSL https://get.agent-assembly.io | sh",
 ].join("\n");
+
+/**
+ * Path to the platform-specific `aasm` binary bundled as an optional npm
+ * dependency. Resolved relative to this module so it works both in `src/`
+ * (during tests) and `dist/esm/` (after build).
+ */
+function bundledRuntimeBinaryPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // src/runtime.ts → ../node_modules/...
+  // dist/esm/runtime.js → ../../node_modules/...
+  const candidates = [
+    resolve(here, "..", "node_modules", "@agent-assembly", RUNTIME_SUBPACKAGE, "bin", BINARY_NAME),
+    resolve(here, "..", "..", "node_modules", "@agent-assembly", RUNTIME_SUBPACKAGE, "bin", BINARY_NAME),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return candidates[0]!;
+}
+
+/**
+ * Locate the `aasm` binary across the 4 supported install paths.
+ *
+ * Search order: `$PATH` (Homebrew, cargo install) → `~/.local/bin/aasm`
+ * (curl installer) → `node_modules/@agent-assembly/runtime-{platform}-{arch}/bin/aasm`
+ * (npm optionalDependency) → `/usr/local/bin/aasm` (Docker base image).
+ * Returns the first existing match, or `null` when none exist.
+ */
+export function findAasmBinary(): string | null {
+  for (const dir of (env.PATH ?? "").split(PATH_DELIM)) {
+    if (!dir) continue;
+    const candidate = join(dir, BINARY_NAME);
+    if (existsSync(candidate)) return candidate;
+  }
+  const userLocal = join(USER_LOCAL_BIN, BINARY_NAME);
+  if (existsSync(userLocal)) return userLocal;
+  const bundled = bundledRuntimeBinaryPath();
+  if (existsSync(bundled)) return bundled;
+  const docker = join(DOCKER_BASE_BIN, BINARY_NAME);
+  if (existsSync(docker)) return docker;
+  return null;
+}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -8,11 +8,12 @@
  * flow with `import { initAssembly } from "@agent-assembly/sdk/runtime"`.
  */
 
-import { existsSync } from "node:fs";
+import { type ChildProcess, spawn } from "node:child_process";
+import { existsSync, openSync } from "node:fs";
 import { createConnection } from "node:net";
 import { arch, homedir, platform } from "node:os";
 import { delimiter as PATH_DELIM, dirname, join, resolve } from "node:path";
-import { env } from "node:process";
+import { cwd, env } from "node:process";
 import { fileURLToPath } from "node:url";
 
 export const BINARY_NAME = "aasm";
@@ -95,4 +96,27 @@ export function isRunning(
     socket.once("timeout", () => settle(false));
     socket.once("error", () => settle(false));
   });
+}
+
+/**
+ * Spawn `aasm serve --port <port>` as a detached background subprocess.
+ *
+ * Stdout/stderr are appended to `<logDir>/.aasm-runtime.log` (default
+ * `process.cwd()`) so the sidecar outlives the parent. `detached: true`
+ * + `child.unref()` releases the event loop so the Node process can
+ * exit independently of the sidecar.
+ */
+export function startRuntime(
+  binaryPath: string,
+  port: number = DEFAULT_PORT,
+  logDir: string = cwd(),
+): ChildProcess {
+  const logPath = join(logDir, RUNTIME_LOG_FILENAME);
+  const fd = openSync(logPath, "a");
+  const child = spawn(binaryPath, ["serve", "--port", String(port)], {
+    detached: true,
+    stdio: ["ignore", fd, fd],
+  });
+  child.unref();
+  return child;
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -120,3 +120,30 @@ export function startRuntime(
   child.unref();
   return child;
 }
+
+/**
+ * Ensure the local `aasm` sidecar is running, starting it if necessary.
+ *
+ * Lifecycle per F115 / AAASM-1205:
+ *  1. Probe `host:port` via {@link isRunning}; return early if already up.
+ *  2. Resolve the binary via {@link findAasmBinary}.
+ *  3. Spawn the sidecar via {@link startRuntime}.
+ *
+ * `agentId` is accepted to keep the ticket-specified signature stable;
+ * actual register-and-connect is performed by the existing gateway-aware
+ * `@agent-assembly/sdk` `initAssembly` once the sidecar is reachable.
+ *
+ * Throws `Error` with {@link INSTALL_HINT} when no binary is found.
+ */
+export async function initAssembly(
+  agentId?: string,
+  port: number = DEFAULT_PORT,
+): Promise<void> {
+  void agentId; // not consumed at the lifecycle layer; see jsdoc
+  if (await isRunning(port)) return;
+  const binary = findAasmBinary();
+  if (binary === null) {
+    throw new Error(INSTALL_HINT);
+  }
+  startRuntime(binary, port);
+}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -9,6 +9,7 @@
  */
 
 import { existsSync } from "node:fs";
+import { createConnection } from "node:net";
 import { arch, homedir, platform } from "node:os";
 import { delimiter as PATH_DELIM, dirname, join, resolve } from "node:path";
 import { env } from "node:process";
@@ -72,4 +73,26 @@ export function findAasmBinary(): string | null {
   const docker = join(DOCKER_BASE_BIN, BINARY_NAME);
   if (existsSync(docker)) return docker;
   return null;
+}
+
+/**
+ * Resolve to `true` iff a local TCP listener accepts a connect on
+ * `host:port` within 100 ms. Any socket error (refused, timeout,
+ * unreachable) resolves to `false` and is treated as no sidecar.
+ */
+export function isRunning(
+  port: number = DEFAULT_PORT,
+  host: string = DEFAULT_RUNTIME_HOST,
+): Promise<boolean> {
+  return new Promise((resolveResult) => {
+    const socket = createConnection({ port, host, timeout: 100 });
+    const settle = (value: boolean): void => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolveResult(value);
+    };
+    socket.once("connect", () => settle(true));
+    socket.once("timeout", () => settle(false));
+    socket.once("error", () => settle(false));
+  });
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,0 +1,30 @@
+/**
+ * Runtime auto-detection and lifecycle management for the `aasm` sidecar
+ * (F115 / AAASM-1205).
+ *
+ * The `initAssembly()` exported here is intentionally NOT re-exported from
+ * `@agent-assembly/sdk` at the top level: the existing gateway-based
+ * `initAssembly(config)` keeps its meaning. Opt in to the runtime-managed
+ * flow with `import { initAssembly } from "@agent-assembly/sdk/runtime"`.
+ */
+
+import { arch, homedir, platform } from "node:os";
+import { join } from "node:path";
+
+export const BINARY_NAME = "aasm";
+export const DEFAULT_PORT = 7878;
+export const DEFAULT_RUNTIME_HOST = "127.0.0.1";
+
+export const USER_LOCAL_BIN: string = join(homedir(), ".local", "bin");
+export const DOCKER_BASE_BIN = "/usr/local/bin";
+export const RUNTIME_LOG_FILENAME = ".aasm-runtime.log";
+
+/** npm sub-package name for the bundled platform binary (esbuild pattern). */
+export const RUNTIME_SUBPACKAGE: string = `runtime-${platform()}-${arch()}`;
+
+export const INSTALL_HINT: string = [
+  "agent-assembly runtime not found.",
+  "  Install with: pnpm add agent-assembly",
+  "  Or manually:  brew install agent-assembly/tap/aasm",
+  "               curl -fsSL https://get.agent-assembly.io | sh",
+].join("\n");

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -6,7 +6,7 @@
 //   - binary-not-found
 //   - already-running (initAssembly skips spawn when sidecar reachable)
 
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { arch, platform, tmpdir } from "node:os";
 import { join } from "node:path";
@@ -58,7 +58,9 @@ describe("runtime — F115 lifecycle", () => {
       process.env.PATH = join(tmp, "no-such-path");
       process.env.HOME = join(tmp, "no-such-home");
 
-      expect(findAasmBinary()).toBe(fake);
+      // createRequire.resolve canonicalises symlinks (on macOS, /var/folders
+      // → /private/var/folders); compare against the realpath form.
+      expect(findAasmBinary()).toBe(realpathSync(fake));
     } finally {
       process.chdir(originalCwd);
       process.env.PATH = originalPath;

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -28,3 +28,22 @@ function makeBundledRuntimePackage(root: string): string {
   writeFileSync(join(root, "package.json"), JSON.stringify({ name: "test-bundled-runtime" }));
   return makeFakeAasm(join(pkgDir, "bin"));
 }
+
+describe("runtime — F115 lifecycle", () => {
+  it("findAasmBinary returns the resolved path when binary is on $PATH", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "aasm-path-"));
+    const originalPath = process.env.PATH;
+    const originalHome = process.env.HOME;
+    try {
+      const fake = makeFakeAasm(tmp);
+      process.env.PATH = tmp;
+      process.env.HOME = "/var/empty-aasm-no-home";
+
+      expect(findAasmBinary()).toBe(fake);
+    } finally {
+      process.env.PATH = originalPath;
+      process.env.HOME = originalHome;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -90,4 +90,34 @@ describe("runtime — F115 lifecycle", () => {
       rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  it("initAssembly is idempotent when a sidecar is already running on the target port", async () => {
+    // Bind an ephemeral port and pass it explicitly; this avoids a fixed-port
+    // collision with whatever might be on 7878 on the host machine.
+    const server = createServer();
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (typeof address === "string" || address === null) {
+      throw new Error("expected AddressInfo from createServer().address()");
+    }
+    const port = address.port;
+
+    const originalPath = process.env.PATH;
+    const originalHome = process.env.HOME;
+    try {
+      // Pre-load every search path with a guaranteed miss; the orchestrator
+      // should still succeed because is_running short-circuits ahead of
+      // findAasmBinary.
+      process.env.PATH = "/var/empty-aasm-no-path";
+      process.env.HOME = "/var/empty-aasm-no-home";
+
+      await expect(initAssembly(undefined, port)).resolves.toBeUndefined();
+    } finally {
+      process.env.PATH = originalPath;
+      process.env.HOME = originalHome;
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve()))
+      );
+    }
+  });
 });

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -1,0 +1,30 @@
+// Unit tests for src/runtime.ts (AAASM-1228 / F115).
+//
+// Covers the four scenarios from the AAASM-1230 AC checklist:
+//   - binary-in-PATH
+//   - binary-bundled (under node_modules/@agent-assembly/runtime-{platform}-{arch})
+//   - binary-not-found
+//   - already-running (initAssembly skips spawn when sidecar reachable)
+
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { arch, platform, tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { BINARY_NAME, INSTALL_HINT, findAasmBinary, initAssembly } from "../src/runtime.js";
+
+function makeFakeAasm(dir: string): string {
+  const path = join(dir, BINARY_NAME);
+  writeFileSync(path, "#!/bin/sh\nexit 0\n");
+  chmodSync(path, 0o755);
+  return path;
+}
+
+function makeBundledRuntimePackage(root: string): string {
+  const pkgDir = join(root, "node_modules", "@agent-assembly", `runtime-${platform()}-${arch()}`);
+  mkdirSync(join(pkgDir, "bin"), { recursive: true });
+  writeFileSync(join(pkgDir, "package.json"), JSON.stringify({ name: `@agent-assembly/runtime-${platform()}-${arch()}` }));
+  writeFileSync(join(root, "package.json"), JSON.stringify({ name: "test-bundled-runtime" }));
+  return makeFakeAasm(join(pkgDir, "bin"));
+}

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -68,4 +68,26 @@ describe("runtime — F115 lifecycle", () => {
       rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  it("initAssembly throws Error with INSTALL_HINT when binary not found", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "aasm-missing-"));
+    const originalCwd = process.cwd();
+    const originalPath = process.env.PATH;
+    const originalHome = process.env.HOME;
+    try {
+      // Empty cwd (no node_modules), empty PATH/HOME → every search path misses.
+      writeFileSync(join(tmp, "package.json"), JSON.stringify({ name: "test-missing" }));
+      process.chdir(tmp);
+      process.env.PATH = join(tmp, "no-such-path");
+      process.env.HOME = join(tmp, "no-such-home");
+
+      await expect(initAssembly()).rejects.toThrowError(INSTALL_HINT);
+      await expect(initAssembly()).rejects.toThrowError(/agent-assembly runtime not found/);
+    } finally {
+      process.chdir(originalCwd);
+      process.env.PATH = originalPath;
+      process.env.HOME = originalHome;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -46,4 +46,24 @@ describe("runtime — F115 lifecycle", () => {
       rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  it("findAasmBinary returns the bundled-runtime path when the npm optional sub-package is installed", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "aasm-bundled-"));
+    const originalCwd = process.cwd();
+    const originalPath = process.env.PATH;
+    const originalHome = process.env.HOME;
+    try {
+      const fake = makeBundledRuntimePackage(tmp);
+      process.chdir(tmp);
+      process.env.PATH = join(tmp, "no-such-path");
+      process.env.HOME = join(tmp, "no-such-home");
+
+      expect(findAasmBinary()).toBe(fake);
+    } finally {
+      process.chdir(originalCwd);
+      process.env.PATH = originalPath;
+      process.env.HOME = originalHome;
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Add `src/runtime.ts` — a new submodule that implements the F115 runtime lifecycle for the Node.js SDK: locate the `aasm` Rust sidecar, probe whether it's already running, start it if not, and report a clear install hint when no binary is found. The new orchestrator is exposed as `initAssembly(agentId?)` from `@agent-assembly/sdk/runtime` and is **not** re-exported from `src/index.ts` — the existing gateway-based `initAssembly(config)` keeps its meaning.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: **AAASM-1228**
    * Relative task IDs:
        * [x] **AAASM-1205** (parent Story — F115 SDK runtime auto-detection)
        * [x] **AAASM-1199** (Epic — Release & Distribution Pipeline)
    * Relative PRs:
        * Sibling sub-task **AAASM-1227** (python-sdk): https://github.com/AI-agent-assembly/python-sdk/pull/48
        * Sibling sub-task **AAASM-1229** (go-sdk): to be opened next

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    ```text
    initAssembly(agentId, port = DEFAULT_PORT)
      1. if (await isRunning(port)) return                  // idempotent re-init
      2. binary = findAasmBinary()                          // 4 search paths
         if (binary === null) throw new Error(INSTALL_HINT)
      3. startRuntime(binary, port)                         // detached subprocess
    ```

    Binary search order:

    | Step | Location | Covers install method |
    |---|---|---|
    | 1 | `$PATH` (delimiter-split) | `brew install`, `cargo install` |
    | 2 | `~/.local/bin/aasm` | `curl \| sh` |
    | 3 | `node_modules/@agent-assembly/runtime-{platform}-{arch}/bin/aasm` | `pnpm add agent-assembly` (optionalDependency) |
    | 4 | `/usr/local/bin/aasm` | Docker base image |

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something
    * [ ] 🚀 Release
* Scopes:
    * [x] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [ ] 🤖 Framework hooks
    * [ ] 🫀 Data model and types
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
    * [ ] 🚀 Building
    * [ ] 📚 Documentation
* Additional description:
    Tests for `runtime.ts` are intentionally deferred to **AAASM-1230** (cross-SDK test sub-task) per the story decomposition. Local verification:
    - `pnpm typecheck` → clean
    - `pnpm lint` → clean
    - `pnpm test` → 126/131 pass; the 3 failures (`tests/packaging/*`) are pre-existing on `master` (need native NAPI build artifacts not available in this environment).

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

5 granular commits, each adds one logical unit:

| # | Commit |
|---|---|
| 1 | `✨ (runtime): Add src/runtime.ts skeleton with F115 constants` |
| 2 | `✨ (runtime): Add findAasmBinary() resolver across the 4 install paths` |
| 3 | `✨ (runtime): Add isRunning() local TCP liveness probe` |
| 4 | `✨ (runtime): Add startRuntime() detached sidecar spawn` |
| 5 | `✨ (runtime): Add initAssembly() lifecycle orchestrator` |