### PR TITLE
[AAASM-2199] 📝 (readme): Link agent-assembly-examples from node-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ across all SDKs.
 | [Documentation site](https://ai-agent-assembly.github.io/agent-assembly-docs/) | Canonical, cross-repo documentation for the whole platform.                                                   |
 | [python-sdk](https://github.com/ai-agent-assembly/python-sdk)                  | Sibling SDK for Python.                                                                                       |
 | [go-sdk](https://github.com/ai-agent-assembly/go-sdk)                          | Sibling SDK for Go.                                                                                           |
-| [agent-assembly-examples](https://github.com/AI-agent-assembly/agent-assembly-examples) | Runnable examples — learn by running small, framework-specific Node.js/TypeScript (and Python/Go) samples for policy enforcement, approvals, audit, trace, and runtime workflows. |
+| [agent-assembly-examples](https://github.com/ai-agent-assembly/agent-assembly-examples) | Runnable examples — learn by running small, framework-specific Node.js/TypeScript (and Python/Go) samples for policy enforcement, approvals, audit, trace, and runtime workflows. |
 | [Release notes](https://github.com/ai-agent-assembly/node-sdk/releases)        | Per-version changelog for this package.                                                                       |
 | [Organization profile](https://github.com/ai-agent-assembly)                   | Index of every Agent Assembly repository and its status.                                                      |
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ across all SDKs.
 | [Documentation site](https://ai-agent-assembly.github.io/agent-assembly-docs/) | Canonical, cross-repo documentation for the whole platform.                                                   |
 | [python-sdk](https://github.com/ai-agent-assembly/python-sdk)                  | Sibling SDK for Python.                                                                                       |
 | [go-sdk](https://github.com/ai-agent-assembly/go-sdk)                          | Sibling SDK for Go.                                                                                           |
+| [agent-assembly-examples](https://github.com/AI-agent-assembly/agent-assembly-examples) | Runnable examples — learn by running small, framework-specific Node.js/TypeScript (and Python/Go) samples for policy enforcement, approvals, audit, trace, and runtime workflows. |
 | [Release notes](https://github.com/ai-agent-assembly/node-sdk/releases)        | Per-version changelog for this package.                                                                       |
 | [Organization profile](https://github.com/ai-agent-assembly)                   | Index of every Agent Assembly repository and its status.                                                      |
 


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Add an `agent-assembly-examples` entry to the README **Related projects** table so Node.js/TypeScript SDK users can discover runnable, framework-specific examples (policy enforcement, approvals, audit, trace, runtime workflows).

* ### Task tickets:

    * Task ID: AAASM-2199.

* ### Key point change (optional):

    README-only documentation link addition. No code or behavior change.

## _Effecting Scope_

* Action Types:
    * ✏️ Modifying existing something (README)
        * 🟢 No breaking change

## How to verify

Open `README.md`, find the **Related projects** table, confirm the new `agent-assembly-examples` row links to <https://github.com/AI-agent-assembly/agent-assembly-examples>.