### PR TITLE
[AAASM-2742] 🔗 (readme): Fix stale npm badge and SonarCloud slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @agent-assembly/sdk
 
-[![npm version](https://img.shields.io/npm/v/@agent-assembly/sdk.svg)](https://www.npmjs.com/package/@agent-assembly/sdk)
+[![npm version](https://img.shields.io/npm/v/@agent-assembly/sdk/alpha.svg)](https://www.npmjs.com/package/@agent-assembly/sdk)
 [![CI](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/test-matrix.yml/badge.svg?branch=master)](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/test-matrix.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ai-agent-assembly_node-sdk&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ai-agent-assembly_node-sdk)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/@agent-assembly/sdk/alpha.svg)](https://www.npmjs.com/package/@agent-assembly/sdk)
 [![CI](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/test-matrix.yml/badge.svg?branch=master)](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/test-matrix.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ai-agent-assembly_node-sdk&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ai-agent-assembly_node-sdk)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=AI-agent-assembly_node-sdk&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=AI-agent-assembly_node-sdk)
 [![codecov](https://codecov.io/gh/ai-agent-assembly/node-sdk/branch/master/graph/badge.svg)](https://codecov.io/gh/ai-agent-assembly/node-sdk)
 
 TypeScript/Node.js SDK for Agent Assembly, licensed under Apache 2.0.


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Fix two README badges that loaded but rendered the wrong value.

    1. **npm version badge** — the default `img.shields.io/npm/v/@agent-assembly/sdk` reads the `latest` dist-tag, which is pinned at `0.0.1-alpha.3`, while the newest published release is `0.0.1-alpha.5` under the `alpha` dist-tag. Pointing the badge at the `alpha` tag (`…/npm/v/@agent-assembly/sdk/alpha`) makes it reflect the real latest pre-release. Verified: badge now renders `v0.0.1-alpha.5`. (README-only fix — no `npm publish` / dist-tag change.)
    2. **SonarCloud quality-gate badge** — the project key was lowercase `ai-agent-assembly_node-sdk`, which returns "Project not found" on SonarCloud. The registered project key is `AI-agent-assembly_node-sdk` (matching the GitHub org name casing). Corrected both the badge measure URL and the summary link target. Verified: badge now renders the real gate status instead of no-data.

* ### Task tickets:

    * Task ID: AAASM-2742.
    * Relative task IDs:
        * [x] Epic AAASM-2741.
    * Relative PRs:
        * Sibling badge fixes opened per affected repo.

* ### Key point change (optional):

    Badge URLs only. No code, prose, or dist-tag changes.

## _Effecting Scope_

* Action Types:
    * [x] 🔧 Fixing bug
* Scopes:
    * [x] 📚 Documentation
* Additional description:
    Codecov badge already renders a real value (51%); left unchanged.

## _Description_

* `README.md`: npm version badge now reads the `alpha` dist-tag (`alpha.5`).
* `README.md`: SonarCloud badge + summary link use the correct-case project key `AI-agent-assembly_node-sdk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)