### PR TITLE
[AAASM-2326] 🐛 (npm): Ship scripts/postinstall.mjs in published tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   },
   "files": [
     "dist/",
+    "scripts/postinstall.mjs",
     "native/aa-ffi-node/*.node",
     "native/aa-ffi-node/index.cjs",
     "native/aa-ffi-node/index.d.ts",


### PR DESCRIPTION
## Description
v0.0.1-alpha.3 verified AAASM-2190's `--access public` fix unblocked the publish, but the published tarball is **broken on install**:

```
npm error Cannot find module '/tmp/.../scripts/postinstall.mjs'
```

Root cause: `package.json` declares
`"postinstall": "node ./scripts/postinstall.mjs"`
but the `files:` array doesn't include `scripts/` — so `pnpm pack` produces a tarball without the postinstall script it tries to run.

## Severity
**High.** All currently-published `@agent-assembly/sdk@0.0.1-alpha.{1,2,3}` versions are unusable by end users (`npm install` always fails). After this PR merges + next tag publishes, consider `npm deprecate` on the 3 broken pre-release versions.

## Fix
Add `scripts/postinstall.mjs` to the `files:` array.

## Local verification

```
$ pnpm pack
$ tar -tzf agent-assembly-sdk-0.0.1-alpha.3.tgz | grep postinstall
  package/scripts/postinstall.mjs    ← present

$ cd /tmp/fresh-dir
$ npm install /tmp/agent-assembly-sdk-0.0.1-alpha.3.tgz
  added 36 packages, audited 37 packages in 5s, 0 vulnerabilities
  ← no Cannot-find-module error
```

## Related
- Jira: [AAASM-2326](https://lightning-dust-mite.atlassian.net/browse/AAASM-2326)
- Parent: [AAASM-1203](https://lightning-dust-mite.atlassian.net/browse/AAASM-1203)

— Claude Code (Opus 4.7, 1M context)

[AAASM-2326]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ