### PR TITLE
[AAASM-2105] 🔧 (npm): Bump root + 4 runtime sub-packages to 0.0.1-alpha.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/sdk",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "description": "TypeScript SDK for Agent Assembly",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/runtime-darwin-arm64/package.json
+++ b/packages/runtime-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/runtime-darwin-arm64",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "description": "AAASM aasm runtime binary for macOS ARM64 (Apple Silicon)",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/runtime-darwin-x64/package.json
+++ b/packages/runtime-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/runtime-darwin-x64",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "description": "AAASM aasm runtime binary for macOS x86_64",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/runtime-linux-arm64/package.json
+++ b/packages/runtime-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/runtime-linux-arm64",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "description": "AAASM aasm runtime binary for Linux ARM64",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/runtime-linux-x64/package.json
+++ b/packages/runtime-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/runtime-linux-x64",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "description": "AAASM aasm runtime binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Description

Bump `node-sdk` from `0.0.1-alpha.1` → `0.0.1-alpha.2` for the cross-repo alpha-2 pre-release dry-run.

## Diff

5 single-line version-field edits in `package.json` files:

- `package.json` (root)
- `packages/runtime-darwin-arm64/package.json`
- `packages/runtime-darwin-x64/package.json`
- `packages/runtime-linux-arm64/package.json`
- `packages/runtime-linux-x64/package.json`

**`pnpm-lock.yaml` unchanged** — this is the AAASM-2098 fix paying off. The `workspace:*` protocol in `optionalDependencies` resolves to local workspace links (`version: link:packages/runtime-*`) which store no version, so workspace bumps don't drift the lockfile.

Compared to the alpha-1 bump (AAASM-1934), this PR is **6 lines smaller and zero lockfile churn**.

## Related Issues

- Jira ticket: [AAASM-2105](https://lightning-dust-mite.atlassian.net/browse/AAASM-2105)
- Parent Story: [AAASM-1234](https://lightning-dust-mite.atlassian.net/browse/AAASM-1234) — F118: Release-trigger
- Epic: [AAASM-1199](https://lightning-dust-mite.atlassian.net/browse/AAASM-1199)

## Testing

- [x] `pnpm install --frozen-lockfile` — exit 0
- [x] `pnpm test --run` — 179 passed, 0 failed, 2 skipped
- [x] `grep -rnE '"version": "0\.0\.1-alpha\.1"' package.json packages/` — 0 hits

— Claude Code (Opus 4.7, 1M context)

[AAASM-2105]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1234]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1199]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ