### PR TITLE
[AAASM-2842] ✨ (gateway): Expose public gateway client for offline withAssembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,14 +134,51 @@ call is checked against policy before it runs.
 | ------ | ------- |
 | `initAssembly(config)` | Set up governance and auto-wire detected frameworks. The main entrypoint. |
 | `withAssembly(tools, options)` | Lower-level wrapper to govern a tool map when you manage the gateway client yourself. |
+| `createNoopGatewayClient(mode)` | Build an allow-all `GatewayClient` for offline demos and tests, or as a base to wrap. |
+| `PolicyViolationError` | Thrown by a governed tool when the gateway client denies the call. |
 | `currentAgentId()`, `runWithAgentId()` | Read and set the active agent id in the async-context lineage store. |
 | `encodeAuditEvent()` / `decodeAuditEvent()` (and the call-stack codecs) | Encode and decode audit events to and from their wire shape. |
 | `findAasmBinary()`, `INSTALL_HINT` | Locate the bundled `aasm` runtime binary and the install hint shown when it is missing. |
 | `ENFORCEMENT_MODES` | The allowed `enforcementMode` values. |
 
 Type-only exports (`AssemblyConfig`, `AssemblyContext`, `AssemblyMode`, `EnforcementMode`,
-`ToolMap`, and friends) are documented in the
-[API reference](https://ai-agent-assembly.github.io/node-sdk/api-reference).
+`ToolMap`, `GatewayClient`, the `Gateway*` governance types, and friends) are documented in
+the [API reference](https://ai-agent-assembly.github.io/node-sdk/api-reference).
+
+## Governing tools offline
+
+`withAssembly(tools, options)` needs a `GatewayClient`. For offline demos, tests, or custom
+in-process policies you can build one yourself — no running gateway required:
+
+```ts
+import {
+  createNoopGatewayClient,
+  withAssembly,
+  type GatewayClient
+} from "@agent-assembly/sdk";
+
+// Allow-all client — handy for offline smoke tests:
+withAssembly(
+  { search: { description: "Search", execute: async (q: string) => `result:${q}` } },
+  { gatewayClient: createNoopGatewayClient("sdk-only") }
+);
+
+// Or enforce your own in-process policy by implementing the GatewayClient interface:
+const policyClient: GatewayClient = {
+  mode: "sdk-only",
+  start: async () => undefined,
+  close: async () => undefined,
+  check: async (request) =>
+    request.toolName === "delete_file"
+      ? { denied: true, reason: "blocked by local policy" }
+      : { denied: false },
+  waitForApproval: async () => ({ denied: false }),
+  record: async () => undefined,
+  recordResult: async () => undefined,
+  scanPrompts: async () => undefined
+};
+// A governed tool throws `PolicyViolationError` when `check` denies it.
+```
 
 ## How LangChain tools are blocked
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,3 +35,4 @@ export type {
   GatewayRecordEvent,
   GatewayResultRecord
 } from "./types/index.js";
+export { createNoopGatewayClient } from "./gateway/index.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,3 +36,4 @@ export type {
   GatewayResultRecord
 } from "./types/index.js";
 export { createNoopGatewayClient } from "./gateway/index.js";
+export { PolicyViolationError } from "./errors/index.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,3 +26,12 @@ export { currentAgentId, runWithAgentId } from "./lineage/index.js";
 // `@agent-assembly/sdk/runtime` subpath export to avoid colliding with
 // the gateway-based `initAssembly` re-exported above.
 export { INSTALL_HINT, findAasmBinary } from "./runtime.js";
+export type { GatewayClient } from "./gateway/index.js";
+export type {
+  GatewayApprovalResult,
+  GatewayCheckRequest,
+  GatewayDecision,
+  GatewayPromptScan,
+  GatewayRecordEvent,
+  GatewayResultRecord
+} from "./types/index.js";

--- a/tests/public-gateway-client-export.test.ts
+++ b/tests/public-gateway-client-export.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { createNoopGatewayClient, withAssembly } from "../src/index.js";
+
+describe("public gateway client export", () => {
+  it("ALLOW: withAssembly governs a tool offline via the public noop client", async () => {
+    const gatewayClient = createNoopGatewayClient("sdk-only");
+    const tools = {
+      search: {
+        description: "Search",
+        execute: async (args: { query: string }) => `result:${args.query}`
+      }
+    };
+
+    withAssembly(tools, { gatewayClient });
+    const result = await tools.search.execute({ query: "hello" });
+
+    expect(result).toBe("result:hello");
+  });
+});

--- a/tests/public-gateway-client-export.test.ts
+++ b/tests/public-gateway-client-export.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { createNoopGatewayClient, withAssembly } from "../src/index.js";
+import { createNoopGatewayClient, PolicyViolationError, withAssembly } from "../src/index.js";
+import type { GatewayClient } from "../src/index.js";
 
 describe("public gateway client export", () => {
   it("ALLOW: withAssembly governs a tool offline via the public noop client", async () => {
@@ -15,5 +16,29 @@ describe("public gateway client export", () => {
     const result = await tools.search.execute({ query: "hello" });
 
     expect(result).toBe("result:hello");
+  });
+
+  it("DENY: a custom public GatewayClient blocks a tool offline", async () => {
+    const blocked = new Set(["delete_file"]);
+    const gatewayClient: GatewayClient = {
+      mode: "sdk-only",
+      start: async () => undefined,
+      close: async () => undefined,
+      check: async (request) =>
+        request.toolName !== undefined && blocked.has(request.toolName)
+          ? { denied: true, reason: "blocked by local policy" }
+          : { denied: false },
+      waitForApproval: async () => ({ denied: false }),
+      record: async () => undefined,
+      recordResult: async () => undefined,
+      scanPrompts: async () => undefined
+    };
+    const tools = {
+      delete_file: { description: "Delete a file", execute: async () => "deleted" }
+    };
+
+    withAssembly(tools, { gatewayClient });
+
+    await expect(tools.delete_file.execute()).rejects.toBeInstanceOf(PolicyViolationError);
   });
 });


### PR DESCRIPTION
## _Target_

The node examples (AAASM-2824) could not demonstrate `withAssembly` offline because the public `@agent-assembly/sdk` entrypoint exposed **no way to obtain a `GatewayClient`** — `createNoopGatewayClient` and the `GatewayClient` interface were defined internally but never re-exported, and `initAssembly()`'s context doesn't surface a client. This surfaces the offline tool-governance path through the public API, bringing Node in line with the Go SDK's exported-interface model.

* ### Task summary:

    Re-export the gateway client public API (`GatewayClient`, the `Gateway*` governance types, `createNoopGatewayClient`, `PolicyViolationError`) from the package entrypoint, add offline `withAssembly` tests that import only from the public root, and document the offline usage.

* ### Task tickets:

    * Task ID: AAASM-2842.
    * Relative task IDs:
        * [x] AAASM-2824 — the bug that surfaced this gap (Done)
        * [x] AAASM-2843 / AAASM-2844 / AAASM-2845 — impl / tests / docs subtasks
        * [ ] AAASM-2846 — restore `withAssembly` in node examples (**release-blocked**: needs a new `@agent-assembly/sdk` alpha on npm)
        * [ ] AAASM-2847 — verify acceptance criteria
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    **As-is:** `withAssembly(tools, { gatewayClient })` requires a `GatewayClient`, but the public API gave no way to get one — offline examples/tests had to drop `withAssembly` (AAASM-2824).
    **To-be:** `import { createNoopGatewayClient, withAssembly, PolicyViolationError, type GatewayClient } from "@agent-assembly/sdk"` — use the noop client, or implement your own `GatewayClient` for in-process policy, fully offline and typechecked.

## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
    * [x] 📚 Documentation
* Scopes:
    * [x] 🧩 SDK public API
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
    * [x] 📚 Documentation
* Additional description:
    Additive re-exports only — no behavior change, no breaking change. The symbols were already public via the internal barrels (`gateway/index.ts`, `types/index.ts`, `errors/index.ts`); this just surfaces them at the package root.

## _Description_

* `✨ (index)` Re-export `GatewayClient` + the `Gateway*` governance types.
* `✨ (index)` Re-export `createNoopGatewayClient`.
* `✨ (index)` Re-export `PolicyViolationError`.
* `✅ (gateway)` Offline `withAssembly` test via the public noop client.
* `✅ (gateway)` Offline `withAssembly` test via a custom public `GatewayClient` (deny path).
* `📝 (readme)` "Governing tools offline" section + export-table entries.

**Validation:** `pnpm typecheck` clean · `pnpm lint` clean · `pnpm test` → **181 passed / 2 skipped / 0 failed** (incl. the packaging / export-resolution tests).

**Parity (AC #4):** Python and Go do not have this gap — Go exports `assembly.GovernanceClient` as a public interface; Python's `AssemblyCallbackHandler(interceptor=…)` takes a local interceptor and exposes `ctx.client`. Node alone required a client it didn't expose.
