### PR TITLE
[AAASM-2500] ⬆ (node-sdk): Add /website to Dependabot npm coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/"
+      - "/website"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## What
Adds `/website` to the npm `directories` in `.github/dependabot.yml` so the Docusaurus site's dependencies (9 deps + 8 devDeps) are tracked. Existing npm (`/`), cargo (`/native/aa-ffi-node`), and github-actions entries are retained.

## Why
Follow-up to Epic AAASM-2465. `website/` sits outside the pnpm workspace (`["." , "packages/*"]`), so the root npm entry never covered it — caught during the Epic's completeness audit.

## How to verify
- Dependabot tab parses the config with no errors.
- Dependabot opens version-update PRs for `website/` deps.

Closes AAASM-2500. Refs AAASM-2499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)