### PR TITLE
[AAASM-2190] 🐛 (ci): Add --access public to pnpm publish in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,4 +48,4 @@ jobs:
           fi
           echo "Publishing version=$VERSION with dist-tag arg='$DIST_TAG'"
           # shellcheck disable=SC2086
-          pnpm publish --no-git-checks $DIST_TAG
+          pnpm publish --access public --no-git-checks $DIST_TAG


### PR DESCRIPTION
## Description

The v0.0.1-alpha.2 dry-run surfaced this E402 from npm:

```
npm notice Publishing to https://registry.npmjs.org/ with tag alpha and default access
npm error code E402
npm error 402 Payment Required - PUT https://registry.npmjs.org/@agent-assembly%2fsdk
  - You must sign up for private packages.
```

Note the **"with tag alpha"** in the log — that confirms AAASM-2097's derived-dist-tag fix works. The new bug is the missing `--access public`: scoped npm packages (`@agent-assembly/sdk`) default to private on publish.

The sibling `release-node.yml` workflow's publish steps already carry `--access public`. This is the same bug, different file.

## Fix

```diff
- pnpm publish --no-git-checks $DIST_TAG
+ pnpm publish --access public --no-git-checks $DIST_TAG
```

## Local verification

- `pnpm publish --help` confirms `--access <public|restricted>` is a documented flag
- `actionlint .github/workflows/release.yml` clean

## Note on CI

Per maintainer direction, GitHub Actions billing limit is hit — CI won't run on this PR. The fix is verified by inspection + the pnpm CLI docs. Re-running once billing resets is the verification.

## Related Issues

- Jira ticket: [AAASM-2190](https://lightning-dust-mite.atlassian.net/browse/AAASM-2190)
- Parent Story: [AAASM-1203](https://lightning-dust-mite.atlassian.net/browse/AAASM-1203) — F113: Node.js SDK binary distribution

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

— Claude Code (Opus 4.7, 1M context)

[AAASM-2190]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ