### PR TITLE
[AAASM-2794] ♻️ (release-node): Auto-merge docs-version PR via bot PAT

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -263,3 +263,26 @@ jobs:
             --head "$branch" \
             --title "📸 (docs): Cut docs snapshot for ${RELEASE_TAG}" \
             --body "Automated docs version snapshot cut by release-node.yml after the npm publish of \`${RELEASE_TAG}\`. Freezes \`docs/\` into \`website/versioned_docs/version-${RELEASE_TAG}\` and repoints the version channels (labels, banners, \`lastVersion\`)."
+
+      # AAASM-2794: self-approve + enable auto-merge so the snapshot lands on
+      # master without a per-release manual merge. The approve step MUST use a
+      # PAT (DOCS_BOT_PAT) because GitHub forbids self-approval from the same
+      # actor that opened the PR — the PAT is from the operator account, so the
+      # approval comes from a different actor than github-actions[bot]. Auto-
+      # merge waits for any required status checks, then squash-merges. master
+      # branch protection (1 required review + code-owner) is preserved.
+      - name: Self-approve docs-version PR (via PAT)
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_BOT_PAT }}
+        run: |
+          set -euo pipefail
+          branch="docs/version-${RELEASE_TAG}"
+          gh pr review "$branch" --approve --body "Auto-approving deterministic docs snapshot (AAASM-2794)."
+
+      - name: Enable auto-merge on docs-version PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          branch="docs/version-${RELEASE_TAG}"
+          gh pr merge "$branch" --auto --squash --delete-branch


### PR DESCRIPTION
## Summary

Eliminates the per-release manual merge step for the auto-generated docs snapshot. Before this change, every node-sdk release tag fires `release-node.yml`'s `version-docs` job which cuts the Docusaurus snapshot, pushes a branch, opens a PR — then a human has to click "Squash and merge" on a deterministic auto-generated diff. The most recent example is [#104](https://github.com/ai-agent-assembly/node-sdk/pull/104) (the alpha-6 backfill I had to open manually because the workflow itself couldn't due to the org-level setting that was off).

The deterministic nature of the snapshot (`cp -r docs versioned_docs/version-${tag}` plus channel-metadata recompute) means human review adds nothing. This change adds two new steps after the existing PR-creation step so the workflow self-approves the auto-PR via a bot PAT, then enables GitHub auto-merge.

## ⚠️ Operator setup required BEFORE merging this PR

Create a **fine-grained PAT** scoped to `ai-agent-assembly/node-sdk` only with these repository permissions:

- **Pull requests**: Read and write (required by `gh pr review --approve`)

Add it to this repo's Actions secrets as **`DOCS_BOT_PAT`**.

Without the secret, the new `Self-approve docs-version PR (via PAT)` step will fail at runtime on the next release. You can then add the secret and either re-run the workflow or manually approve+merge that one release's docs PR.

PAT rotation is the operator's responsibility per GH's PAT expiry policy.

## Why not push directly to master

`master` is protected (1 required review + code-owner). Classic branch protection has no bypass-actor mechanism (rulesets-only feature, requires GitHub Team which the org doesn't have). Direct push from `github-actions[bot]` would be rejected.

## Why a PAT for the approve step (not just GITHUB_TOKEN)

GitHub forbids self-approval from the same actor that opened the PR. The PR is created by `github-actions[bot]` (via `GITHUB_TOKEN`); the approval has to come from a different actor. `DOCS_BOT_PAT` is a fine-grained PAT from the operator's account → the approval is attributed to that account → counts toward the required-review threshold.

## New flow

```
push branch ────────────┐
                        ├── via GITHUB_TOKEN
open PR ────────────────┘
                        ┐
approve PR ─────────────┤── via DOCS_BOT_PAT (different actor)
                        ┘
                        ┐
enable auto-merge ──────┤── via GITHUB_TOKEN
                        ┘
              (auto-merge waits for any required checks,
               then squash-merges + deletes the branch)
```

`master` branch protection (1 required review + code-owner) is preserved end-to-end.

## Repo-level config already applied via API

- `allow_auto_merge=true` (set via `gh api -X PATCH repos/.../node-sdk -F allow_auto_merge=true`)
- Org-level `can_approve_pull_request_reviews=true` (already done during the AAASM-2792 / alpha-7 release cycle so `gh pr create` works at all)

## Diff

Single atomic commit (+23 lines in `.github/workflows/release-node.yml`, 0 deletions). YAML re-parses cleanly via `yaml.safe_load`.

## Test plan

- [ ] CI green on this PR (workflow-only edit; minimal CI footprint expected by design)
- [ ] **Operator adds `DOCS_BOT_PAT` secret before merging**
- [ ] After merge: next release tag fires → docs-version PR opens → bot self-approves via PAT → auto-merge kicks in → master receives the snapshot with zero human steps
- [ ] Backstop: if `DOCS_BOT_PAT` is missing or expires, the approve step fails loudly so the engineer notices

## Refs

- Origin: `release-node.yml` AAASM-2751 comment block (the engineer-review intent that this PR explicitly relaxes for this specific bot-generated PR class)
- alpha-6 backfill PR (the workflow couldn't open it itself before today's org-level fix): [#104](https://github.com/ai-agent-assembly/node-sdk/pull/104)
- Ticket: [AAASM-2794](https://lightning-dust-mite.atlassian.net/browse/AAASM-2794)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-2794]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ