### PR TITLE
[AAASM-2765] ✨ (docs): node-sdk README badges (state at a glance, with logos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # @agent-assembly/sdk
 
-[![npm version](https://img.shields.io/npm/v/@agent-assembly/sdk/alpha.svg)](https://www.npmjs.com/package/@agent-assembly/sdk)
-[![CI](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/test-matrix.yml/badge.svg?branch=master)](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/test-matrix.yml)
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=AI-agent-assembly_node-sdk&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=AI-agent-assembly_node-sdk)
-[![codecov](https://codecov.io/gh/ai-agent-assembly/node-sdk/branch/master/graph/badge.svg)](https://codecov.io/gh/ai-agent-assembly/node-sdk)
+[![CI](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/test-matrix.yml/badge.svg?branch=master&logo=githubactions)](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/test-matrix.yml)
+[![Docs](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/publish-docs.yml/badge.svg?branch=master&logo=githubactions)](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/publish-docs.yml)
+[![npm version](https://img.shields.io/npm/v/@agent-assembly/sdk/alpha?logo=npm)](https://www.npmjs.com/package/@agent-assembly/sdk/v/alpha)
+[![Coverage](https://img.shields.io/codecov/c/github/ai-agent-assembly/node-sdk?logo=codecov)](https://codecov.io/gh/ai-agent-assembly/node-sdk)
+[![Quality Gate](https://img.shields.io/sonar/quality_gate/AI-agent-assembly_node-sdk?server=https%3A%2F%2Fsonarcloud.io&logo=sonarcloud)](https://sonarcloud.io/summary/new_code?id=AI-agent-assembly_node-sdk)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](./LICENSE)
+[![Node](https://img.shields.io/badge/node-%E2%89%A518.18-339933?logo=nodedotjs)](https://github.com/ai-agent-assembly/node-sdk/blob/master/package.json)
+[![Code style](https://img.shields.io/badge/style-eslint-4B32C3?logo=eslint)](https://github.com/ai-agent-assembly/node-sdk/blob/master/eslint.config.mjs)
 
 TypeScript/Node.js SDK for Agent Assembly, licensed under Apache 2.0.
 


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Add a rich, logo'd badge strip to the top of `README.md` so the project
    state (CI, docs, published version, coverage, quality gate, license,
    supported Node, code style) is readable at a glance. Every badge carries
    its vendor `logo` and links to its source page. **Every badge URL was
    `curl`-verified to render a real value against its live integration**
    before landing.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: AAASM-2765.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc.)
* ### Key point change (optional):

    | # | Badge | Logo | Verified rendered value |
    |---|---|---|---|
    | 1 | CI (test-matrix) | githubactions | `test-matrix - passing` |
    | 2 | Docs (publish-docs) | githubactions | `publish-docs - passing` |
    | 3 | npm version (`alpha` tag) | npm | `v0.0.1-alpha.5` |
    | 4 | Coverage (Codecov) | codecov | `coverage: 47%` |
    | 5 | Quality gate (SonarCloud) | sonarcloud | `quality gate: failed` |
    | 6 | License | apache | `license: Apache-2.0` |
    | 7 | Node engines | nodedotjs | `node: ≥18.18` |
    | 8 | Code style | eslint | `style: eslint` |

    SonarCloud project key kept at original casing `AI-agent-assembly_node-sdk`
    — the lowercase variant returns "component not found" on shields.io, the
    original casing renders the real gate. No badges omitted; all 8 render.

## _Effecting Scope_

* Action Types:
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
* Scopes:
    * [x] 📚 Documentation
* Additional description:
    Docs-only change. Existing README content is left intact; only the badge
    block at the top was replaced/expanded.

## _Description_

* Replaced the previous 5-badge block with an 8-badge strip in a consistent
  order, each badge logo'd and linked to its page.
