### PR TITLE
[AAASM-2550] 🐛 (node-sdk): Resolve SonarCloud reliability + ReDoS-hotspot findings

### DIFF
--- a/src/core/gateway-resolver.ts
+++ b/src/core/gateway-resolver.ts
@@ -44,7 +44,11 @@ export async function probeHealthz(
   baseUrl: string,
   timeoutMs: number = DEFAULT_PROBE_TIMEOUT_MS
 ): Promise<boolean> {
-  const url = baseUrl.replace(/\/+$/, "") + DEFAULT_HEALTHZ_PATH;
+  let trimmedBase = baseUrl;
+  while (trimmedBase.endsWith("/")) {
+    trimmedBase = trimmedBase.slice(0, -1);
+  }
+  const url = trimmedBase + DEFAULT_HEALTHZ_PATH;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {

--- a/src/hooks/mastra.ts
+++ b/src/hooks/mastra.ts
@@ -75,12 +75,14 @@ export async function patchMastra(options: PatchMastraOptions): Promise<boolean>
   module.Agent.prototype.generate = function patchedGenerate(
     ...args: unknown[]
   ): Promise<unknown> {
+    let result: Promise<unknown>;
     try {
-      return runWithAgentId(agentId, () => originalGenerate.apply(this, args));
+      result = runWithAgentId(agentId, () => originalGenerate.apply(this, args));
     } catch (e) {
       console.warn("[assembly] Mastra lineage patch error on generate; falling back:", e);
       return originalGenerate.apply(this, args);
     }
+    return result;
   };
 
   // Wrap Workflow.prototype.execute if present
@@ -92,12 +94,14 @@ export async function patchMastra(options: PatchMastraOptions): Promise<boolean>
     module.Workflow.prototype.execute = function patchedExecute(
       ...args: unknown[]
     ): Promise<unknown> {
+      let result: Promise<unknown>;
       try {
-        return runWithAgentId(agentId, () => originalExecute.apply(this, args));
+        result = runWithAgentId(agentId, () => originalExecute.apply(this, args));
       } catch (e) {
         console.warn("[assembly] Mastra lineage patch error on execute; falling back:", e);
         return originalExecute.apply(this, args);
       }
+      return result;
     };
   }
 


### PR DESCRIPTION
## What
Resolves the two non-coverage SonarCloud quality-gate findings on node-sdk:
1. **Reliability C** — `src/hooks/mastra.ts` (generate + execute hooks): promise was returned inside `try` (try only guarded sync errors). Now assigned to a local and returned **outside** the try.
2. **Security Hotspot (ReDoS)** — `src/core/gateway-resolver.ts`: replaced the slash-strip regex with a plain loop.

## Why
SonarCloud quality gate failed (Reliability C + 1 Security Hotspot). ⚠️ Note: Sonar suggested adding `await` to the mastra hooks — that was **deliberately not done**: awaiting would route a genuine `generate()`/`execute()` rejection into the catch and **re-invoke the original (double execution)**. The chosen fix preserves behavior (sync patch errors fall back; async rejections propagate) while clearing the finding. The regex was a benign false-positive; rewritten without regex to clear the hotspot.

## How to verify
- SonarCloud: Reliability A, hotspot resolved (coverage condition deferred separately).
- Behavior unchanged: trailing-slash strip identical; patch fallback semantics identical.

Closes AAASM-2550.