### PR TITLE
[AAASM-2076] 📝 (docs): Production-ready node-sdk README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ selects ESM or CJS automatically based on how the consumer imports it.
 
 `initAssembly()` registers the LangChain callback handler and auto-wraps the configured
 tools, so each is checked against gateway policy before invocation. For more frameworks
-and the lower-level `withAssembly()` wrapper, see the
-[Examples](https://ai-agent-assembly.github.io/node-sdk/examples) guide.
+and the lower-level `withAssembly()` wrapper, see the **Examples** guide on the
+[documentation site](https://ai-agent-assembly.github.io/node-sdk/).
 
 ## Supported Node.js versions
 

--- a/README.md
+++ b/README.md
@@ -190,8 +190,10 @@ Native integration acceptance test:
 
 - `AA_NATIVE_TEST=1 pnpm vitest run tests/native-napi-integration.test.ts`
 
-The `build-addon` GitHub workflow produces prebuilt `index.node` artifacts
-for Node 18/20/22 on Linux/macOS/Windows.
+The `build-addon` GitHub workflow compiles the native addon (Node 20 and 22): an
+ubuntu-only debug build on pull requests, and ubuntu + macOS builds on `master` and release
+tags. The addon embeds a Unix-domain-socket transport and **does not build on Windows**;
+Windows consumers use `grpc-sidecar` mode.
 
 ## Packaging Layout (AAASM-61)
 
@@ -201,8 +203,11 @@ The package now publishes dual module outputs with explicit conditional exports:
 - CJS entry: `./dist/cjs/index.js`
 - Type declarations: `./dist/types/index.d.ts`
 
-Platform-native binaries are declared via `optionalDependencies` and selected
-during `postinstall` based on `process.platform` and `process.arch`.
+The four `@agent-assembly/runtime-*` packages (`runtime-linux-x64`, `runtime-linux-arm64`,
+`runtime-darwin-x64`, `runtime-darwin-arm64`) are declared as `optionalDependencies`,
+`os`/`cpu`-constrained so only the matching platform installs. They carry the `aasm`
+runtime binary; there is no Windows runtime package. The napi-rs `.node` addon is loaded at
+runtime by `native/aa-ffi-node/index.cjs`.
 
 Package verification checks include:
 

--- a/README.md
+++ b/README.md
@@ -194,3 +194,18 @@ Full guides, architecture deep-dives, and the complete API reference are publish
 
 The site is built from the `docs/` (content) and `website/` (Docusaurus app) directories
 and is re-published on every push to `master` via the `publish-docs.yml` workflow.
+
+## Related projects
+
+`@agent-assembly/sdk` is one client of the Agent Assembly platform. The governance
+decisions it enforces are made by the core Rust runtime; the protocol it speaks is shared
+across all SDKs.
+
+| Project | What it is |
+| ------- | ---------- |
+| [agent-assembly](https://github.com/AI-agent-assembly/agent-assembly) | Core Rust runtime — gateway, policy engine, proxy, eBPF, CLI (`aasm`). The protocol specification lives here. |
+| [Documentation site](https://ai-agent-assembly.github.io/agent-assembly-docs/) | Canonical, cross-repo documentation for the whole platform. |
+| [python-sdk](https://github.com/AI-agent-assembly/python-sdk) | Sibling SDK for Python. |
+| [go-sdk](https://github.com/AI-agent-assembly/go-sdk) | Sibling SDK for Go. |
+| [Release notes](https://github.com/AI-agent-assembly/node-sdk/releases) | Per-version changelog for this package. |
+| [Organization profile](https://github.com/AI-agent-assembly) | Index of every Agent Assembly repository and its status. |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@
 
 TypeScript/Node.js SDK for Agent Assembly, licensed under Apache 2.0.
 
+## Project status
+
+> **Pre-1.0 / alpha.** The current release line is `0.0.1-alpha.x`, published to npm under
+> the `alpha` dist-tag. The public surface (`initAssembly`, `withAssembly`) is stabilizing
+> but **may change between alpha releases**, and per-platform native packaging is still
+> being hardened. Pin an exact version for reproducible installs and review the
+> [release notes](https://github.com/AI-agent-assembly/node-sdk/releases) before upgrading.
+> Production deployments should track the first `0.1.0` release.
+
+```bash
+pnpm add @agent-assembly/sdk@alpha   # latest alpha
+pnpm add @agent-assembly/sdk@0.0.1-alpha.3   # pin exact
+```
+
 ## Prerequisites
 
 Before installing or contributing, ensure your environment has:

--- a/README.md
+++ b/README.md
@@ -209,3 +209,15 @@ across all SDKs.
 | [go-sdk](https://github.com/AI-agent-assembly/go-sdk) | Sibling SDK for Go. |
 | [Release notes](https://github.com/AI-agent-assembly/node-sdk/releases) | Per-version changelog for this package. |
 | [Organization profile](https://github.com/AI-agent-assembly) | Index of every Agent Assembly repository and its status. |
+
+## Support & security
+
+- **Questions and bug reports** — open an issue on the
+  [node-sdk issue tracker](https://github.com/AI-agent-assembly/node-sdk/issues). Include
+  your Node.js version, OS/arch, and the SDK version (`pnpm why @agent-assembly/sdk`).
+- **Security vulnerabilities** — please do **not** file a public issue. Report privately
+  via the repository's
+  [security advisories](https://github.com/AI-agent-assembly/node-sdk/security/advisories)
+  page so a fix can be coordinated before disclosure.
+- **Contributing** — see [CONTRIBUTING.md](./CONTRIBUTING.md) for environment setup, the
+  adapter-authoring guide, and the test/commit conventions.

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ import { initAssembly } from "@agent-assembly/sdk";
 
 const searchWeb = {
   name: "search_web",
-  invoke: async (input: { q: string }) => `results for ${input.q}`,
+  invoke: async (input: { q: string }) => `results for ${input.q}`
 };
 
 const ctx = await initAssembly({
   gatewayUrl: "http://localhost:7391",
   agentId: "demo",
-  langchain: { tools: { searchWeb } },
+  langchain: { tools: { searchWeb } }
 });
 
 await searchWeb.invoke({ q: "agent assembly" }); // governed; throws on policy deny
@@ -77,13 +77,13 @@ const { initAssembly } = require("@agent-assembly/sdk");
 
 const searchWeb = {
   name: "search_web",
-  invoke: async (input) => `results for ${input.q}`,
+  invoke: async (input) => `results for ${input.q}`
 };
 
 const ctx = await initAssembly({
   gatewayUrl: "http://localhost:7391",
   agentId: "demo",
-  langchain: { tools: { searchWeb } },
+  langchain: { tools: { searchWeb } }
 });
 
 await searchWeb.invoke({ q: "agent assembly" });
@@ -225,14 +225,14 @@ and is re-published on every push to `master` via the `publish-docs.yml` workflo
 decisions it enforces are made by the core Rust runtime; the protocol it speaks is shared
 across all SDKs.
 
-| Project | What it is |
-| ------- | ---------- |
-| [agent-assembly](https://github.com/AI-agent-assembly/agent-assembly) | Core Rust runtime — gateway, policy engine, proxy, eBPF, CLI (`aasm`). The protocol specification lives here. |
-| [Documentation site](https://ai-agent-assembly.github.io/agent-assembly-docs/) | Canonical, cross-repo documentation for the whole platform. |
-| [python-sdk](https://github.com/AI-agent-assembly/python-sdk) | Sibling SDK for Python. |
-| [go-sdk](https://github.com/AI-agent-assembly/go-sdk) | Sibling SDK for Go. |
-| [Release notes](https://github.com/AI-agent-assembly/node-sdk/releases) | Per-version changelog for this package. |
-| [Organization profile](https://github.com/AI-agent-assembly) | Index of every Agent Assembly repository and its status. |
+| Project                                                                        | What it is                                                                                                    |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| [agent-assembly](https://github.com/AI-agent-assembly/agent-assembly)          | Core Rust runtime — gateway, policy engine, proxy, eBPF, CLI (`aasm`). The protocol specification lives here. |
+| [Documentation site](https://ai-agent-assembly.github.io/agent-assembly-docs/) | Canonical, cross-repo documentation for the whole platform.                                                   |
+| [python-sdk](https://github.com/AI-agent-assembly/python-sdk)                  | Sibling SDK for Python.                                                                                       |
+| [go-sdk](https://github.com/AI-agent-assembly/go-sdk)                          | Sibling SDK for Go.                                                                                           |
+| [Release notes](https://github.com/AI-agent-assembly/node-sdk/releases)        | Per-version changelog for this package.                                                                       |
+| [Organization profile](https://github.com/AI-agent-assembly)                   | Index of every Agent Assembly repository and its status.                                                      |
 
 ## Support & security
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ during `postinstall`. No additional build step is required for typical consumers
 import { initAssembly, withAssembly } from "@agent-assembly/sdk";
 import { ChatOpenAI } from "@langchain/openai";
 
-const ctx = await initAssembly({ gatewayUrl: "http://localhost:8080", agentId: "demo" });
+const ctx = await initAssembly({ gatewayUrl: "http://localhost:7391", agentId: "demo" });
 const governedTools = withAssembly(myTools, { context: ctx });
 const model = new ChatOpenAI({ model: "gpt-4o-mini" }).bindTools(governedTools);
 ```
@@ -49,7 +49,7 @@ const model = new ChatOpenAI({ model: "gpt-4o-mini" }).bindTools(governedTools);
 const { initAssembly, withAssembly } = require("@agent-assembly/sdk");
 const { ChatOpenAI } = require("@langchain/openai");
 
-const ctx = await initAssembly({ gatewayUrl: "http://localhost:8080", agentId: "demo" });
+const ctx = await initAssembly({ gatewayUrl: "http://localhost:7391", agentId: "demo" });
 const governedTools = withAssembly(myTools, { context: ctx });
 const model = new ChatOpenAI({ model: "gpt-4o-mini" }).bindTools(governedTools);
 ```

--- a/README.md
+++ b/README.md
@@ -46,33 +46,57 @@ during `postinstall`. No additional build step is required for typical consumers
 
 ## Quickstart
 
+Pass your LangChain-style tools (`{ name, invoke }`) to `initAssembly` under
+`langchain.tools`. Each tool is wrapped **in place** so every `invoke()` is checked
+against gateway policy before it runs.
+
 ### ESM (`import`)
 
 ```ts
-import { initAssembly, withAssembly } from "@agent-assembly/sdk";
-import { ChatOpenAI } from "@langchain/openai";
+import { initAssembly } from "@agent-assembly/sdk";
 
-const ctx = await initAssembly({ gatewayUrl: "http://localhost:7391", agentId: "demo" });
-const governedTools = withAssembly(myTools, { context: ctx });
-const model = new ChatOpenAI({ model: "gpt-4o-mini" }).bindTools(governedTools);
+const searchWeb = {
+  name: "search_web",
+  invoke: async (input: { q: string }) => `results for ${input.q}`,
+};
+
+const ctx = await initAssembly({
+  gatewayUrl: "http://localhost:7391",
+  agentId: "demo",
+  langchain: { tools: { searchWeb } },
+});
+
+await searchWeb.invoke({ q: "agent assembly" }); // governed; throws on policy deny
+await ctx.shutdown();
 ```
 
 ### CJS (`require`)
 
 ```js
-const { initAssembly, withAssembly } = require("@agent-assembly/sdk");
-const { ChatOpenAI } = require("@langchain/openai");
+const { initAssembly } = require("@agent-assembly/sdk");
 
-const ctx = await initAssembly({ gatewayUrl: "http://localhost:7391", agentId: "demo" });
-const governedTools = withAssembly(myTools, { context: ctx });
-const model = new ChatOpenAI({ model: "gpt-4o-mini" }).bindTools(governedTools);
+const searchWeb = {
+  name: "search_web",
+  invoke: async (input) => `results for ${input.q}`,
+};
+
+const ctx = await initAssembly({
+  gatewayUrl: "http://localhost:7391",
+  agentId: "demo",
+  langchain: { tools: { searchWeb } },
+});
+
+await searchWeb.invoke({ q: "agent assembly" });
+await ctx.shutdown();
 ```
 
 Both entrypoints resolve to the same governance pipeline; the package's `exports` field
 selects ESM or CJS automatically based on how the consumer imports it.
 
-`initAssembly()` registers the LangChain callback handler and the AdapterRegistry, so any
-tool wrapped by `withAssembly()` is checked against gateway policy before invocation.
+`initAssembly()` registers the LangChain callback handler and auto-wraps the configured
+tools, so each is checked against gateway policy before invocation. For more frameworks
+and the lower-level `withAssembly()` wrapper, see the
+[Examples](https://ai-agent-assembly.github.io/node-sdk/examples) guide.
 
 ## Supported Node.js versions
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 8
 ---
 
 # API reference

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,11 +25,16 @@ flowchart LR
     F -->|gRPC / in-process| G["Agent Assembly gateway"]
 ```
 
-The per-platform binary is shipped as an `optionalDependencies` entry
-(`@agent-assembly/linux-x64-gnu`, `darwin-x64`, `darwin-arm64`, `win32-x64-msvc`) and
-selected at install time by `scripts/postinstall.mjs` based on `process.platform` and
-`process.arch`. Consumers who can't use a prebuilt binary may rebuild via
-`pnpm native:build:release` against a local Rust toolchain.
+Four `@agent-assembly/runtime-*` packages — `runtime-linux-x64`, `runtime-linux-arm64`,
+`runtime-darwin-x64`, and `runtime-darwin-arm64` — are declared as `optionalDependencies`.
+Each is constrained by `os`/`cpu` so npm installs only the one matching the host, and each
+carries the platform `aasm` runtime binary the SDK can auto-start as a local gateway.
+There is no prebuilt package for Windows; Windows hosts build the native addon from source.
+
+The napi-rs `.node` addon itself is loaded at runtime by `native/aa-ffi-node/index.cjs`
+(which resolves `index.node`, or a platform-suffixed `index.*.node`). Consumers who need
+to (re)build it locally can run `pnpm native:build:release` against a Rust toolchain — see
+[Troubleshooting](./troubleshooting.md).
 
 ## Framework adapters and the AdapterRegistry
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -11,10 +11,10 @@ requires **Node.js ≥ 18.18.0**; older lines (≤ 16) are unsupported.
 
 | Node.js | Linux | macOS | Windows |
 | ------- | ----- | ----- | ------- |
-| 18 | ✅ | ✅ | ✅ |
-| 20 | ✅ | ✅ | ✅ |
-| 22 | ✅ | ✅ | ✅ |
-| 24 | ✅ | ✅ | ✅ |
+| 18      | ✅    | ✅    | ✅      |
+| 20      | ✅    | ✅    | ✅      |
+| 22      | ✅    | ✅    | ✅      |
+| 24      | ✅    | ✅    | ✅      |
 
 This matrix is enforced by `.github/workflows/test-matrix.yml`, which runs the full grid on
 pushes to `master` and on release tags, and an ubuntu-only subset on pull requests for fast

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,58 @@
+---
+sidebar_position: 5
+---
+
+# Compatibility
+
+## Node.js
+
+The SDK targets active Node.js LTS lines. The napi-rs ABI used by the native binding
+requires **Node.js ≥ 18.18.0**; older lines (≤ 16) are unsupported.
+
+| Node.js | Linux | macOS | Windows |
+| ------- | ----- | ----- | ------- |
+| 18 | ✅ | ✅ | ✅ |
+| 20 | ✅ | ✅ | ✅ |
+| 22 | ✅ | ✅ | ✅ |
+| 24 | ✅ | ✅ | ✅ |
+
+This matrix is enforced by `.github/workflows/test-matrix.yml`, which runs the full grid on
+pushes to `master` and on release tags, and an ubuntu-only subset on pull requests for fast
+feedback.
+
+### Prebuilt native packages
+
+Prebuilt platform runtime packages (`@agent-assembly/runtime-*`) are published for
+**linux-x64, linux-arm64, darwin-x64, and darwin-arm64**. There is no prebuilt package for
+Windows: Windows hosts are tested in CI but build the native addon from source, which
+requires a Rust toolchain. See [Troubleshooting](./troubleshooting.md).
+
+## Package manager
+
+`pnpm ≥ 10` is the supported package manager (enforced via `engines` and a committed
+`pnpm-lock.yaml`). `npm` and `yarn` can install the published package as a dependency, but
+contributing to this repository requires pnpm.
+
+## Module systems
+
+The package ships both ESM and CJS entries with conditional `exports`. `import` resolves to
+`dist/esm/`, `require` resolves to `dist/cjs/`, and TypeScript consumers in either module
+system resolve `dist/types/index.d.ts`. See [Architecture](./architecture.md) for how the
+dual build is produced.
+
+## Core runtime
+
+`@agent-assembly/sdk` is a client of the Agent Assembly core runtime
+([agent-assembly](https://github.com/AI-agent-assembly/agent-assembly)) and speaks the
+shared wire protocol to the gateway. The release process keeps the two aligned: each SDK
+release bumps the main package **and** the four `@agent-assembly/runtime-*` packages to the
+same version, and the `aasm` runtime binaries inside those packages are taken from the
+**matching** `agent-assembly` release tag (see [Release process](./releasing.md)).
+
+Practical guidance:
+
+- Install the SDK version whose runtime packages match the gateway you run. The simplest
+  path is to let the SDK auto-start its bundled local `aasm` runtime, which is already
+  version-matched.
+- Because the project is **pre-1.0**, the wire protocol may change between minor versions.
+  Pin an exact SDK version and upgrade the SDK and any standalone gateway together.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,146 @@
+---
+sidebar_position: 3
+---
+
+# Configuration
+
+Everything the SDK does starts at `initAssembly(config)`. The `config` argument is
+optional — `initAssembly()` with no arguments is a supported, zero-config call that
+discovers a local gateway automatically. This page documents the full
+[`AssemblyConfig`](./api-reference.md) surface and the order in which `initAssembly()`
+applies it.
+
+## The init flow
+
+When you call `initAssembly(config)`, the SDK runs these steps in order:
+
+```mermaid
+flowchart TD
+    A["initAssembly(config)"] --> B["Validate input<br/>(delegationReason ≤ 256, enforcementMode ∈ enum)"]
+    B --> C["Resolve parentAgentId<br/>(explicit → async lineage store)"]
+    C --> D["Resolve gatewayUrl + apiKey<br/>(4-step precedence)"]
+    D --> E["Create gateway client + detect frameworks"]
+    E --> F{"mode === 'sdk-only'?"}
+    F -->|no| G["Start network layer +<br/>send 'register' event via native transport"]
+    F -->|yes| H["Skip network + registration"]
+    G --> I["Register LangChain handler, wrap tools,<br/>patch detected frameworks"]
+    H --> I
+    I --> J["Return AssemblyContext<br/>{ activeAdapters, …, shutdown() }"]
+```
+
+1. **Validation.** `delegationReason` longer than 256 characters throws a `RangeError`;
+   an `enforcementMode` outside the allowed set throws a `RangeError`. These run before
+   any network activity so a misconfigured call fails fast.
+2. **Lineage resolution.** `parentAgentId` defaults to the current agent id from the
+   async-context lineage store, so child agents spawned inside framework hooks inherit
+   lineage automatically.
+3. **Gateway resolution.** `gatewayUrl` and `apiKey` are resolved through the precedence
+   chain below.
+4. **Client + framework detection.** A gateway client is created and installed
+   frameworks are detected from the consumer's `node_modules`.
+5. **Network + registration.** Unless `mode` is `"sdk-only"`, the network layer starts
+   and a `register` topology event is sent through the native transport.
+6. **Adapter wiring.** The LangChain callback handler is registered, configured LangChain
+   tools are wrapped, and any other detected framework (Vercel AI SDK, OpenAI Agents,
+   LangGraph, Mastra) is patched.
+7. **Return.** An `AssemblyContext` is returned with the list of `activeAdapters`, any
+   echoed lineage fields, and an async `shutdown()` that tears down adapters and clients.
+
+## Gateway URL & API key resolution
+
+Both `gatewayUrl` and `apiKey` are resolved with the same four-step precedence
+(highest first). The first source that yields a value wins:
+
+| Priority | Source | URL key | API-key key |
+| -------- | ------ | ------- | ----------- |
+| 1 | Explicit field on `config` | `gatewayUrl` | `apiKey` |
+| 2 | Environment variable | `AAASM_GATEWAY_URL` | `AAASM_API_KEY` |
+| 3 | Config file `~/.aasm/config.yaml` | `agent.gateway_url` | `agent.api_key` |
+| 4 | Local default | `http://localhost:7391` (probed; auto-started if absent) | `""` (local mode accepts unauthenticated agents) |
+
+The config file is optional and parsed only when the `js-yaml` soft dependency is
+present; a missing file, missing `js-yaml`, or malformed contents are treated as
+"no value" rather than an error:
+
+```yaml
+# ~/.aasm/config.yaml
+agent:
+  gateway_url: "https://gateway.internal:7391"
+  api_key: "k-xxxxxxxx"
+```
+
+When resolution reaches step 4, the SDK probes `http://localhost:7391/healthz`. If
+nothing responds, it attempts to auto-start a local gateway by running
+`aasm start --mode local --foreground` (the `aasm` binary must be on `PATH` — install it
+with `npm install -g @agent-assembly/cli`). A `ConfigurationError` is thrown when `aasm`
+is missing, and a `GatewayError` when the auto-started gateway does not become healthy in
+time. See [Troubleshooting](./troubleshooting.md) for the recovery paths.
+
+## `AssemblyConfig` fields
+
+| Field | Type | Default | Purpose |
+| ----- | ---- | ------- | ------- |
+| `gatewayUrl` | `string` | resolved (see above) | Base URL of the Agent Assembly gateway. |
+| `apiKey` | `string` | resolved (see above) | Credential for the gateway; empty in local mode. |
+| `agentId` | `string` | _none_ | Stable identifier for this agent. |
+| `mode` | `AssemblyMode` | `"auto"` | Transport selection (see below). |
+| `enforcementMode` | `EnforcementMode` | gateway default (`"enforce"`) | Per-agent governance posture sent at registration (see below). |
+| `parentAgentId` | `string` | async-lineage value | Parent agent that delegated to this one. |
+| `teamId` | `string` | _none_ | Team for budget and policy scoping. |
+| `delegationReason` | `string` | _none_ | Why this agent was delegated to; **must be ≤ 256 chars** or `initAssembly` throws `RangeError`. |
+| `spawnedByTool` | `string` | _none_ | Name of the tool that spawned this agent. |
+| `langchain` | `LangChainAdapterConfig` | _none_ | LangChain callbacks/tools/approval timeout. |
+| `gatewayClient` | `GatewayClient` | created internally | Inject a pre-built client (mainly for tests). |
+
+### `mode`
+
+`AssemblyMode` selects how the SDK reaches the runtime:
+
+| Value | Behavior |
+| ----- | -------- |
+| `"auto"` | Default. Pick the transport automatically. |
+| `"sdk-only"` | No network layer and no registration event — in-process bookkeeping only. |
+| `"grpc-sidecar"` | Talk to a separate gateway process over gRPC. |
+| `"napi-inprocess"` | Use the in-process napi-rs binding. |
+
+### `enforcementMode`
+
+`EnforcementMode` mirrors the core runtime's posture. When omitted, the field is left off
+the registration payload and the gateway applies its server-side default (`"enforce"`),
+preserving the pre-feature wire shape.
+
+| Value | Behavior |
+| ----- | -------- |
+| `"enforce"` | Default. Deny blocks the action; redact strips secrets. |
+| `"observe"` | Dry-run. Every action proceeds; would-be violations are recorded as shadow audit events (`aa audit list --dry-run-only`). |
+| `"disabled"` | Policy evaluation skipped entirely. Hermetic tests only. |
+
+Unknown values throw a `RangeError` so a typo can never silently downgrade an agent into
+live enforcement when the operator meant `observe`.
+
+## Examples
+
+Zero-config — discover (and if needed auto-start) a local gateway:
+
+```ts
+import { initAssembly } from "@agent-assembly/sdk";
+
+const ctx = await initAssembly();
+// ... run your agent ...
+await ctx.shutdown();
+```
+
+Explicit, with lineage and a dry-run posture:
+
+```ts
+const ctx = await initAssembly({
+  gatewayUrl: "https://gateway.internal:7391",
+  apiKey: process.env.AAASM_API_KEY,
+  agentId: "research-agent",
+  teamId: "growth",
+  enforcementMode: "observe",
+  delegationReason: "summarize quarterly metrics",
+});
+```
+
+See [Examples](./examples.md) for full framework-integration walkthroughs.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,12 +51,12 @@ flowchart TD
 Both `gatewayUrl` and `apiKey` are resolved with the same four-step precedence
 (highest first). The first source that yields a value wins:
 
-| Priority | Source | URL key | API-key key |
-| -------- | ------ | ------- | ----------- |
-| 1 | Explicit field on `config` | `gatewayUrl` | `apiKey` |
-| 2 | Environment variable | `AAASM_GATEWAY_URL` | `AAASM_API_KEY` |
-| 3 | Config file `~/.aasm/config.yaml` | `agent.gateway_url` | `agent.api_key` |
-| 4 | Local default | `http://localhost:7391` (probed; auto-started if absent) | `""` (local mode accepts unauthenticated agents) |
+| Priority | Source                            | URL key                                                  | API-key key                                      |
+| -------- | --------------------------------- | -------------------------------------------------------- | ------------------------------------------------ |
+| 1        | Explicit field on `config`        | `gatewayUrl`                                             | `apiKey`                                         |
+| 2        | Environment variable              | `AAASM_GATEWAY_URL`                                      | `AAASM_API_KEY`                                  |
+| 3        | Config file `~/.aasm/config.yaml` | `agent.gateway_url`                                      | `agent.api_key`                                  |
+| 4        | Local default                     | `http://localhost:7391` (probed; auto-started if absent) | `""` (local mode accepts unauthenticated agents) |
 
 The config file is optional and parsed only when the `js-yaml` soft dependency is
 present; a missing file, missing `js-yaml`, or malformed contents are treated as
@@ -78,30 +78,30 @@ time. See [Troubleshooting](./troubleshooting.md) for the recovery paths.
 
 ## `AssemblyConfig` fields
 
-| Field | Type | Default | Purpose |
-| ----- | ---- | ------- | ------- |
-| `gatewayUrl` | `string` | resolved (see above) | Base URL of the Agent Assembly gateway. |
-| `apiKey` | `string` | resolved (see above) | Credential for the gateway; empty in local mode. |
-| `agentId` | `string` | _none_ | Stable identifier for this agent. |
-| `mode` | `AssemblyMode` | `"auto"` | Transport selection (see below). |
-| `enforcementMode` | `EnforcementMode` | gateway default (`"enforce"`) | Per-agent governance posture sent at registration (see below). |
-| `parentAgentId` | `string` | async-lineage value | Parent agent that delegated to this one. |
-| `teamId` | `string` | _none_ | Team for budget and policy scoping. |
-| `delegationReason` | `string` | _none_ | Why this agent was delegated to; **must be ≤ 256 chars** or `initAssembly` throws `RangeError`. |
-| `spawnedByTool` | `string` | _none_ | Name of the tool that spawned this agent. |
-| `langchain` | `LangChainAdapterConfig` | _none_ | LangChain callbacks/tools/approval timeout. |
-| `gatewayClient` | `GatewayClient` | created internally | Inject a pre-built client (mainly for tests). |
+| Field              | Type                     | Default                       | Purpose                                                                                         |
+| ------------------ | ------------------------ | ----------------------------- | ----------------------------------------------------------------------------------------------- |
+| `gatewayUrl`       | `string`                 | resolved (see above)          | Base URL of the Agent Assembly gateway.                                                         |
+| `apiKey`           | `string`                 | resolved (see above)          | Credential for the gateway; empty in local mode.                                                |
+| `agentId`          | `string`                 | _none_                        | Stable identifier for this agent.                                                               |
+| `mode`             | `AssemblyMode`           | `"auto"`                      | Transport selection (see below).                                                                |
+| `enforcementMode`  | `EnforcementMode`        | gateway default (`"enforce"`) | Per-agent governance posture sent at registration (see below).                                  |
+| `parentAgentId`    | `string`                 | async-lineage value           | Parent agent that delegated to this one.                                                        |
+| `teamId`           | `string`                 | _none_                        | Team for budget and policy scoping.                                                             |
+| `delegationReason` | `string`                 | _none_                        | Why this agent was delegated to; **must be ≤ 256 chars** or `initAssembly` throws `RangeError`. |
+| `spawnedByTool`    | `string`                 | _none_                        | Name of the tool that spawned this agent.                                                       |
+| `langchain`        | `LangChainAdapterConfig` | _none_                        | LangChain callbacks/tools/approval timeout.                                                     |
+| `gatewayClient`    | `GatewayClient`          | created internally            | Inject a pre-built client (mainly for tests).                                                   |
 
 ### `mode`
 
 `AssemblyMode` selects how the SDK reaches the runtime:
 
-| Value | Behavior |
-| ----- | -------- |
-| `"auto"` | Default. Pick the transport automatically. |
-| `"sdk-only"` | No network layer and no registration event — in-process bookkeeping only. |
-| `"grpc-sidecar"` | Talk to a separate gateway process over gRPC. |
-| `"napi-inprocess"` | Use the in-process napi-rs binding. |
+| Value              | Behavior                                                                  |
+| ------------------ | ------------------------------------------------------------------------- |
+| `"auto"`           | Default. Pick the transport automatically.                                |
+| `"sdk-only"`       | No network layer and no registration event — in-process bookkeeping only. |
+| `"grpc-sidecar"`   | Talk to a separate gateway process over gRPC.                             |
+| `"napi-inprocess"` | Use the in-process napi-rs binding.                                       |
 
 ### `enforcementMode`
 
@@ -109,11 +109,11 @@ time. See [Troubleshooting](./troubleshooting.md) for the recovery paths.
 the registration payload and the gateway applies its server-side default (`"enforce"`),
 preserving the pre-feature wire shape.
 
-| Value | Behavior |
-| ----- | -------- |
-| `"enforce"` | Default. Deny blocks the action; redact strips secrets. |
-| `"observe"` | Dry-run. Every action proceeds; would-be violations are recorded as shadow audit events (`aa audit list --dry-run-only`). |
-| `"disabled"` | Policy evaluation skipped entirely. Hermetic tests only. |
+| Value        | Behavior                                                                                                                  |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `"enforce"`  | Default. Deny blocks the action; redact strips secrets.                                                                   |
+| `"observe"`  | Dry-run. Every action proceeds; would-be violations are recorded as shadow audit events (`aa audit list --dry-run-only`). |
+| `"disabled"` | Policy evaluation skipped entirely. Hermetic tests only.                                                                  |
 
 Unknown values throw a `RangeError` so a typo can never silently downgrade an agent into
 live enforcement when the operator meant `observe`.
@@ -139,7 +139,7 @@ const ctx = await initAssembly({
   agentId: "research-agent",
   teamId: "growth",
   enforcementMode: "observe",
-  delegationReason: "summarize quarterly metrics",
+  delegationReason: "summarize quarterly metrics"
 });
 ```
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -27,15 +27,15 @@ const searchWeb = {
   name: "search_web",
   invoke: async (input: { q: string }) => {
     return `results for ${input.q}`;
-  },
+  }
 };
 
 const ctx = await initAssembly({
   agentId: "demo",
   langchain: {
     tools: { searchWeb },
-    approvalTimeoutMs: 30_000, // optional; how long to wait on a "pending" decision
-  },
+    approvalTimeoutMs: 30_000 // optional; how long to wait on a "pending" decision
+  }
 });
 
 // Governed: if policy denies the call, invoke() rejects with a PolicyViolationError.
@@ -60,8 +60,8 @@ import { withAssembly } from "@agent-assembly/sdk";
 const tools = {
   search: {
     description: "Search the web",
-    execute: async (args: { query: string }) => `result:${args.query}`,
-  },
+    execute: async (args: { query: string }) => `result:${args.query}`
+  }
 };
 
 // `gatewayClient` is required; inject the client you constructed (e.g. the same one you
@@ -87,13 +87,13 @@ console.log(ctx.activeAdapters);
 // e.g. ["vercel-ai-sdk"] or ["openai-agents"] or ["langgraph-js"] or ["mastra"]
 ```
 
-| Framework | Detected package | Status |
-| --------- | ---------------- | ------ |
-| LangChain | `@langchain/core` | Validated (test suite) |
-| OpenAI Agents | `@openai/agents` | Experimental (auto-detect patch) |
-| Vercel AI SDK | `ai` | Experimental (auto-detect patch) |
-| LangGraph | `@langchain/langgraph` | Experimental (auto-detect patch) |
-| Mastra | `@mastra/core` | Experimental (auto-detect patch) |
+| Framework     | Detected package       | Status                           |
+| ------------- | ---------------------- | -------------------------------- |
+| LangChain     | `@langchain/core`      | Validated (test suite)           |
+| OpenAI Agents | `@openai/agents`       | Experimental (auto-detect patch) |
+| Vercel AI SDK | `ai`                   | Experimental (auto-detect patch) |
+| LangGraph     | `@langchain/langgraph` | Experimental (auto-detect patch) |
+| Mastra        | `@mastra/core`         | Experimental (auto-detect patch) |
 
 > **Tool naming caveat (Vercel AI SDK).** Vercel AI SDK tools do not expose a `.name`
 > field, so governance policies must match by tool description content (or the tool-map

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,103 @@
+---
+sidebar_position: 4
+---
+
+# Examples
+
+`initAssembly()` auto-detects which agent framework you have installed and wires the
+appropriate governance hooks. The snippets below mirror the patterns exercised by the
+SDK's own test suite.
+
+> **Maturity.** The LangChain path and the low-level `withAssembly` wrapper are covered by
+> the unit test suite. The Vercel AI SDK, OpenAI Agents, LangGraph, and Mastra
+> integrations are wired through auto-detection patches and are **experimental** while the
+> SDK is pre-1.0 — treat their ergonomics as subject to change.
+
+## LangChain (validated)
+
+Install `@langchain/core` (a peer dependency). Pass your tools to `initAssembly` under
+`langchain.tools`; each tool is wrapped **in place** so every `invoke()` is checked
+against gateway policy before it runs. The callback handler is registered automatically.
+
+```ts
+import { initAssembly } from "@agent-assembly/sdk";
+
+// A LangChain-style tool is any object with { name, invoke }.
+const searchWeb = {
+  name: "search_web",
+  invoke: async (input: { q: string }) => {
+    return `results for ${input.q}`;
+  },
+};
+
+const ctx = await initAssembly({
+  agentId: "demo",
+  langchain: {
+    tools: { searchWeb },
+    approvalTimeoutMs: 30_000, // optional; how long to wait on a "pending" decision
+  },
+});
+
+// Governed: if policy denies the call, invoke() rejects with a PolicyViolationError.
+await searchWeb.invoke({ q: "agent assembly" });
+
+await ctx.shutdown();
+```
+
+When the gateway returns a **deny**, the wrapped call throws `PolicyViolationError`. When
+it returns **pending**, the call waits up to `approvalTimeoutMs` for a decision and then
+either proceeds or throws.
+
+## `withAssembly` (validated, low-level)
+
+`withAssembly` is the explicit wrapper used when you manage the gateway client yourself.
+It wraps every tool in a map that exposes an `execute` or `invoke` method, **mutating the
+objects in place** and returning the same map:
+
+```ts
+import { withAssembly } from "@agent-assembly/sdk";
+
+const tools = {
+  search: {
+    description: "Search the web",
+    execute: async (args: { query: string }) => `result:${args.query}`,
+  },
+};
+
+// `gatewayClient` is required; inject the client you constructed (e.g. the same one you
+// passed to initAssembly via `config.gatewayClient`).
+withAssembly(tools, { gatewayClient, approvalTimeoutMs: 30_000 });
+
+await tools.search.execute({ query: "hello" }); // now policy-checked
+```
+
+## Other frameworks (experimental, auto-detected)
+
+If one of these packages is installed, `initAssembly()` detects it and patches its
+execution surface. Pass `agentId` so lineage is attributed correctly.
+
+```ts
+import { initAssembly } from "@agent-assembly/sdk";
+
+// With @openai/agents, ai (Vercel AI SDK), @langchain/langgraph, or @mastra/core
+// installed, this is all that is required to activate governance for it:
+const ctx = await initAssembly({ agentId: "demo" });
+
+console.log(ctx.activeAdapters);
+// e.g. ["vercel-ai-sdk"] or ["openai-agents"] or ["langgraph-js"] or ["mastra"]
+```
+
+| Framework | Detected package | Status |
+| --------- | ---------------- | ------ |
+| LangChain | `@langchain/core` | Validated (test suite) |
+| OpenAI Agents | `@openai/agents` | Experimental (auto-detect patch) |
+| Vercel AI SDK | `ai` | Experimental (auto-detect patch) |
+| LangGraph | `@langchain/langgraph` | Experimental (auto-detect patch) |
+| Mastra | `@mastra/core` | Experimental (auto-detect patch) |
+
+> **Tool naming caveat (Vercel AI SDK).** Vercel AI SDK tools do not expose a `.name`
+> field, so governance policies must match by tool description content (or the tool-map
+> key), not by a framework-level tool name.
+
+For the full list of configuration fields used above, see
+[Configuration](./configuration.md).

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -10,5 +10,29 @@ and Node.js SDK for [Agent Assembly](https://github.com/AI-agent-assembly).
 
 This site is the long-form companion to the GitHub repository
 [`AI-agent-assembly/node-sdk`](https://github.com/AI-agent-assembly/node-sdk). The
-repository's `README.md` covers installation and a 5-line quickstart; this site goes
-deeper into architecture, framework adapter design, and the auto-generated API reference.
+repository's `README.md` covers installation and a quickstart; this site goes deeper into
+architecture, configuration, framework integration, and the auto-generated API reference.
+
+## What's here
+
+- **[Architecture](./architecture.md)** — the napi-rs FFI layer, the framework adapter
+  registry, and the dual ESM/CJS package structure.
+- **[Configuration](./configuration.md)** — the `initAssembly` init flow, gateway/API-key
+  resolution precedence, and every `AssemblyConfig` field.
+- **[Examples](./examples.md)** — validated LangChain and `withAssembly` usage, plus the
+  experimental auto-detected framework integrations.
+- **[Compatibility](./compatibility.md)** — Node LTS matrix, prebuilt platforms, and core
+  runtime version alignment.
+- **[Troubleshooting](./troubleshooting.md)** — gateway auto-start, native addon, and
+  configuration failure modes.
+- **[Release process](./releasing.md)** — how the SDK and runtime packages are published.
+- **[API reference](./api-reference.md)** — auto-generated from the TypeScript source.
+
+## Beyond this SDK
+
+- [agent-assembly](https://github.com/AI-agent-assembly/agent-assembly) — the core Rust
+  runtime and the home of the protocol specification.
+- [Canonical documentation site](https://ai-agent-assembly.github.io/agent-assembly-docs/)
+  — cross-repo platform documentation.
+- [Organization profile](https://github.com/AI-agent-assembly) — every Agent Assembly
+  repository and its status.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,66 @@
+---
+sidebar_position: 7
+---
+
+# Release process
+
+Releases are automated by `.github/workflows/release-node.yml`. They are **driven by the
+core runtime's release**, not cut independently from this repository — this keeps the SDK
+and the `aasm` runtime binaries it ships version-aligned.
+
+## What gets published
+
+Each release publishes **five npm packages at one version**:
+
+- `@agent-assembly/sdk` — the main package.
+- `@agent-assembly/runtime-linux-x64`, `runtime-linux-arm64`, `runtime-darwin-x64`,
+  `runtime-darwin-arm64` — the `os`/`cpu`-constrained packages carrying the platform
+  `aasm` runtime binary.
+
+## Trigger
+
+The workflow runs on either:
+
+- **`repository_dispatch`** (type `agent-assembly-release-published`) — fired by the
+  `agent-assembly` release pipeline's `notify-downstream` job once its GitHub Release is
+  published. This is the normal path and avoids racing the upstream release.
+- **`workflow_dispatch`** — a manual re-run for an already-published tag (e.g. to recover
+  from a partial publish), taking the `release_tag` input.
+
+Both paths resolve a `v*.*.*` tag and reject anything that is not SemVer.
+
+## Steps
+
+1. Download the `aasm-<rust-target>.tar.gz` assets from the **matching**
+   `AI-agent-assembly/agent-assembly` GitHub Release.
+2. Stage each binary into the corresponding `packages/runtime-*/bin/aasm` by Rust target:
+   `x86_64-unknown-linux-gnu → runtime-linux-x64`, `aarch64-unknown-linux-gnu →
+   runtime-linux-arm64`, `x86_64-apple-darwin → runtime-darwin-x64`,
+   `aarch64-apple-darwin → runtime-darwin-arm64`.
+3. Bump all five `package.json` files (and the `@agent-assembly/runtime-*`
+   `optionalDependencies` ranges) to the tag's version.
+4. Build the main SDK (`pnpm build`, ESM + CJS).
+5. Publish the **four runtime sub-packages first**, then the main SDK — so the main
+   package's `optionalDependencies` always resolve to versions that already exist on the
+   registry.
+
+## dist-tag
+
+The npm dist-tag is derived from the SemVer pre-release identifier:
+
+- `0.0.1-alpha.3` → published under `--tag alpha`
+- `0.0.1-rc.1` → published under `--tag rc`
+- `0.0.1` (no pre-release) → published under the default `latest` tag
+
+So pre-1.0 alpha builds never displace `@latest`. Install a specific channel with
+`pnpm add @agent-assembly/sdk@alpha`.
+
+## Provenance
+
+Publishing uses npm OIDC Trusted Publishing with `id-token: write` and
+`NPM_CONFIG_PROVENANCE=true`, so each release carries SLSA build provenance.
+
+## Documentation publishing
+
+The documentation site is published separately by `.github/workflows/publish-docs.yml` on
+pushes to `master` — it is not part of the npm release.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -35,7 +35,7 @@ Both paths resolve a `v*.*.*` tag and reject anything that is not SemVer.
    `AI-agent-assembly/agent-assembly` GitHub Release.
 2. Stage each binary into the corresponding `packages/runtime-*/bin/aasm` by Rust target:
    `x86_64-unknown-linux-gnu → runtime-linux-x64`, `aarch64-unknown-linux-gnu →
-   runtime-linux-arm64`, `x86_64-apple-darwin → runtime-darwin-x64`,
+runtime-linux-arm64`, `x86_64-apple-darwin → runtime-darwin-x64`,
    `aarch64-apple-darwin → runtime-darwin-arm64`.
 3. Bump all five `package.json` files (and the `@agent-assembly/runtime-*`
    `optionalDependencies` ranges) to the tag's version.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,75 @@
+---
+sidebar_position: 6
+---
+
+# Troubleshooting
+
+## `No gateway found … and 'aasm' is not on PATH`
+
+`initAssembly()` reached the local-default step of
+[gateway resolution](./configuration.md): no `gatewayUrl`
+was supplied, no `AAASM_GATEWAY_URL` was set, no `~/.aasm/config.yaml` entry was found, and
+nothing answered at `http://localhost:7391`. It then tried to auto-start a gateway but
+could not find the `aasm` binary.
+
+Fix one of:
+
+- Install the CLI so auto-start works: `npm install -g @agent-assembly/cli`.
+- Point the SDK at an already-running gateway: set `AAASM_GATEWAY_URL`, or pass
+  `gatewayUrl` explicitly, or add an `agent.gateway_url` entry to `~/.aasm/config.yaml`.
+
+## `Auto-started gateway … did not become ready`
+
+`aasm` was found and spawned, but `/healthz` did not return success within the timeout.
+Check that the gateway can bind its port and start cleanly by running
+`aasm start --mode local --foreground` yourself and reading its output, then retry.
+
+## Native addon fails to load / `No native addon binary found`
+
+The native napi-rs addon is loaded by `native/aa-ffi-node/index.cjs`, which expects an
+`index.node` (or platform-suffixed `index.*.node`) to be present. This can be missing on a
+platform with no prebuilt package — notably **Windows**, which has no
+`@agent-assembly/runtime-*` prebuild.
+
+Build it from source against a Rust toolchain:
+
+```bash
+pnpm native:build           # debug build, local
+pnpm native:build:release   # release build, per-platform artifact
+pnpm native:check-types     # validate the generated index.d.ts
+```
+
+If you do not need the in-process binding, run in `mode: "sdk-only"` (or
+`"grpc-sidecar"`), which does not load the addon.
+
+## `~/.aasm/config.yaml` seems to be ignored
+
+The config file is parsed only when the optional `js-yaml` dependency is installed; a
+missing `js-yaml`, a missing file, or malformed YAML is treated as "no value" (never an
+error), so resolution silently falls through to the next step. Install `js-yaml` and
+confirm the file is valid YAML with the expected `agent.gateway_url` / `agent.api_key`
+shape shown in [Configuration](./configuration.md).
+
+## `RangeError` from `initAssembly`
+
+Two inputs are validated before any network activity:
+
+- `delegationReason` must be **≤ 256 characters**.
+- `enforcementMode` must be one of `"enforce"`, `"observe"`, `"disabled"`.
+
+A value outside these bounds throws a `RangeError` so a typo can't silently register an
+agent under the wrong governance posture. See [Configuration](./configuration.md).
+
+## `PolicyViolationError` at tool call time
+
+This is expected behavior, not a bug: the gateway **denied** the tool call (or an approval
+request timed out). The message includes the tool name and the gateway's reason. To run an
+agent without blocking while you tune policy, register it with `enforcementMode: "observe"`
+— actions proceed and would-be violations are recorded as shadow audit events.
+
+## ESM vs CJS import errors
+
+`import` resolves the ESM entry and `require` resolves the CJS entry automatically via the
+package's `exports` map. If a bundler or older toolchain misresolves these, confirm it
+honors the `exports` field (rather than the legacy `main`) and see
+[Compatibility](./compatibility.md#module-systems).


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Bring the `node-sdk` README and documentation site to production-readiness for the
    org documentation Epic (AAASM-2072). Adds the missing guide pages, hardens the README
    with release-state / cross-links / support sections, and corrects two doc-accuracy
    bugs found while writing — all grounded in the actual source and validated by a clean
    Docusaurus build (`onBrokenLinks: throw`).

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: AAASM-2076.
    * Relative task IDs:
        * [x] AAASM-2695 — README release-state, cross-links, support/security.
        * [x] AAASM-2696 — configuration & init-flow reference page.
        * [x] AAASM-2697 — framework integration examples page.
        * [x] AAASM-2698 — troubleshooting, release process, compatibility pages.
        * [x] AAASM-2699 — verification.
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    **New docs pages** (`docs/`): `configuration.md`, `examples.md`, `compatibility.md`,
    `troubleshooting.md`, `releasing.md` — wired into the autogenerated sidebar and linked
    from an expanded `intro.md` documentation map.

    **README hardening**: project status / release-state callout, Related-projects
    cross-links (core runtime, docs site, spec, sibling SDKs, release notes, org profile),
    and a Support & security section.

    **Accuracy fixes (verified against source):**
    * Quickstart used `http://localhost:8080`; the resolver default (and every test/source
      reference) is `http://localhost:7391` — aligned.
    * Quickstart called `withAssembly(myTools, { context: ctx })`, which is not a valid
      signature (`withAssembly` requires `gatewayClient`; `AssemblyContext` exposes none).
      Replaced with the auto-wiring pattern exercised by
      `tests/langchain-init-assembly.test.ts`.
    * `architecture.md` listed `optionalDependencies` as
      `@agent-assembly/{linux-x64-gnu,darwin-x64,darwin-arm64,win32-x64-msvc}`; the actual
      ones are the four `@agent-assembly/runtime-*` packages (os/cpu-constrained, carrying
      the `aasm` binary; no Windows prebuild).

[//]: # (What's the scope in project it would affect with your modify?)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
* Scopes:
    * [x] 📚 Documentation
* Additional description:

    Documentation only — no SDK code, types, or build behavior changes. The README
    quickstart snippet was corrected to compile against the real public API.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* `docs/configuration.md` — init flow, gateway/API-key resolution precedence, full
  `AssemblyConfig` reference, `mode` and `enforcementMode` enums.
* `docs/examples.md` — validated LangChain + `withAssembly` snippets; auto-detection table
  for the experimental Vercel AI / OpenAI Agents / LangGraph / Mastra integrations
  (package names verified against `src/hooks/*-detection.ts`).
* `docs/compatibility.md` — Node LTS matrix + napi ABI floor, prebuilt-platform set,
  pnpm requirement, ESM/CJS resolution, core-runtime version alignment.
* `docs/troubleshooting.md` — gateway auto-start, native addon (incl. Windows
  build-from-source), `js-yaml` soft dep, `RangeError`s, `PolicyViolationError`, ESM/CJS.
* `docs/releasing.md` — agent-assembly-driven 5-package release, dispatch triggers,
  ordered publish, dist-tag derivation, OIDC provenance.
* `docs/intro.md`, `docs/architecture.md`, `docs/api-reference.md`, `README.md` — updates
  described above.

### Verification

* `pnpm --dir website build` succeeds — with `onBrokenLinks: "throw"`, this proves every
  internal doc link and anchor resolves and TypeDoc generates the API reference.
* `prettier --check` passes on the README and all docs pages.
* All external links return HTTP 200 (GitHub repos/releases/org/security-advisories,
  canonical docs site, npm registry). Package-manager commands (`pnpm add @agent-assembly/sdk`,
  `@alpha`, exact-pin) verified against the published npm registry metadata.
