### PR TITLE
[AAASM-2314] 🔧 (npm): Bump root + 4 runtime sub-packages to 0.0.1-alpha.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/sdk",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "description": "TypeScript SDK for Agent Assembly",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/runtime-darwin-arm64/package.json
+++ b/packages/runtime-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/runtime-darwin-arm64",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "description": "AAASM aasm runtime binary for macOS ARM64 (Apple Silicon)",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/runtime-darwin-x64/package.json
+++ b/packages/runtime-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/runtime-darwin-x64",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "description": "AAASM aasm runtime binary for macOS x86_64",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/runtime-linux-arm64/package.json
+++ b/packages/runtime-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/runtime-linux-arm64",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "description": "AAASM aasm runtime binary for Linux ARM64",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/runtime-linux-x64/package.json
+++ b/packages/runtime-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/runtime-linux-x64",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "description": "AAASM aasm runtime binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Description

5 single-line version-field edits in package.json (root + 4 runtime-*). `pnpm-lock.yaml` unchanged thanks to AAASM-2098's `workspace:*` resolving to `link:packages/*` with no stored version.

## Related Issues
- Jira: [AAASM-2314](https://lightning-dust-mite.atlassian.net/browse/AAASM-2314)
- Parent: [AAASM-1234](https://lightning-dust-mite.atlassian.net/browse/AAASM-1234)

## Testing
- [x] `pnpm install --frozen-lockfile` exit 0
- [x] 5 `package.json` files now report 0.0.1-alpha.3

— Claude Code (Opus 4.7, 1M context)

[AAASM-2314]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1234]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ