### PR TITLE
[AAASM-1221] ✨ (api): Wire runtime-* optionalDependencies + SDK entrypoint re-export

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -37,7 +37,14 @@ jobs:
         run: pnpm install --no-frozen-lockfile
 
       - name: Install website dependencies
-        run: pnpm install --no-frozen-lockfile
+        # `--ignore-workspace` tells pnpm to skip the parent
+        # `pnpm-workspace.yaml` (added under AAASM-1220) when installing
+        # in `website/`. Without this flag, pnpm 10 inherits the parent
+        # workspace context, sees website/ isn't a listed workspace
+        # member, and produces no website/node_modules — so the
+        # follow-up `pnpm build` then fails with `docusaurus: not found`.
+        # See AAASM-1221 / PR #43 CI diagnosis.
+        run: pnpm install --no-frozen-lockfile --ignore-workspace
         working-directory: website
 
       - name: Build Docusaurus site

--- a/package.json
+++ b/package.json
@@ -73,7 +73,11 @@
     "@agent-assembly/linux-x64-gnu": "0.0.0",
     "@agent-assembly/darwin-x64": "0.0.0",
     "@agent-assembly/darwin-arm64": "0.0.0",
-    "@agent-assembly/win32-x64-msvc": "0.0.0"
+    "@agent-assembly/win32-x64-msvc": "0.0.0",
+    "@agent-assembly/runtime-linux-x64": "0.0.0",
+    "@agent-assembly/runtime-linux-arm64": "0.0.0",
+    "@agent-assembly/runtime-darwin-x64": "0.0.0",
+    "@agent-assembly/runtime-darwin-arm64": "0.0.0"
   },
   "files": [
     "dist/",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,3 +21,9 @@ export type {
   WireCallStackNode,
 } from "./audit/index.js";
 export { currentAgentId, runWithAgentId } from "./lineage/index.js";
+// Runtime binary resolution helpers (F113 / AAASM-1221). Re-export the
+// discovery + error-message surfaces from src/runtime.ts; the lifecycle
+// `initAssembly` from runtime.ts intentionally stays scoped to the
+// `@agent-assembly/sdk/runtime` subpath export to avoid colliding with
+// the gateway-based `initAssembly` re-exported above.
+export { INSTALL_HINT, findAasmBinary } from "./runtime.js";

--- a/tests/runtime-entrypoint-export.test.ts
+++ b/tests/runtime-entrypoint-export.test.ts
@@ -1,0 +1,23 @@
+// AAASM-1221: the runtime binary resolution helpers must be reachable
+// from the SDK's top-level entrypoint, not just from `src/runtime.ts`
+// or the `@agent-assembly/sdk/runtime` subpath. Consumers should be
+// able to discover the `aasm` binary location without having to know
+// the runtime-helpers ship in a sub-module.
+import { describe, expect, it } from "vitest";
+
+import { INSTALL_HINT, findAasmBinary } from "../src/index.js";
+
+describe("SDK entrypoint — runtime helpers re-export (AAASM-1221)", () => {
+  it("re-exports findAasmBinary as a callable function", () => {
+    expect(typeof findAasmBinary).toBe("function");
+    // The function returns either a string path or null depending on
+    // the host machine; assert the union without asserting the value.
+    const result = findAasmBinary();
+    expect(result === null || typeof result === "string").toBe(true);
+  });
+
+  it("re-exports INSTALL_HINT as the canonical not-found error message", () => {
+    expect(typeof INSTALL_HINT).toBe("string");
+    expect(INSTALL_HINT).toContain("agent-assembly runtime not found");
+  });
+});


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Complete the AAASM-1203 (F113) wiring: add the 4 `@agent-assembly/runtime-{platform}` packages (scaffolded under AAASM-1220) to `@agent-assembly/sdk`'s `optionalDependencies`, and re-export the existing `findAasmBinary` + `INSTALL_HINT` helpers (shipped under AAASM-1228 / F115) from the top-level SDK entrypoint so consumers can discover the `aasm` binary without having to import from the `@agent-assembly/sdk/runtime` subpath.

* ### Task tickets:

    * Task ID: [AAASM-1221](https://lightning-dust-mite.atlassian.net/browse/AAASM-1221)
    * Relative task IDs:
        * [x] [AAASM-1220](https://lightning-dust-mite.atlassian.net/browse/AAASM-1220) (prerequisite — scaffolded the 4 runtime sub-packages)
        * [x] [AAASM-1228](https://lightning-dust-mite.atlassian.net/browse/AAASM-1228) (prerequisite — shipped `src/runtime.ts` + `findAasmBinary` + `INSTALL_HINT`)
        * [ ] [AAASM-1222](https://lightning-dust-mite.atlassian.net/browse/AAASM-1222) (next — pnpm publish workflow for all 5 npm packages on release tag)
        * [ ] [AAASM-1223](https://lightning-dust-mite.atlassian.net/browse/AAASM-1223) (final — verify F113 acceptance)
        * [ ] [AAASM-1203](https://lightning-dust-mite.atlassian.net/browse/AAASM-1203) (parent Story)
    * Relative PRs:
        * #42 (AAASM-1220 — scaffolds the runtime sub-packages this PR depends on)

* ### Key point change (optional):

    **Scope deviation from the ticket text** — the ticket says "Implement src/runtime.ts with findBinary()". The function already exists as `findAasmBinary` (shipped under AAASM-1228); this PR does NOT rename or re-implement. Instead it wires the existing implementation into the top-level entrypoint, which closes the same intent (consumers can call `findBinary`-equivalent from the SDK root). The `findAasmBinary` name is preserved because (a) renaming would break AAASM-1228's tests + downstream callers and (b) the more specific name communicates intent better than the generic `findBinary`.

    The runtime-lifecycle `initAssembly` from `src/runtime.ts` is intentionally NOT re-exported here — it would collide with the gateway-based `initAssembly` already exported from `src/core/init-assembly.ts`. Callers who want the lifecycle flow use `import { initAssembly } from "@agent-assembly/sdk/runtime"`. (Documented in inline comments on both files.)

## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change

* Scopes:
    * [x] 🧩 SDK public API (2 new top-level exports: `findAasmBinary`, `INSTALL_HINT`)
    * [x] 🚀 Building
        * [x] 🔗 Dependencies (4 new `optionalDependencies`)
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing (new `tests/runtime-entrypoint-export.test.ts`)

* Additional description:
    No behaviour change to the existing `findAasmBinary` implementation — only the surface area expands.

## _Description_

* 3 granular commits:
    * `🔗 (deps): Add 4 @agent-assembly/runtime-{platform} packages to optionalDependencies`
    * `✨ (api): Re-export findAasmBinary + INSTALL_HINT from SDK entrypoint`
    * `✅ (test): Add SDK-entrypoint runtime helpers re-export test`
* Local pre-push validation (all green):
    * `pnpm install` — no lockfile change (the runtime-* packages were already registered as workspace entries under AAASM-1220)
    * `pnpm typecheck` — clean
    * `pnpm lint` — clean
    * `pnpm test` — 135 passed, 2 skipped (137 total); includes the 2 new entrypoint-export tests

[AAASM-1221]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1220]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1228]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1222]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1223]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ