### PR TITLE
[AAASM-2328] 🐛 (ci): Retry gh release download on cross-repo race (release not found)

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -77,10 +77,32 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p bin-staging
-          gh release download "$RELEASE_TAG" \
-            --repo AI-agent-assembly/agent-assembly \
-            --pattern "aasm-*.tar.gz" \
-            --dir bin-staging
+          # Cross-repo race: release-node fires on the same tag-push event as
+          # agent-assembly's Release workflow, in parallel. agent-assembly takes
+          # ~10 min to build + publish the binaries we depend on. Retry up to
+          # 20 times × 60s = 20 min ceiling waiting for the Release object.
+          # AAASM-2328.
+          MAX_ATTEMPTS=20
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            if gh release download "$RELEASE_TAG" \
+                 --repo AI-agent-assembly/agent-assembly \
+                 --pattern "aasm-*.tar.gz" \
+                 --dir bin-staging 2>&1 | tee /tmp/gh-rd.log; then
+              echo "✓ Downloaded on attempt ${attempt}/${MAX_ATTEMPTS}"
+              break
+            fi
+            # Distinguish 'release not found' (race — retry) from other errors (fail-fast)
+            if ! grep -q 'release not found' /tmp/gh-rd.log; then
+              echo "::error::gh release download failed with non-race error — aborting retry"
+              exit 1
+            fi
+            if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+              echo "::error::Release v${RELEASE_TAG} never appeared after $((MAX_ATTEMPTS * 60))s — agent-assembly Release pipeline likely failed"
+              exit 1
+            fi
+            echo "Attempt ${attempt}/${MAX_ATTEMPTS}: release not yet published, sleeping 60s..."
+            sleep 60
+          done
           ls -la bin-staging/
 
       - name: Stage runtime binaries into runtime-* sub-packages


### PR DESCRIPTION
## Description
release-node.yml fires on the same tag-push event as agent-assembly's Release workflow, in parallel. agent-assembly takes ~10 min to build + publish the binaries release-node depends on, so the first download attempt consistently fails:

```
gh release download "v0.0.1-alpha.3" --repo AI-agent-assembly/agent-assembly --pattern "aasm-*.tar.gz" --dir bin-staging
release not found
```

Observed on alpha-2 and alpha-3 dry-runs. Hidden in alpha-1 by an earlier-failing pnpm-lock step (AAASM-2098).

## Fix
Wrap `gh release download` in a retry loop: up to 20 attempts × 60s = 20 min ceiling. Distinguish 'release not found' (race → retry) from other errors (auth, rate-limit → fail-fast).

## Alternatives considered

| Option | Why not |
|---|---|
| `workflow_run` cross-repo trigger | Only fires for same-repo workflows; not feasible cross-repo |
| `repository_dispatch` from agent-assembly | Cleaner architecturally but needs PAT + extra wiring. Defer until polling cost is a real issue. |
| Manual workflow_dispatch only | Loses automation entirely |

Retry-with-backoff is the smallest change that solves the race.

## Local verification
- Simulated retry on race: 3-attempt loop with first 2 returning 'release not found' → third succeeds → loop exits cleanly
- Fail-fast on non-race error: `HTTP 403 rate limit` → grep miss on 'release not found' → exit 1 without retry

## Related
- Jira: [AAASM-2328](https://lightning-dust-mite.atlassian.net/browse/AAASM-2328)
- Parent: [AAASM-1203](https://lightning-dust-mite.atlassian.net/browse/AAASM-1203)

— Claude Code (Opus 4.7, 1M context)

[AAASM-2328]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ