### PR TITLE
[AAASM-1934] 🔖 (sdk): Bump node-sdk packages to 0.0.1-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,10 +76,10 @@
   ],
   "optionalDependencies": {
     "@agent-assembly/darwin-arm64": "0.0.0",
-    "@agent-assembly/runtime-darwin-arm64": "0.0.0",
-    "@agent-assembly/runtime-darwin-x64": "0.0.0",
-    "@agent-assembly/runtime-linux-arm64": "0.0.0",
-    "@agent-assembly/runtime-linux-x64": "0.0.0",
+    "@agent-assembly/runtime-darwin-arm64": "0.0.1-alpha.1",
+    "@agent-assembly/runtime-darwin-x64": "0.0.1-alpha.1",
+    "@agent-assembly/runtime-linux-arm64": "0.0.1-alpha.1",
+    "@agent-assembly/runtime-linux-x64": "0.0.1-alpha.1",
     "@agent-assembly/win32-x64-msvc": "0.0.0"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/sdk",
-  "version": "0.0.0",
+  "version": "0.0.1-alpha.1",
   "description": "TypeScript SDK for Agent Assembly",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/runtime-darwin-arm64/package.json
+++ b/packages/runtime-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/runtime-darwin-arm64",
-  "version": "0.0.0",
+  "version": "0.0.1-alpha.1",
   "description": "AAASM aasm runtime binary for macOS ARM64 (Apple Silicon)",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/runtime-darwin-x64/package.json
+++ b/packages/runtime-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/runtime-darwin-x64",
-  "version": "0.0.0",
+  "version": "0.0.1-alpha.1",
   "description": "AAASM aasm runtime binary for macOS x86_64",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/runtime-linux-arm64/package.json
+++ b/packages/runtime-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/runtime-linux-arm64",
-  "version": "0.0.0",
+  "version": "0.0.1-alpha.1",
   "description": "AAASM aasm runtime binary for Linux ARM64",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/runtime-linux-x64/package.json
+++ b/packages/runtime-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/runtime-linux-x64",
-  "version": "0.0.0",
+  "version": "0.0.1-alpha.1",
   "description": "AAASM aasm runtime binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Bumps all 5 npm-published packages in this repo from `0.0.0` to
    `0.0.1-alpha.1` so a `v0.0.1-alpha.1` git tag can dry-run the npm
    publish pipeline before the v0.0.1 GA bump (AAASM-1244).

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: AAASM-1934 (sub-task of AAASM-1233, under Epic AAASM-1199)
    * Relative task IDs:
        * [x] AAASM-1932 — corresponding Cargo workspace bump (agent-assembly)
        * [x] AAASM-1933 — corresponding PyPI bump (python-sdk)
        * [x] AAASM-1935 — corresponding Go SDK bump
        * [ ] AAASM-1936 — alpha-1 release-pipeline verification (downstream)
        * [ ] AAASM-1244 — GA bump to `0.0.1` (downstream)
    * Relative PRs:
        * agent-assembly#793 (Cargo workspace bump)
        * python-sdk#61 (pyproject + __version__ bump)
        * go-sdk#38 (Version constant)

* ### Key point change:

    | File | Version |
    | --- | --- |
    | `package.json` (root `@agent-assembly/sdk`) | `0.0.0` → `0.0.1-alpha.1` |
    | `package.json` `optionalDependencies.@agent-assembly/runtime-*` (4 pins) | `0.0.0` → `0.0.1-alpha.1` |
    | `packages/runtime-darwin-arm64/package.json` | `0.0.0` → `0.0.1-alpha.1` |
    | `packages/runtime-darwin-x64/package.json` | `0.0.0` → `0.0.1-alpha.1` |
    | `packages/runtime-linux-arm64/package.json` | `0.0.0` → `0.0.1-alpha.1` |
    | `packages/runtime-linux-x64/package.json` | `0.0.0` → `0.0.1-alpha.1` |

    Stale `@agent-assembly/darwin-arm64` and `@agent-assembly/win32-x64-msvc`
    `optionalDependencies` entries are left at `"0.0.0"` — they have no
    matching sub-package in `packages/`, so npm treats them as missing
    optional deps and the install succeeds anyway. Cleaning them up is
    out of scope for the alpha-1 dry-run bump.

[//]: # (What's the scope in project it would affect with your modify?)
## _Effecting Scope_

* Action Types:
    * [ ] ✨ Adding new something
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change (pre-release version, downgrade by SemVer ordering)

* Affected paths:
    * `package.json` (root + `optionalDependencies` pins)
    * `packages/runtime-*/package.json` (all 4 platform sub-packages)

* Smoke-test cross-impact (documented in the sub-task):
  `npm install @agent-assembly/sdk` filters pre-releases by default;
  the F119 `smoke-npm` job in `agent-assembly` needs an explicit
  `@0.0.1-alpha.1` or `@alpha` install during the dry-run. Tracked
  under AAASM-1936.

## Commit breakdown (6 granular commits per project conventions)

1. `🔖 (sdk): Bump @agent-assembly/sdk to 0.0.1-alpha.1`
2. `🔖 (sdk): Bump optionalDependencies runtime-* pins to 0.0.1-alpha.1`
3. `🔖 (runtime-darwin-arm64): Bump version to 0.0.1-alpha.1`
4. `🔖 (runtime-darwin-x64): Bump version to 0.0.1-alpha.1`
5. `🔖 (runtime-linux-arm64): Bump version to 0.0.1-alpha.1`
6. `🔖 (runtime-linux-x64): Bump version to 0.0.1-alpha.1`
