### PR TITLE
[AAASM-2769] 🔧 (release): Bump node-sdk packages to v0.0.1-alpha.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/sdk",
-  "version": "0.0.1-alpha.3",
+  "version": "0.0.1-alpha.4",
   "description": "TypeScript SDK for Agent Assembly",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/runtime-darwin-arm64/package.json
+++ b/packages/runtime-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/runtime-darwin-arm64",
-  "version": "0.0.1-alpha.3",
+  "version": "0.0.1-alpha.4",
   "description": "AAASM aasm runtime binary for macOS ARM64 (Apple Silicon)",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/runtime-darwin-x64/package.json
+++ b/packages/runtime-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/runtime-darwin-x64",
-  "version": "0.0.1-alpha.3",
+  "version": "0.0.1-alpha.4",
   "description": "AAASM aasm runtime binary for macOS x86_64",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/runtime-linux-arm64/package.json
+++ b/packages/runtime-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/runtime-linux-arm64",
-  "version": "0.0.1-alpha.3",
+  "version": "0.0.1-alpha.4",
   "description": "AAASM aasm runtime binary for Linux ARM64",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/runtime-linux-x64/package.json
+++ b/packages/runtime-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/runtime-linux-x64",
-  "version": "0.0.1-alpha.3",
+  "version": "0.0.1-alpha.4",
   "description": "AAASM aasm runtime binary for Linux x86_64",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

Companion to [AAASM-2767 / agent-assembly PR #1018](https://github.com/AI-agent-assembly/agent-assembly/pull/1018) (core v0.0.1-alpha.6). The user has improved CI/CD workflows across all org repos; this cycle re-runs each repo's release pipeline to verify those improvements end-to-end.

- Bumps root `package.json` version from `0.0.1-alpha.3` to `0.0.1-alpha.4`.
- Bumps the 4 runtime sub-packages (`packages/runtime-{darwin-arm64,darwin-x64,linux-arm64,linux-x64}/package.json`) to match.

5 single-line version bumps, no JSON reformatting (verified via `git diff --stat`: 5/5 inserts/deletes).

## Two parallel publish paths after tagging

Tagging `v0.0.1-alpha.4` triggers `release.yml` (`push: tags`) which publishes `@agent-assembly/sdk@0.0.1-alpha.4` (+ 4 runtime sub-packages) to npm at the **static** package.json version.

Separately, when AAASM-2767's `v0.0.1-alpha.6` tag fires on agent-assembly, that fan-outs to node-sdk via `release-node.yml` (`repository_dispatch`), which rewrites all 5 package.json versions to `0.0.1-alpha.6` at runtime and publishes there. Both publishes are valid; npm retains both versions.

## Test plan

- [ ] CI green (`build-addon.yml`, `test-matrix.yml`, `precommit.yml`, `module-system-smoke.yml`, `regression.yml`)
- [ ] After merge: tag `v0.0.1-alpha.4` → `release.yml` fires → 5 packages on npm at alpha.4
- [ ] Cross-check: agent-assembly's later v0.0.1-alpha.6 tag → `release-node.yml` fires → 5 packages on npm at alpha.6

## Refs

- AAASM-2769
- Companion: AAASM-2767 / agent-assembly PR #1018

🤖 Generated with [Claude Code](https://claude.com/claude-code)