### PR TITLE
[AAASM-2098] 🐛 (npm): Resync pnpm-lock.yaml via workspace: protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,12 +75,10 @@
     "nodejs"
   ],
   "optionalDependencies": {
-    "@agent-assembly/darwin-arm64": "0.0.0",
-    "@agent-assembly/runtime-darwin-arm64": "0.0.1-alpha.1",
-    "@agent-assembly/runtime-darwin-x64": "0.0.1-alpha.1",
-    "@agent-assembly/runtime-linux-arm64": "0.0.1-alpha.1",
-    "@agent-assembly/runtime-linux-x64": "0.0.1-alpha.1",
-    "@agent-assembly/win32-x64-msvc": "0.0.0"
+    "@agent-assembly/runtime-darwin-arm64": "workspace:*",
+    "@agent-assembly/runtime-darwin-x64": "workspace:*",
+    "@agent-assembly/runtime-linux-arm64": "workspace:*",
+    "@agent-assembly/runtime-linux-x64": "workspace:*"
   },
   "files": [
     "dist/",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,19 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@25.9.1)
+    optionalDependencies:
+      '@agent-assembly/runtime-darwin-arm64':
+        specifier: workspace:*
+        version: link:packages/runtime-darwin-arm64
+      '@agent-assembly/runtime-darwin-x64':
+        specifier: workspace:*
+        version: link:packages/runtime-darwin-x64
+      '@agent-assembly/runtime-linux-arm64':
+        specifier: workspace:*
+        version: link:packages/runtime-linux-arm64
+      '@agent-assembly/runtime-linux-x64':
+        specifier: workspace:*
+        version: link:packages/runtime-linux-x64
 
   packages/runtime-darwin-arm64: {}
 


### PR DESCRIPTION
## Description

The v0.0.1-alpha.1 dry-run failed in `release-node.yml` with:

```
specifiers in the lockfile don't match specifiers in package.json:
* 6 dependencies were added: @agent-assembly/darwin-arm64@0.0.0,
  @agent-assembly/runtime-darwin-arm64@0.0.1-alpha.1, ...
```

AAASM-1934 bumped the `optionalDependencies` `runtime-*` pins from `0.0.0` → `0.0.1-alpha.1` but the lockfile wasn't updated to track them. Re-running `pnpm install` does **not** heal the drift because pnpm treats unpublished `optionalDependencies` versions as "failed compatibility check" and silently excludes them — they never land in the lockfile, so `--frozen-lockfile` keeps failing.

## Two distinct repairs (both required to clear the drift)

### 1. Convert the 4 `runtime-*` entries to `workspace:*` protocol

These are workspace members under `packages/runtime-*/`. The `workspace:*` protocol is the canonical pnpm idiom for inter-workspace deps: it resolves via the workspace at install-time and is rewritten to the actual version at publish-time (`pnpm publish` translates it automatically). The hardcoded `0.0.1-alpha.1` was the wrong pattern from the start — it created the drift the moment any version bump happened without a manual lockfile regen.

### 2. Drop the 2 legacy napi-rs platform entries (`@0.0.0`)

- `@agent-assembly/darwin-arm64@0.0.0`
- `@agent-assembly/win32-x64-msvc@0.0.0`

Neither is a workspace member, neither is published to npm, and neither has a build pipeline that produces it. They were left over from the AAASM-1221 napi-rs scaffold and were superseded by the runtime-* matrix in AAASM-1934. Listing them in `optionalDependencies` does nothing useful (npm silently skips unresolvable optional deps) but blocks `--frozen-lockfile`.

**Postinstall test stays green** — `tests/scripts/postinstall.test.ts` tests *string resolution* (`resolveBinaryPackageName("win32", "x64")` → `@agent-assembly/win32-x64-msvc`), not actual package installation. The 7-test suite passes unchanged.

When win32 / additional napi-rs platform support is added in the future, those entries can be re-introduced or replaced by a new `runtime-win32-x64` workspace member.

## Verification

| Command | Before | After |
|---|---|---|
| `pnpm install --frozen-lockfile` | ❌ exit 1, "6 dependencies were added" | ✅ exit 0 |
| `pnpm test --run` (full suite) | n/a | ✅ 179 passed, 0 failed, 2 skipped |
| `pnpm test tests/scripts/postinstall.test.ts --run` | n/a | ✅ 7/7 passed |

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No — `optionalDependencies` semantics for the runtime-* packages are unchanged (they're still optional, still platform-gated). The 2 dropped entries weren't installable anyway.

## Related Issues

- Related Jira ticket: [AAASM-2098](https://lightning-dust-mite.atlassian.net/browse/AAASM-2098)
- Parent Story: [AAASM-1203](https://lightning-dust-mite.atlassian.net/browse/AAASM-1203) — F113: Node.js SDK binary distribution
- Discovery context: v0.0.1-alpha.1 dry-run, release-node.yml run 26483480059

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Commits follow Gitmoji convention

— Claude Code (Opus 4.7, 1M context)

[AAASM-2098]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ