### PR TITLE
[AAASM-2344] 🐛 (release): Lowercase repository.url for npm sigstore provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/AI-agent-assembly/node-sdk.git"
+    "url": "https://github.com/ai-agent-assembly/node-sdk.git"
   },
   "bugs": {
-    "url": "https://github.com/AI-agent-assembly/node-sdk/issues"
+    "url": "https://github.com/ai-agent-assembly/node-sdk/issues"
   },
-  "homepage": "https://github.com/AI-agent-assembly/node-sdk#readme",
+  "homepage": "https://github.com/ai-agent-assembly/node-sdk#readme",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",

--- a/packages/runtime-darwin-arm64/package.json
+++ b/packages/runtime-darwin-arm64/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/AI-agent-assembly/node-sdk.git",
+    "url": "https://github.com/ai-agent-assembly/node-sdk.git",
     "directory": "packages/runtime-darwin-arm64"
   },
   "os": ["darwin"],

--- a/packages/runtime-darwin-x64/package.json
+++ b/packages/runtime-darwin-x64/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/AI-agent-assembly/node-sdk.git",
+    "url": "https://github.com/ai-agent-assembly/node-sdk.git",
     "directory": "packages/runtime-darwin-x64"
   },
   "os": ["darwin"],

--- a/packages/runtime-linux-arm64/package.json
+++ b/packages/runtime-linux-arm64/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/AI-agent-assembly/node-sdk.git",
+    "url": "https://github.com/ai-agent-assembly/node-sdk.git",
     "directory": "packages/runtime-linux-arm64"
   },
   "os": ["linux"],

--- a/packages/runtime-linux-x64/package.json
+++ b/packages/runtime-linux-x64/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/AI-agent-assembly/node-sdk.git",
+    "url": "https://github.com/ai-agent-assembly/node-sdk.git",
     "directory": "packages/runtime-linux-x64"
   },
   "os": ["linux"],


### PR DESCRIPTION
## Summary

Fixes a v0.0.1-alpha.4 publish failure in `release-node.yml` where `pnpm publish --provenance` was rejected by the npm registry with HTTP 422 because the package's `repository.url` (`AI-agent-assembly`) did not byte-for-byte match the canonical lowercase URL (`ai-agent-assembly`) emitted in the sigstore provenance bundle.

GitHub routing is case-insensitive — both URLs resolve to the same repository — but npm's sigstore verifier performs a case-sensitive string compare and refused the upload.

Lowercase the org segment in every package.json that ships to npm:

- `package.json` (root `@agent-assembly/sdk`, plus `bugs.url` and `homepage`)
- `packages/runtime-linux-x64/package.json`
- `packages/runtime-linux-arm64/package.json`
- `packages/runtime-darwin-x64/package.json`
- `packages/runtime-darwin-arm64/package.json`

## Failed run

https://github.com/ai-agent-assembly/node-sdk/actions/runs/26855112352

## npm error (verbatim)

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@agent-assembly%2fruntime-linux-x64 -
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "git+https://github.com/AI-agent-assembly/node-sdk.git",
expected to match "https://github.com/ai-agent-assembly/node-sdk" from provenance
```

## Release re-trigger plan

Once this PR is merged, re-run `release-node.yml` via `workflow_dispatch` with `release_tag: v0.0.1-alpha.4`. No new git tag is needed — none of the `0.0.1-alpha.4` npm versions were ever created (publish failed before any package made it to the registry), so re-publishing the same version is clean.

## Test plan

- [x] `grep -rn "AI-agent-assembly" --include="package.json"` returns no results after the change
- [x] All 5 package.json files now use `https://github.com/ai-agent-assembly/node-sdk.git`
- [ ] After merge: trigger `release-node.yml` with `release_tag: v0.0.1-alpha.4`
- [ ] Confirm all 5 packages publish successfully to npm with provenance

## Notes on out-of-scope references

`AI-agent-assembly` also appears in `README.md` badges, `docs/`, `CONTRIBUTING.md`, `.github/workflows/*.yml` (gh CLI `--repo` args), `verification-reports/`, and `website/.docusaurus/` generated output. None of these affect npm provenance and all work fine via GitHub's case-insensitive routing, so they are intentionally left alone.

Closes [AAASM-2344](https://lightning-dust-mite.atlassian.net/browse/AAASM-2344)

[AAASM-2344]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ