### PR TITLE
[AAASM-2722] 🔧 (node-sdk): Use canonical lowercase org ID ai-agent-assembly

### DIFF
--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -55,7 +55,7 @@ jobs:
           files: ./coverage/lcov.info
           flags: unittest
           name: node-sdk-coverage
-          slug: AI-agent-assembly/node-sdk
+          slug: ai-agent-assembly/node-sdk
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -89,7 +89,7 @@ jobs:
           # is published. So `gh release download` is guaranteed to find the
           # assets on the first try — no retry needed.
           gh release download "$RELEASE_TAG" \
-            --repo AI-agent-assembly/agent-assembly \
+            --repo ai-agent-assembly/agent-assembly \
             --pattern "aasm-*.tar.gz" \
             --dir bin-staging
           ls -la bin-staging/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "agent-assembly-spec"]
 	path = agent-assembly-spec
-	url = https://github.com/AI-agent-assembly/agent-assembly-spec.git
+	url = https://github.com/ai-agent-assembly/agent-assembly-spec.git
 	branch = master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ environment and start hacking on the Node.js SDK for Agent Assembly.
 ### Clone and install
 
 ```bash
-git clone https://github.com/AI-agent-assembly/node-sdk.git
+git clone https://github.com/ai-agent-assembly/node-sdk.git
 cd node-sdk
 pnpm install
 pnpm build

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # @agent-assembly/sdk
 
 [![npm version](https://img.shields.io/npm/v/@agent-assembly/sdk.svg)](https://www.npmjs.com/package/@agent-assembly/sdk)
-[![CI](https://github.com/AI-agent-assembly/node-sdk/actions/workflows/test-matrix.yml/badge.svg?branch=master)](https://github.com/AI-agent-assembly/node-sdk/actions/workflows/test-matrix.yml)
+[![CI](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/test-matrix.yml/badge.svg?branch=master)](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/test-matrix.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=AI-agent-assembly_node-sdk&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=AI-agent-assembly_node-sdk)
-[![codecov](https://codecov.io/gh/AI-agent-assembly/node-sdk/branch/master/graph/badge.svg)](https://codecov.io/gh/AI-agent-assembly/node-sdk)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ai-agent-assembly_node-sdk&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ai-agent-assembly_node-sdk)
+[![codecov](https://codecov.io/gh/ai-agent-assembly/node-sdk/branch/master/graph/badge.svg)](https://codecov.io/gh/ai-agent-assembly/node-sdk)
 
 TypeScript/Node.js SDK for Agent Assembly, licensed under Apache 2.0.
 
@@ -14,7 +14,7 @@ TypeScript/Node.js SDK for Agent Assembly, licensed under Apache 2.0.
 > the `alpha` dist-tag. The public surface (`initAssembly`, `withAssembly`) is stabilizing
 > but **may change between alpha releases**, and per-platform native packaging is still
 > being hardened. Pin an exact version for reproducible installs and review the
-> [release notes](https://github.com/AI-agent-assembly/node-sdk/releases) before upgrading.
+> [release notes](https://github.com/ai-agent-assembly/node-sdk/releases) before upgrading.
 > Production deployments should track the first `0.1.0` release.
 
 ```bash
@@ -232,21 +232,21 @@ across all SDKs.
 
 | Project                                                                        | What it is                                                                                                    |
 | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
-| [agent-assembly](https://github.com/AI-agent-assembly/agent-assembly)          | Core Rust runtime — gateway, policy engine, proxy, eBPF, CLI (`aasm`). The protocol specification lives here. |
+| [agent-assembly](https://github.com/ai-agent-assembly/agent-assembly)          | Core Rust runtime — gateway, policy engine, proxy, eBPF, CLI (`aasm`). The protocol specification lives here. |
 | [Documentation site](https://ai-agent-assembly.github.io/agent-assembly-docs/) | Canonical, cross-repo documentation for the whole platform.                                                   |
-| [python-sdk](https://github.com/AI-agent-assembly/python-sdk)                  | Sibling SDK for Python.                                                                                       |
-| [go-sdk](https://github.com/AI-agent-assembly/go-sdk)                          | Sibling SDK for Go.                                                                                           |
-| [Release notes](https://github.com/AI-agent-assembly/node-sdk/releases)        | Per-version changelog for this package.                                                                       |
-| [Organization profile](https://github.com/AI-agent-assembly)                   | Index of every Agent Assembly repository and its status.                                                      |
+| [python-sdk](https://github.com/ai-agent-assembly/python-sdk)                  | Sibling SDK for Python.                                                                                       |
+| [go-sdk](https://github.com/ai-agent-assembly/go-sdk)                          | Sibling SDK for Go.                                                                                           |
+| [Release notes](https://github.com/ai-agent-assembly/node-sdk/releases)        | Per-version changelog for this package.                                                                       |
+| [Organization profile](https://github.com/ai-agent-assembly)                   | Index of every Agent Assembly repository and its status.                                                      |
 
 ## Support & security
 
 - **Questions and bug reports** — open an issue on the
-  [node-sdk issue tracker](https://github.com/AI-agent-assembly/node-sdk/issues). Include
+  [node-sdk issue tracker](https://github.com/ai-agent-assembly/node-sdk/issues). Include
   your Node.js version, OS/arch, and the SDK version (`pnpm why @agent-assembly/sdk`).
 - **Security vulnerabilities** — please do **not** file a public issue. Report privately
   via the repository's
-  [security advisories](https://github.com/AI-agent-assembly/node-sdk/security/advisories)
+  [security advisories](https://github.com/ai-agent-assembly/node-sdk/security/advisories)
   page so a fix can be coordinated before disclosure.
 - **Contributing** — see [CONTRIBUTING.md](./CONTRIBUTING.md) for environment setup, the
   adapter-authoring guide, and the test/commit conventions.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -43,7 +43,7 @@ dual build is produced.
 ## Core runtime
 
 `@agent-assembly/sdk` is a client of the Agent Assembly core runtime
-([agent-assembly](https://github.com/AI-agent-assembly/agent-assembly)) and speaks the
+([agent-assembly](https://github.com/ai-agent-assembly/agent-assembly)) and speaks the
 shared wire protocol to the gateway. The release process keeps the two aligned: each SDK
 release bumps the main package **and** the four `@agent-assembly/runtime-*` packages to the
 same version, and the `aasm` runtime binaries inside those packages are taken from the

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -6,10 +6,10 @@ sidebar_position: 1
 # Introduction
 
 Welcome to the developer documentation for **`@agent-assembly/sdk`** — the TypeScript
-and Node.js SDK for [Agent Assembly](https://github.com/AI-agent-assembly).
+and Node.js SDK for [Agent Assembly](https://github.com/ai-agent-assembly).
 
 This site is the long-form companion to the GitHub repository
-[`AI-agent-assembly/node-sdk`](https://github.com/AI-agent-assembly/node-sdk). The
+[`ai-agent-assembly/node-sdk`](https://github.com/ai-agent-assembly/node-sdk). The
 repository's `README.md` covers installation and a quickstart; this site goes deeper into
 architecture, configuration, framework integration, and the auto-generated API reference.
 
@@ -30,9 +30,9 @@ architecture, configuration, framework integration, and the auto-generated API r
 
 ## Beyond this SDK
 
-- [agent-assembly](https://github.com/AI-agent-assembly/agent-assembly) — the core Rust
+- [agent-assembly](https://github.com/ai-agent-assembly/agent-assembly) — the core Rust
   runtime and the home of the protocol specification.
 - [Canonical documentation site](https://ai-agent-assembly.github.io/agent-assembly-docs/)
   — cross-repo platform documentation.
-- [Organization profile](https://github.com/AI-agent-assembly) — every Agent Assembly
+- [Organization profile](https://github.com/ai-agent-assembly) — every Agent Assembly
   repository and its status.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -32,7 +32,7 @@ Both paths resolve a `v*.*.*` tag and reject anything that is not SemVer.
 ## Steps
 
 1. Download the `aasm-<rust-target>.tar.gz` assets from the **matching**
-   `AI-agent-assembly/agent-assembly` GitHub Release.
+   `ai-agent-assembly/agent-assembly` GitHub Release.
 2. Stage each binary into the corresponding `packages/runtime-*/bin/aasm` by Rust target:
    `x86_64-unknown-linux-gnu → runtime-linux-x64`, `aarch64-unknown-linux-gnu →
 runtime-linux-arm64`, `x86_64-apple-darwin → runtime-darwin-x64`,

--- a/native/aa-ffi-node/Cargo.lock
+++ b/native/aa-ffi-node/Cargo.lock
@@ -17,7 +17,7 @@ dependencies = [
 [[package]]
 name = "aa-proto"
 version = "0.0.1-alpha.5"
-source = "git+https://github.com/AI-agent-assembly/agent-assembly.git?rev=9cf8a033d39c870ba46a0929b62261d125a00a09#9cf8a033d39c870ba46a0929b62261d125a00a09"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=9cf8a033d39c870ba46a0929b62261d125a00a09#9cf8a033d39c870ba46a0929b62261d125a00a09"
 dependencies = [
  "prost",
  "tonic",
@@ -28,7 +28,7 @@ dependencies = [
 [[package]]
 name = "aa-sdk-client"
 version = "0.0.1-alpha.5"
-source = "git+https://github.com/AI-agent-assembly/agent-assembly.git?rev=9cf8a033d39c870ba46a0929b62261d125a00a09#9cf8a033d39c870ba46a0929b62261d125a00a09"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=9cf8a033d39c870ba46a0929b62261d125a00a09#9cf8a033d39c870ba46a0929b62261d125a00a09"
 dependencies = [
  "aa-proto",
  "aa-security",
@@ -40,7 +40,7 @@ dependencies = [
 [[package]]
 name = "aa-security"
 version = "0.0.1-alpha.5"
-source = "git+https://github.com/AI-agent-assembly/agent-assembly.git?rev=9cf8a033d39c870ba46a0929b62261d125a00a09#9cf8a033d39c870ba46a0929b62261d125a00a09"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=9cf8a033d39c870ba46a0929b62261d125a00a09#9cf8a033d39c870ba46a0929b62261d125a00a09"
 dependencies = [
  "aho-corasick",
 ]

--- a/native/aa-ffi-node/Cargo.toml
+++ b/native/aa-ffi-node/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 # `rev`); advisory preflight arrives transitively via its default `preflight`
 # feature. AAASM-2559 will formalize a published/pinned distribution + a
 # standalone-build CI smoke check on the agent-assembly side.
-aa-sdk-client = { git = "https://github.com/AI-agent-assembly/agent-assembly.git", rev = "9cf8a033d39c870ba46a0929b62261d125a00a09", package = "aa-sdk-client" }
+aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "9cf8a033d39c870ba46a0929b62261d125a00a09", package = "aa-sdk-client" }
 napi = { version = "3", default-features = false, features = ["napi8", "tokio_rt", "serde-json"] }
 napi-derive = "3"
 serde_json = "1"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.host.url=https://sonarcloud.io
-sonar.projectKey=AI-agent-assembly_node-sdk
+sonar.projectKey=ai-agent-assembly_node-sdk
 sonar.organization=ai-agent-assembly
 
 sonar.projectName=agent-assembly-node-sdk

--- a/verification-reports/AAASM-1203.md
+++ b/verification-reports/AAASM-1203.md
@@ -34,9 +34,9 @@
 
 | Sub-task | Title | Status | PR |
 |---|---|---|---|
-| [AAASM-1220] | Scaffold 4 platform runtime sub-packages | Done | [#42](https://github.com/AI-agent-assembly/node-sdk/pull/42) |
-| [AAASM-1221] | Wire optionalDependencies + SDK entrypoint re-export | Done | [#43](https://github.com/AI-agent-assembly/node-sdk/pull/43) |
-| [AAASM-1222] | Implement release-node.yml publish workflow | Done | [#45](https://github.com/AI-agent-assembly/node-sdk/pull/45) |
+| [AAASM-1220] | Scaffold 4 platform runtime sub-packages | Done | [#42](https://github.com/ai-agent-assembly/node-sdk/pull/42) |
+| [AAASM-1221] | Wire optionalDependencies + SDK entrypoint re-export | Done | [#43](https://github.com/ai-agent-assembly/node-sdk/pull/43) |
+| [AAASM-1222] | Implement release-node.yml publish workflow | Done | [#45](https://github.com/ai-agent-assembly/node-sdk/pull/45) |
 | [AAASM-1223] | Verify F113 acceptance | in this report | this PR |
 
 ## Walkthrough vs AAASM-1223 acceptance criteria
@@ -161,7 +161,7 @@ Workflow trace (read from `master @ 8d2f23e`):
 |---|---|
 | 1 | checkout + pnpm + node setup + `pnpm install --frozen-lockfile` |
 | 2 | Resolve tag version — semver-validate; reject non-`v*.*.*` |
-| 3 | `gh release download <tag> --repo AI-agent-assembly/agent-assembly --pattern "aasm-*.tar.gz"` — downloads 4 platform binaries from agent-assembly's matching release (AAASM-1200's output) |
+| 3 | `gh release download <tag> --repo ai-agent-assembly/agent-assembly --pattern "aasm-*.tar.gz"` — downloads 4 platform binaries from agent-assembly's matching release (AAASM-1200's output) |
 | 4 | Per-target `tar -xzf` into `packages/runtime-{platform}/bin/aasm` + `chmod +x` + strip `.gitkeep` placeholder |
 | 5 | Bump `version` in all 5 `package.json` + sync root SDK's `optionalDependencies['@agent-assembly/runtime-*']` to the same version |
 | 6 | `pnpm build` (ESM + CJS dual build) |

--- a/verification-reports/AAASM-2560.md
+++ b/verification-reports/AAASM-2560.md
@@ -17,7 +17,7 @@
 > [AAASM-2567]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2567
 > [AAASM-2568]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2568
 > [AAASM-2570]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2570
-> [#82]: https://github.com/AI-agent-assembly/node-sdk/pull/82
+> [#82]: https://github.com/ai-agent-assembly/node-sdk/pull/82
 
 ## Sub-task roll-up
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -14,7 +14,7 @@ const config: Config = {
   url: "https://ai-agent-assembly.github.io",
   baseUrl: "/node-sdk/",
 
-  organizationName: "AI-agent-assembly",
+  organizationName: "ai-agent-assembly",
   projectName: "node-sdk",
 
   onBrokenLinks: "throw",
@@ -57,7 +57,7 @@ const config: Config = {
           path: "../docs",
           routeBasePath: "/",
           sidebarPath: "./sidebars.ts",
-          editUrl: "https://github.com/AI-agent-assembly/node-sdk/tree/master/",
+          editUrl: "https://github.com/ai-agent-assembly/node-sdk/tree/master/",
         },
         blog: false,
         theme: {
@@ -86,7 +86,7 @@ const config: Config = {
           label: "Docs",
         },
         {
-          href: "https://github.com/AI-agent-assembly/node-sdk",
+          href: "https://github.com/ai-agent-assembly/node-sdk",
           label: "GitHub",
           position: "right",
         },
@@ -105,7 +105,7 @@ const config: Config = {
           items: [
             {
               label: "GitHub",
-              href: "https://github.com/AI-agent-assembly/node-sdk",
+              href: "https://github.com/ai-agent-assembly/node-sdk",
             },
             {
               label: "npm package",
@@ -113,7 +113,7 @@ const config: Config = {
             },
             {
               label: "Issues",
-              href: "https://github.com/AI-agent-assembly/node-sdk/issues",
+              href: "https://github.com/ai-agent-assembly/node-sdk/issues",
             },
           ],
         },
@@ -122,11 +122,11 @@ const config: Config = {
           items: [
             {
               label: "Python SDK",
-              href: "https://github.com/AI-agent-assembly/python-sdk",
+              href: "https://github.com/ai-agent-assembly/python-sdk",
             },
             {
               label: "Go SDK",
-              href: "https://github.com/AI-agent-assembly/go-sdk",
+              href: "https://github.com/ai-agent-assembly/go-sdk",
             },
           ],
         },


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Lowercase the GitHub org ID `AI-agent-assembly` → `ai-agent-assembly` across the node-sdk repo so every reference uses the canonical lowercase org slug. The most important change is the `aa-sdk-client` git-SHA-pin URL in `native/aa-ffi-node/Cargo.toml`, with `native/aa-ffi-node/Cargo.lock` updated to match (source URL only; the pinned `rev` and all crate versions are unchanged).

* ### Task tickets:

    * Task ID: AAASM-2722 (Epic AAASM-2715).
    * Relative task IDs:
        * [x] AAASM-2722.
    * Relative PRs:
        * Precedent: go-sdk PR #48.

* ### Key point change (optional):

    * `native/aa-ffi-node/Cargo.toml`: `aa-sdk-client` git URL host → `github.com/ai-agent-assembly/agent-assembly.git`.
    * `native/aa-ffi-node/Cargo.lock`: regenerated source URL lines to match (URL-only; `--locked` resolves clean, no version churn).
    * `.github/workflows/*`, `.gitmodules`, README/docs/*.md, `sonar-project.properties`, `website/docusaurus.config.ts`, verification reports: org slug lowercased.

## _Effecting Scope_

* Action Types:
    * [x] ♻️ Refactoring something
        * [x] 🟢 No breaking change
* Scopes:
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
        * [x] 🔗 Dependencies
        * [x] 📦 Project configurations
    * [x] 📚 Documentation
* Additional description:
    No code/behavior change. GitHub treats org slug case-insensitively (the repo has already moved to the lowercase canonical location), so this only normalizes references.

## _Description_

Verified locally:

* `git grep 'AI-agent-assembly'` → no matches.
* `cargo metadata --locked` resolves clean (pinned `rev` unchanged, no crate version churn).
* `pnpm install && pnpm build && pnpm test` → 179 passed / 2 skipped.
* `pnpm native:build` → `aa-sdk-client` + `aa-proto` compile from the lowercased git URL.

Closes AAASM-2722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
