### PR TITLE
[AAASM-2852] ✨ (release-node): Add SDK-only publish workflow_dispatch inputs

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -42,7 +42,7 @@ on:
           - all
           - main-only
       release_tag:
-        description: "agent-assembly release tag to consume (e.g. v0.0.1). Required for manual dispatch."
+        description: "[DEPRECATED — removal scheduled for AAASM-2853] agent-assembly release tag to consume (e.g. v0.0.1). Use npm_version + binary_source_tag instead going forward."
         required: true
         type: string
 

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -33,6 +33,14 @@ on:
         description: "agent-assembly tag whose aasm-* binaries to bundle into the 4 runtime sub-packages (e.g. v0.0.1-alpha.8). Defaults to latest agent-assembly Release. AAASM-2852: accepted but unused until AAASM-2853 wires it through."
         required: false
         type: string
+      publish_mode:
+        description: "Which packages to publish. 'all' = main SDK + 4 runtime sub-packages (coordinated release). 'main-only' = only @agent-assembly/sdk (SDK hotfix mode). AAASM-2852: accepted but unused until AAASM-2854 gates the publish steps."
+        required: false
+        type: choice
+        default: "all"
+        options:
+          - all
+          - main-only
       release_tag:
         description: "agent-assembly release tag to consume (e.g. v0.0.1). Required for manual dispatch."
         required: true

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -25,6 +25,10 @@ on:
     types: [agent-assembly-release-published]
   workflow_dispatch:
     inputs:
+      npm_version:
+        description: "Version to publish to npm (e.g. 0.0.1-alpha.8.1, 0.0.1-alpha.9, 0.0.2). AAASM-2852: accepted but unused until AAASM-2853 wires it through."
+        required: false
+        type: string
       release_tag:
         description: "agent-assembly release tag to consume (e.g. v0.0.1). Required for manual dispatch."
         required: true

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -29,6 +29,10 @@ on:
         description: "Version to publish to npm (e.g. 0.0.1-alpha.8.1, 0.0.1-alpha.9, 0.0.2). AAASM-2852: accepted but unused until AAASM-2853 wires it through."
         required: false
         type: string
+      binary_source_tag:
+        description: "agent-assembly tag whose aasm-* binaries to bundle into the 4 runtime sub-packages (e.g. v0.0.1-alpha.8). Defaults to latest agent-assembly Release. AAASM-2852: accepted but unused until AAASM-2853 wires it through."
+        required: false
+        type: string
       release_tag:
         description: "agent-assembly release tag to consume (e.g. v0.0.1). Required for manual dispatch."
         required: true


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Add three new `workflow_dispatch` inputs (`npm_version`, `binary_source_tag`, `publish_mode`) to `.github/workflows/release-node.yml` as the schema foundation for the decoupled SDK-only publish path described in the AAASM-2851 Story. This PR is **schema-only** — the new inputs are accepted but unused; subsequent subtasks (AAASM-2853 / AAASM-2854) wire them through the Resolve / publish / version-docs steps.

    First of 4 implementation subtasks under AAASM-2851. The motivating user request is: "all the project release must not bind with each others." Today an SDK-only hotfix is structurally impossible — see the parent Story for the full scenario.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: **AAASM-2852** (Subtask)
    * Relative task IDs:
        * [x] Parent Story: AAASM-2851
        * [ ] Next subtask: AAASM-2853 (refactor Resolve step)
        * [ ] Next subtask: AAASM-2854 (gate publish steps on publish_mode)
        * [ ] Next subtask: AAASM-2855 (version-docs uses npm_version)
    * Relative PRs:
        * N/A (first PR in the AAASM-2851 chain)

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    **As-is** — `workflow_dispatch` accepts a single `release_tag` input that drives both binary source AND publish version AND triggers all-5-packages publish.

    ```yaml
    workflow_dispatch:
      inputs:
        release_tag:
          description: "agent-assembly release tag to consume (e.g. v0.0.1). Required for manual dispatch."
          required: true
          type: string
    ```

    **To-be (after this PR)** — three new optional inputs added above the existing `release_tag`. No behavior change yet — they're parsed and visible in the dispatch UI but not consumed anywhere.

    ```yaml
    workflow_dispatch:
      inputs:
        npm_version:           # NEW
          description: "Version to publish to npm (e.g. 0.0.1-alpha.8.1, 0.0.1-alpha.9, 0.0.2)."
          required: false      # flipped to required: true in AAASM-2853
          type: string
        binary_source_tag:     # NEW
          description: "agent-assembly tag whose aasm-* binaries to bundle (e.g. v0.0.1-alpha.8). Defaults to latest."
          required: false
          type: string
        publish_mode:          # NEW
          description: "Which packages to publish. 'all' = main SDK + 4 runtime sub-packages. 'main-only' = only @agent-assembly/sdk."
          required: false
          type: choice
          default: "all"
          options:
            - all
            - main-only
        release_tag:           # KEPT, marked deprecated for the transition window
          description: "[DEPRECATED — removal scheduled for AAASM-2853] ..."
          required: true
          type: string
    ```

    The three new inputs are **optional** in this PR to preserve the existing operator-dispatch behavior. AAASM-2853 flips them to their final required/default semantics when the Resolve step is refactored.

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [ ] 🤖 Framework hooks
    * [ ] 🫀 Data model and types
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
        * [ ] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
    * [ ] 📚 Documentation
* Additional description:
    Schema-only change to one workflow file. No code path consumes the new inputs yet (intentional — see Key point change above).

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* **Commit 1** `✨ (release-node): Add npm_version workflow_dispatch input` — operator-supplied version to stamp on the published `@agent-assembly/sdk` package.
* **Commit 2** `✨ (release-node): Add binary_source_tag workflow_dispatch input` — agent-assembly tag whose `aasm-*` binaries get bundled into the 4 runtime sub-packages. Defaults to latest agent-assembly Release.
* **Commit 3** `✨ (release-node): Add publish_mode workflow_dispatch input` — choice between `all` (existing 5-package coordinated publish) and `main-only` (SDK-only hotfix mode: only `@agent-assembly/sdk` publishes, runtime sub-packages stay at existing version).
* **Commit 4** `📝 (release-node): Mark release_tag workflow_dispatch input as deprecated` — description-string update flagging that this input will be removed in AAASM-2853 once the Resolve step is refactored to read from the new inputs.

### Acceptance criteria coverage

| AC (from AAASM-2852) | Status |
|---|---|
| `release-node.yml` parses with `actionlint` cleanly | ✅ Verified locally — empty output (clean) |
| All three new inputs appear in `gh workflow view` dispatch UI | ✅ Will be visible on master after merge; YAML structure verified via `yaml.safe_load` shows all 4 keys parsing correctly |
| `repository_dispatch` event still triggers the `publish` job | ✅ Unchanged on this layer — `repository_dispatch` trigger block untouched |
| No publish-flow behavior change in this subtask | ✅ New inputs are optional and unused; Resolve step still reads from `release_tag` |

### Self-verification

* `actionlint .github/workflows/release-node.yml` → clean exit
* `python3 -c "import yaml; yaml.safe_load(...)"` → all 4 input keys + correct types parse
* The 4 commits in this PR are atomic per the project's granularity convention (1 input added = 1 commit; 1 deprecation note = 1 commit).