### PR TITLE
[AAASM-1561] ✨ (sdk): Add enforcementMode parameter to initAssembly

### DIFF
--- a/src/core/init-assembly.ts
+++ b/src/core/init-assembly.ts
@@ -9,6 +9,7 @@ import { createNoopGatewayClient, type GatewayClient } from "../gateway/client.j
 import { createNativeClient, type NativeClient } from "../native/client.js";
 import type { AssemblyConfig } from "../types/assembly-config.js";
 import type { AssemblyContext } from "../types/assembly-context.js";
+import { ENFORCEMENT_MODES } from "../types/enforcement-mode.js";
 import type {
   LangChainCallbackHandlerLike,
   LangChainToolLike
@@ -32,6 +33,11 @@ function buildRegistrationEvent(config: AssemblyConfig): Record<string, string> 
   if (config.teamId !== undefined) event.team_id = config.teamId;
   if (config.delegationReason !== undefined) event.delegation_reason = config.delegationReason;
   if (config.spawnedByTool !== undefined) event.spawned_by_tool = config.spawnedByTool;
+  // AAASM-1561: per-agent enforcement_mode override. Sent only when the
+  // caller set it explicitly so a pre-feature SDK call produces a pre-feature
+  // wire shape. The gateway's REST → gRPC bridge maps the snake_case token
+  // onto RegisterRequest.enforcement_mode (proto enum) per AAASM-1555.
+  if (config.enforcementMode !== undefined) event.enforcement_mode = config.enforcementMode;
   return event;
 }
 
@@ -205,6 +211,14 @@ export async function initAssembly(config: AssemblyConfig = {}): Promise<Assembl
   if (config.delegationReason !== undefined && config.delegationReason.length > 256) {
     throw new RangeError("delegationReason must be <= 256 characters");
   }
+  // AAASM-1561: catch invalid enforcementMode strings from non-TS callers
+  // (plain JS, JSON config, dynamic input) so the agent doesn't silently
+  // register under live enforcement when the operator meant observe.
+  if (config.enforcementMode !== undefined && !ENFORCEMENT_MODES.includes(config.enforcementMode)) {
+    throw new RangeError(
+      `enforcementMode must be one of: ${ENFORCEMENT_MODES.join(", ")} (got: ${String(config.enforcementMode)})`
+    );
+  }
   // Auto-populate parentAgentId from the async context store when not explicitly provided.
   // This allows child agents spawned inside framework hooks to inherit lineage automatically.
   const resolvedParentAgentId = config.parentAgentId ?? currentAgentId();
@@ -258,6 +272,7 @@ export async function initAssembly(config: AssemblyConfig = {}): Promise<Assembl
     ...(resolvedConfig.teamId !== undefined && { teamId: resolvedConfig.teamId }),
     ...(resolvedConfig.delegationReason !== undefined && { delegationReason: resolvedConfig.delegationReason }),
     ...(resolvedConfig.spawnedByTool !== undefined && { spawnedByTool: resolvedConfig.spawnedByTool }),
+    ...(resolvedConfig.enforcementMode !== undefined && { enforcementMode: resolvedConfig.enforcementMode }),
     shutdown: async () => {
       for (const adapter of adapters) {
         await adapter.shutdown?.();

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,18 +8,17 @@ export type {
   AuditEvent,
   CallStackNode,
   CallStackNodeKind,
-  ToolMap,
+  EnforcementMode,
+  ToolMap
 } from "./types/index.js";
+export { ENFORCEMENT_MODES } from "./types/index.js";
 export {
   decodeAuditEvent,
   decodeCallStackNode,
   encodeAuditEvent,
-  encodeCallStackNode,
+  encodeCallStackNode
 } from "./audit/index.js";
-export type {
-  WireAuditEvent,
-  WireCallStackNode,
-} from "./audit/index.js";
+export type { WireAuditEvent, WireCallStackNode } from "./audit/index.js";
 export { currentAgentId, runWithAgentId } from "./lineage/index.js";
 // Runtime binary resolution helpers (F113 / AAASM-1221). Re-export the
 // discovery + error-message surfaces from src/runtime.ts; the lifecycle

--- a/src/types/assembly-config.ts
+++ b/src/types/assembly-config.ts
@@ -1,6 +1,7 @@
 import type { GatewayClient } from "../gateway/client.js";
 import type { LangChainAdapterConfig } from "./langchain-adapter.js";
 import type { AssemblyMode } from "./assembly-mode.js";
+import type { EnforcementMode } from "./enforcement-mode.js";
 
 export interface AssemblyConfig {
   /**
@@ -31,4 +32,16 @@ export interface AssemblyConfig {
   delegationReason?: string;
   /** Name of the tool that spawned this agent, if applicable. */
   spawnedByTool?: string;
+  /**
+   * Per-agent governance posture override sent to the gateway at registration.
+   *
+   * When omitted, the field is left off the registration body and the gateway
+   * applies its server-side default (live `"enforce"`) — the pre-feature wire
+   * shape is preserved. Pass `"observe"` to register this agent in dry-run /
+   * sandbox mode (every action proceeds; the gateway records would-be
+   * violations as shadow audit events surfaced by `aa audit list --dry-run-only`).
+   *
+   * Unknown string values are rejected at runtime with a `RangeError`.
+   */
+  enforcementMode?: EnforcementMode;
 }

--- a/src/types/assembly-context.ts
+++ b/src/types/assembly-context.ts
@@ -1,8 +1,12 @@
+import type { EnforcementMode } from "./enforcement-mode.js";
+
 export interface AssemblyContext {
   readonly activeAdapters: readonly string[];
   readonly parentAgentId?: string;
   readonly teamId?: string;
   readonly delegationReason?: string;
   readonly spawnedByTool?: string;
+  /** Echo of the per-agent governance posture sent at registration, when set. */
+  readonly enforcementMode?: EnforcementMode;
   shutdown: () => Promise<void>;
 }

--- a/src/types/enforcement-mode.ts
+++ b/src/types/enforcement-mode.ts
@@ -1,0 +1,20 @@
+/**
+ * Per-agent governance posture sent to the gateway at registration.
+ *
+ * Mirrors `aa_core::EnforcementMode` on the wire; the snake_case tokens
+ * are what the gateway's REST endpoint expects and what its REST → gRPC
+ * bridge maps onto `RegisterRequest.enforcement_mode` (proto enum).
+ *
+ * - `"enforce"` — default; deny blocks the action, redact strips secrets.
+ * - `"observe"` — dry-run; the gateway records what *would* have happened
+ *   but lets every action through. Surfaced by `aa audit list --dry-run-only`.
+ * - `"disabled"` — policy evaluation skipped entirely. Hermetic test only.
+ */
+export type EnforcementMode = "enforce" | "observe" | "disabled";
+
+/**
+ * Runtime-checkable list of valid {@link EnforcementMode} values, used by
+ * `initAssembly` to reject unknown strings from callers who bypass the
+ * TypeScript type system (plain JS, JSON config, dynamic input).
+ */
+export const ENFORCEMENT_MODES: readonly EnforcementMode[] = ["enforce", "observe", "disabled"] as const;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,8 @@
 export type { AssemblyMode } from "./assembly-mode.js";
 export type { AssemblyConfig } from "./assembly-config.js";
 export type { AssemblyContext } from "./assembly-context.js";
+export type { EnforcementMode } from "./enforcement-mode.js";
+export { ENFORCEMENT_MODES } from "./enforcement-mode.js";
 export type { ToolMap } from "./tool-map.js";
 export type { AuditEvent, CallStackNode, CallStackNodeKind } from "./audit.js";
 export type {

--- a/tests/enforcement-mode.test.ts
+++ b/tests/enforcement-mode.test.ts
@@ -1,0 +1,124 @@
+/**
+ * AAASM-1561 — verifies the enforcementMode parameter on initAssembly:
+ * accepted values flow through, default omits the field, invalid strings
+ * are rejected at runtime.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { initAssembly, type EnforcementMode } from "../src/index.js";
+
+describe("initAssembly enforcementMode parameter", () => {
+  it.each(["enforce", "observe", "disabled"] as const)(
+    "accepts %s and echoes it on the returned context",
+    async (mode) => {
+      const ctx = await initAssembly({
+        gatewayUrl: "https://gateway.example.com",
+        apiKey: "test-key",
+        agentId: `agent-${mode}`,
+        enforcementMode: mode
+      });
+      expect(ctx.enforcementMode).toBe(mode);
+      await ctx.shutdown();
+    }
+  );
+
+  it("defaults to undefined when omitted so the registration body keeps its pre-feature shape", async () => {
+    // The gateway then applies its server-side default of live `enforce` —
+    // semantic behaviour is unchanged for any caller who doesn't opt in.
+    const ctx = await initAssembly({
+      gatewayUrl: "https://gateway.example.com",
+      apiKey: "test-key"
+    });
+    expect(ctx.enforcementMode).toBeUndefined();
+    await ctx.shutdown();
+  });
+
+  it("throws RangeError on an unknown enforcementMode string", async () => {
+    // Catches typos like "obesrve" coming from plain-JS / JSON-config /
+    // dynamic-input callers who bypass the TypeScript union type.
+    await expect(
+      initAssembly({
+        gatewayUrl: "https://gateway.example.com",
+        apiKey: "test-key",
+        // Bypass the type check explicitly to simulate a JS caller.
+        enforcementMode: "obesrve" as unknown as EnforcementMode
+      })
+    ).rejects.toThrow(/enforcementMode must be one of/);
+  });
+
+  it("does not echo enforcementMode when caller didn't set it", async () => {
+    const ctx = await initAssembly({
+      gatewayUrl: "https://gateway.example.com",
+      apiKey: "test-key",
+      // unrelated fields populated; enforcementMode left out
+      teamId: "team-alpha"
+    });
+    expect(ctx.enforcementMode).toBeUndefined();
+    expect(ctx.teamId).toBe("team-alpha");
+    await ctx.shutdown();
+  });
+});
+
+describe("enforcementMode on the registration wire", () => {
+  // Mirrors the helper pattern from tests/topology-registration.test.ts so
+  // the assertion is on the snake_case body actually sent to the gateway.
+  interface MockBinding {
+    connect: ReturnType<typeof vi.fn>;
+    sendEvent: ReturnType<typeof vi.fn>;
+    queryPolicy: ReturnType<typeof vi.fn>;
+    disconnect: ReturnType<typeof vi.fn>;
+  }
+
+  function makeMockBinding(): MockBinding {
+    return {
+      connect: vi.fn(async () => ({ id: "reg-handle" })),
+      sendEvent: vi.fn(() => undefined),
+      queryPolicy: vi.fn(async () => ({ denied: false, pending: false })),
+      disconnect: vi.fn(async () => undefined)
+    };
+  }
+
+  async function loadInitAssemblyWithBinding(binding: MockBinding) {
+    vi.resetModules();
+    vi.doMock("node:module", () => ({
+      createRequire: () => () => binding
+    }));
+    return import("../src/index.js");
+  }
+
+  it("emits enforcement_mode on the registration body when set", async () => {
+    const binding = makeMockBinding();
+    const { initAssembly: init } = await loadInitAssemblyWithBinding(binding);
+
+    const ctx = await init({
+      gatewayUrl: "/tmp/aa.sock",
+      apiKey: "test-key",
+      mode: "napi-inprocess",
+      enforcementMode: "observe"
+    });
+    await ctx.shutdown();
+
+    expect(binding.sendEvent).toHaveBeenCalledWith(expect.any(Object), {
+      event_type: "register",
+      enforcement_mode: "observe"
+    });
+  });
+
+  it("omits enforcement_mode from the registration body by default", async () => {
+    const binding = makeMockBinding();
+    const { initAssembly: init } = await loadInitAssemblyWithBinding(binding);
+
+    const ctx = await init({
+      gatewayUrl: "/tmp/aa.sock",
+      apiKey: "test-key",
+      mode: "napi-inprocess"
+    });
+    await ctx.shutdown();
+
+    const registrationCall = binding.sendEvent.mock.calls.find(
+      ([, event]) => (event as Record<string, string>).event_type === "register"
+    );
+    expect(registrationCall).toBeDefined();
+    const [, event] = registrationCall!;
+    expect(event).not.toHaveProperty("enforcement_mode");
+  });
+});


### PR DESCRIPTION
## Description

Per-agent governance posture override for the Node.js SDK. Mirrors the design that landed in [AAASM-1560 (python-sdk #59)](https://github.com/AI-agent-assembly/python-sdk/pull/59):

```typescript
import { initAssembly } from '@agent-assembly/sdk';

const ctx = await initAssembly({
  gatewayUrl: 'http://localhost:8080',
  apiKey: '...',
  agentId: 'experimental-agent',
  enforcementMode: 'observe',   // NEW
});
// Agent runs under sandbox / dry-run posture; gateway records would-be
// violations as shadow audit events surfaced by `aa audit list --dry-run-only`.
```

### Shipped

| Item | Location |
|---|---|
| `EnforcementMode = 'enforce' \| 'observe' \| 'disabled'` union type | `src/types/enforcement-mode.ts` |
| `ENFORCEMENT_MODES` readonly-array constant for runtime validation | Same file |
| `AssemblyConfig.enforcementMode?: EnforcementMode` (optional) | `src/types/assembly-config.ts` |
| `AssemblyContext.enforcementMode?: EnforcementMode` (echo) | `src/types/assembly-context.ts` |
| `initAssembly` rejects unknown strings with `RangeError` | `src/core/init-assembly.ts` |
| `buildRegistrationEvent` emits `enforcement_mode` (snake_case) when set | Same file |
| `AssemblyContext` echoes the value at return | Same file |
| Public re-exports from package root | `src/types/index.ts` + `src/index.ts` |

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

`AssemblyConfig.enforcementMode` is optional. When omitted, `buildRegistrationEvent` leaves the field off the wire — a pre-feature SDK call produces a pre-feature `event_type: register` body shape, and the gateway then applies its server-side default (live `enforce`). Semantically identical to before. Explicit `'enforce'` / `'observe'` / `'disabled'` from the caller still serialize.

## Related Issues

- Related Jira ticket: [AAASM-1561](https://lightning-dust-mite.atlassian.net/browse/AAASM-1561) (Story [AAASM-1553](https://lightning-dust-mite.atlassian.net/browse/AAASM-1553))
- Depends on (already merged): AAASM-1555 (proto field), AAASM-1557 (gateway registry storage), AAASM-1564 (gateway service-layer wiring)
- Sibling: [python-sdk #59 / AAASM-1560](https://github.com/AI-agent-assembly/python-sdk/pull/59) — merged, sets the design precedent (omit-when-unset → preserves wire shape)

## What's in here

3 commits:

1. ✨ Wire `enforcementMode` end-to-end in `initAssembly` (new type alias + AssemblyConfig + AssemblyContext + validation + buildRegistrationEvent + context echo)
2. ✅ Eight new vitest cases — 3 parametrized + 5 standalone (each-mode-accepted / default-undefined / invalid-rejected / unrelated-field-isolation / body-emits-when-set / body-omits-when-unset)
3. 🔧 Re-export `EnforcementMode` + `ENFORCEMENT_MODES` from package root so callers don't need the `/types` subpath

## Testing

```
pnpm typecheck   # clean
pnpm lint        # clean
pnpm test        # 179 passed, 2 skipped (unchanged from master baseline)
```

## AC checklist

- [x] `initAssembly({ enforcementMode: 'observe' })` passes `enforcement_mode: OBSERVE` in `RegisterAgent` (wire shape verified by `emits enforcement_mode on the registration body when set`)
- [x] `enforcementMode` defaults to `'enforce'` semantically (via gateway server-side default when unset); existing tests pass without changes
- [x] TypeScript type system rejects invalid string values at compile time (union type narrows; runtime fallback covers JS / JSON-config callers via `RangeError`)
- [x] `pnpm typecheck` clean
- [x] Unit tests added (8 covering parser-level, runtime validation, wire-shape)

## Checklist

- [x] Code follows project style guidelines (`pnpm lint`, `pnpm format` — only my changed files committed; pre-existing format drift in 56 unrelated files was deliberately not staged)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (JSDoc on new symbols)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1561]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ