### PR TITLE
[AAASM-2740] 📝 (node-sdk): Strip internal Jira IDs from public README headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ tests/
 .github/workflows/
 ```
 
-## Native napi-rs Binding (AAASM-60)
+## Native napi-rs Binding
 
 The `aa-ffi-node` Rust crate is located at `native/aa-ffi-node`.
 
@@ -195,7 +195,7 @@ ubuntu-only debug build on pull requests, and ubuntu + macOS builds on `master` 
 tags. The addon embeds a Unix-domain-socket transport and **does not build on Windows**;
 Windows consumers use `grpc-sidecar` mode.
 
-## Packaging Layout (AAASM-61)
+## Packaging Layout
 
 The package now publishes dual module outputs with explicit conditional exports:
 


### PR DESCRIPTION
## What changed

Strips internal Jira IDs from two public README headings (Epic AAASM-2732, writing-style cleanup):
- `## Native napi-rs Binding (AAASM-60)` → `## Native napi-rs Binding`
- `## Packaging Layout (AAASM-61)` → `## Packaging Layout`

## Why

Public-facing READMEs shouldn't expose internal tracking IDs. The `verification-reports/*.md` keep their AAASM refs — those are internal point-in-time records, not public doc headings.

## How to verify

`grep -nE '^#.*AAASM-[0-9]+' README.md` → no matches. README already links the canonical docs hub (no cross-link change needed).

Part of AAASM-2740.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
