### PR TITLE
[AAASM-2853] ♻️ (release-node): Refactor Resolve step to split binary-source-tag from publish-version

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Download aasm binaries from agent-assembly release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+          RELEASE_TAG: ${{ steps.tag.outputs.binary_source_tag }}
         run: |
           set -euo pipefail
           mkdir -p bin-staging

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -30,7 +30,7 @@ on:
         required: true
         type: string
       binary_source_tag:
-        description: "agent-assembly tag whose aasm-* binaries to bundle into the 4 runtime sub-packages (e.g. v0.0.1-alpha.8). Defaults to latest agent-assembly Release. AAASM-2852: accepted but unused until AAASM-2853 wires it through."
+        description: "agent-assembly tag whose aasm-* binaries to bundle into the 4 runtime sub-packages (e.g. v0.0.1-alpha.8). Defaults to latest agent-assembly Release."
         required: false
         type: string
       publish_mode:
@@ -41,10 +41,6 @@ on:
         options:
           - all
           - main-only
-      release_tag:
-        description: "[DEPRECATED — removal scheduled for AAASM-2853] agent-assembly release tag to consume (e.g. v0.0.1). Use npm_version + binary_source_tag instead going forward."
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -81,7 +77,6 @@ jobs:
         id: tag
         env:
           EVENT_NAME: ${{ github.event_name }}
-          DISPATCH_TAG: ${{ inputs.release_tag }}
           DISPATCH_BINARY_TAG: ${{ inputs.binary_source_tag }}
           DISPATCH_NPM_VERSION: ${{ inputs.npm_version }}
           DISPATCH_PAYLOAD_TAG: ${{ github.event.client_payload.release_tag }}
@@ -89,34 +84,21 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            tag="$DISPATCH_TAG"
-            # AAASM-2853: binary_source_tag resolution on workflow_dispatch.
-            # Precedence: explicit DISPATCH_BINARY_TAG > deprecated DISPATCH_TAG
-            # (release_tag fallback during the transition window) > latest
-            # agent-assembly release. Once release_tag is removed, this
-            # collapses to DISPATCH_BINARY_TAG > latest-release.
+            # Operator path. Precedence for binary_source_tag: explicit
+            # DISPATCH_BINARY_TAG > latest agent-assembly release.
             if [[ -n "${DISPATCH_BINARY_TAG:-}" ]]; then
               binary_source_tag="$DISPATCH_BINARY_TAG"
-            elif [[ -n "${DISPATCH_TAG:-}" ]]; then
-              binary_source_tag="$DISPATCH_TAG"
             else
               binary_source_tag=$(gh release view --repo ai-agent-assembly/agent-assembly --json tagName --jq .tagName)
-              echo "::notice::binary_source_tag and release_tag both omitted; defaulting to latest agent-assembly release: $binary_source_tag"
+              echo "::notice::binary_source_tag omitted; defaulting to latest agent-assembly release: $binary_source_tag"
             fi
-            # AAASM-2853: npm_version falls back to the stripped-v form of
-            # release_tag during the transition window. Once release_tag is
-            # removed, this collapses to just DISPATCH_NPM_VERSION.
-            npm_version="${DISPATCH_NPM_VERSION:-${DISPATCH_TAG#v}}"
+            npm_version="$DISPATCH_NPM_VERSION"
           elif [[ "$EVENT_NAME" == "repository_dispatch" ]]; then
-            tag="$DISPATCH_PAYLOAD_TAG"
+            # Coordinated release path. Both come from the same dispatched tag.
             binary_source_tag="$DISPATCH_PAYLOAD_TAG"
             npm_version="${DISPATCH_PAYLOAD_TAG#v}"
           else
             echo "::error::unexpected event_name '$EVENT_NAME' — release-node should only fire on repository_dispatch or workflow_dispatch"
-            exit 1
-          fi
-          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            echo "::error::tag '$tag' does not match v*.*.* (semver) pattern"
             exit 1
           fi
           if [[ ! "$binary_source_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -55,7 +55,11 @@ jobs:
     name: Publish @agent-assembly/sdk + 4 runtime sub-packages to npm
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ steps.tag.outputs.tag }}
+      # AAASM-2853: tag mirrors binary_source_tag for back-compat with the
+      # version-docs job. AAASM-2855 refactors version-docs to use
+      # binary_source_tag + npm_version directly, after which this alias
+      # can be removed.
+      tag: ${{ steps.tag.outputs.binary_source_tag }}
       binary_source_tag: ${{ steps.tag.outputs.binary_source_tag }}
       npm_version: ${{ steps.tag.outputs.npm_version }}
     steps:

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -117,6 +117,10 @@ jobs:
             echo "::error::binary_source_tag '$binary_source_tag' does not match v*.*.* (semver) pattern"
             exit 1
           fi
+          if [[ ! "$npm_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "::error::npm_version '$npm_version' does not match X.Y.Z semver pattern (must NOT include leading v)"
+            exit 1
+          fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
           echo "binary_source_tag=${binary_source_tag}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -76,13 +76,19 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           DISPATCH_TAG: ${{ inputs.release_tag }}
+          DISPATCH_BINARY_TAG: ${{ inputs.binary_source_tag }}
           DISPATCH_PAYLOAD_TAG: ${{ github.event.client_payload.release_tag }}
         run: |
           set -euo pipefail
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             tag="$DISPATCH_TAG"
+            # AAASM-2853: binary_source_tag falls back to release_tag (deprecated)
+            # during the transition window. Once release_tag is removed, this
+            # fallback collapses to just DISPATCH_BINARY_TAG.
+            binary_source_tag="${DISPATCH_BINARY_TAG:-$DISPATCH_TAG}"
           elif [[ "$EVENT_NAME" == "repository_dispatch" ]]; then
             tag="$DISPATCH_PAYLOAD_TAG"
+            binary_source_tag="$DISPATCH_PAYLOAD_TAG"
           else
             echo "::error::unexpected event_name '$EVENT_NAME' — release-node should only fire on repository_dispatch or workflow_dispatch"
             exit 1
@@ -93,7 +99,8 @@ jobs:
           fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
-          echo "Resolved tag=${tag} version=${tag#v}"
+          echo "binary_source_tag=${binary_source_tag}" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag=${tag} version=${tag#v} binary_source_tag=${binary_source_tag}"
 
       - name: Download aasm binaries from agent-assembly release
         env:

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -26,8 +26,8 @@ on:
   workflow_dispatch:
     inputs:
       npm_version:
-        description: "Version to publish to npm (e.g. 0.0.1-alpha.8.1, 0.0.1-alpha.9, 0.0.2). AAASM-2852: accepted but unused until AAASM-2853 wires it through."
-        required: false
+        description: "Version to publish to npm (e.g. 0.0.1-alpha.8.1, 0.0.1-alpha.9, 0.0.2)."
+        required: true
         type: string
       binary_source_tag:
         description: "agent-assembly tag whose aasm-* binaries to bundle into the 4 runtime sub-packages (e.g. v0.0.1-alpha.8). Defaults to latest agent-assembly Release. AAASM-2852: accepted but unused until AAASM-2853 wires it through."

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -56,6 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
+      binary_source_tag: ${{ steps.tag.outputs.binary_source_tag }}
+      npm_version: ${{ steps.tag.outputs.npm_version }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v4.2.2
 

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -127,11 +127,9 @@ jobs:
             echo "::error::npm_version '$npm_version' does not match X.Y.Z semver pattern (must NOT include leading v)"
             exit 1
           fi
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
           echo "binary_source_tag=${binary_source_tag}" >> "$GITHUB_OUTPUT"
           echo "npm_version=${npm_version}" >> "$GITHUB_OUTPUT"
-          echo "Resolved tag=${tag} version=${tag#v} binary_source_tag=${binary_source_tag} npm_version=${npm_version}"
+          echo "Resolved binary_source_tag=${binary_source_tag} npm_version=${npm_version}"
 
       - name: Download aasm binaries from agent-assembly release
         env:

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -113,6 +113,10 @@ jobs:
             echo "::error::tag '$tag' does not match v*.*.* (semver) pattern"
             exit 1
           fi
+          if [[ ! "$binary_source_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "::error::binary_source_tag '$binary_source_tag' does not match v*.*.* (semver) pattern"
+            exit 1
+          fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
           echo "binary_source_tag=${binary_source_tag}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Bump versions across the 5 packages
         env:
-          VERSION: ${{ steps.tag.outputs.version }}
+          VERSION: ${{ steps.tag.outputs.npm_version }}
         run: |
           set -euo pipefail
           node <<'NODE'

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -79,14 +79,24 @@ jobs:
           DISPATCH_BINARY_TAG: ${{ inputs.binary_source_tag }}
           DISPATCH_NPM_VERSION: ${{ inputs.npm_version }}
           DISPATCH_PAYLOAD_TAG: ${{ github.event.client_payload.release_tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             tag="$DISPATCH_TAG"
-            # AAASM-2853: binary_source_tag falls back to release_tag (deprecated)
-            # during the transition window. Once release_tag is removed, this
-            # fallback collapses to just DISPATCH_BINARY_TAG.
-            binary_source_tag="${DISPATCH_BINARY_TAG:-$DISPATCH_TAG}"
+            # AAASM-2853: binary_source_tag resolution on workflow_dispatch.
+            # Precedence: explicit DISPATCH_BINARY_TAG > deprecated DISPATCH_TAG
+            # (release_tag fallback during the transition window) > latest
+            # agent-assembly release. Once release_tag is removed, this
+            # collapses to DISPATCH_BINARY_TAG > latest-release.
+            if [[ -n "${DISPATCH_BINARY_TAG:-}" ]]; then
+              binary_source_tag="$DISPATCH_BINARY_TAG"
+            elif [[ -n "${DISPATCH_TAG:-}" ]]; then
+              binary_source_tag="$DISPATCH_TAG"
+            else
+              binary_source_tag=$(gh release view --repo ai-agent-assembly/agent-assembly --json tagName --jq .tagName)
+              echo "::notice::binary_source_tag and release_tag both omitted; defaulting to latest agent-assembly release: $binary_source_tag"
+            fi
             # AAASM-2853: npm_version falls back to the stripped-v form of
             # release_tag during the transition window. Once release_tag is
             # removed, this collapses to just DISPATCH_NPM_VERSION.

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -35,7 +35,7 @@ on:
         type: string
       publish_mode:
         description: "Which packages to publish. 'all' = main SDK + 4 runtime sub-packages (coordinated release). 'main-only' = only @agent-assembly/sdk (SDK hotfix mode). AAASM-2852: accepted but unused until AAASM-2854 gates the publish steps."
-        required: false
+        required: true
         type: choice
         default: "all"
         options:

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -77,6 +77,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           DISPATCH_TAG: ${{ inputs.release_tag }}
           DISPATCH_BINARY_TAG: ${{ inputs.binary_source_tag }}
+          DISPATCH_NPM_VERSION: ${{ inputs.npm_version }}
           DISPATCH_PAYLOAD_TAG: ${{ github.event.client_payload.release_tag }}
         run: |
           set -euo pipefail
@@ -86,9 +87,14 @@ jobs:
             # during the transition window. Once release_tag is removed, this
             # fallback collapses to just DISPATCH_BINARY_TAG.
             binary_source_tag="${DISPATCH_BINARY_TAG:-$DISPATCH_TAG}"
+            # AAASM-2853: npm_version falls back to the stripped-v form of
+            # release_tag during the transition window. Once release_tag is
+            # removed, this collapses to just DISPATCH_NPM_VERSION.
+            npm_version="${DISPATCH_NPM_VERSION:-${DISPATCH_TAG#v}}"
           elif [[ "$EVENT_NAME" == "repository_dispatch" ]]; then
             tag="$DISPATCH_PAYLOAD_TAG"
             binary_source_tag="$DISPATCH_PAYLOAD_TAG"
+            npm_version="${DISPATCH_PAYLOAD_TAG#v}"
           else
             echo "::error::unexpected event_name '$EVENT_NAME' — release-node should only fire on repository_dispatch or workflow_dispatch"
             exit 1
@@ -100,7 +106,8 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
           echo "binary_source_tag=${binary_source_tag}" >> "$GITHUB_OUTPUT"
-          echo "Resolved tag=${tag} version=${tag#v} binary_source_tag=${binary_source_tag}"
+          echo "npm_version=${npm_version}" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag=${tag} version=${tag#v} binary_source_tag=${binary_source_tag} npm_version=${npm_version}"
 
       - name: Download aasm binaries from agent-assembly release
         env:


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Refactor the \`Resolve release tag\` step in \`.github/workflows/release-node.yml\` to emit **two outputs** (\`binary_source_tag\` + \`npm_version\`) instead of one (\`tag\`). Wire the three AAASM-2852 inputs (\`npm_version\`, \`binary_source_tag\`, \`publish_mode\`) through the publish job's outputs and downstream steps (Download, Bump versions). Remove the deprecated \`release_tag\` input and its plumbing.

    This is the cohesive flip that lets node-sdk publish \`@agent-assembly/sdk\` at a version independent from the agent-assembly tag whose \`aasm\` binaries get bundled into the runtime sub-packages — the **structural decoupling** that the parent Story AAASM-2851 is about.

    Second of the AAASM-2851 implementation chain. AAASM-2854 will gate the runtime-sub-package publish steps on \`publish_mode\`; AAASM-2855 will refactor the \`version-docs\` job to consume \`npm_version\` + \`binary_source_tag\` instead of the deprecated \`tag\` alias.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: **AAASM-2853** (Subtask)
    * Relative task IDs:
        * [x] Parent Story: AAASM-2851
        * [x] Predecessor: AAASM-2852 (schema added) — merged in [#111](https://github.com/ai-agent-assembly/node-sdk/pull/111)
        * [ ] Next subtask: AAASM-2854 (gate publish steps on publish_mode)
        * [ ] Next subtask: AAASM-2855 (version-docs uses npm_version + binary_source_tag)
    * Relative PRs:
        * [#111](https://github.com/ai-agent-assembly/node-sdk/pull/111) (AAASM-2852, merged)

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    **As-is** — single \`tag\` output drives both binary source AND publish version. \`workflow_dispatch\` accepts deprecated \`release_tag\`; the Resolve step's bash collapses both events into one tag.

    ```yaml
    workflow_dispatch:
      inputs:
        release_tag:
          required: true
          type: string

    publish:
      outputs:
        tag: \${{ steps.tag.outputs.tag }}
    # ...
    - name: Resolve release tag
      env:
        DISPATCH_TAG: \${{ inputs.release_tag }}
        DISPATCH_PAYLOAD_TAG: \${{ github.event.client_payload.release_tag }}
      run: |
        if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
          tag="$DISPATCH_TAG"
        elif [[ "$EVENT_NAME" == "repository_dispatch" ]]; then
          tag="$DISPATCH_PAYLOAD_TAG"
        fi
        echo "tag=$tag" >> "$GITHUB_OUTPUT"
        echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
    ```

    **To-be (after this PR)** — \`release_tag\` removed. Resolve step splits into \`binary_source_tag\` + \`npm_version\`. \`workflow_dispatch\` reads from \`inputs.binary_source_tag\` (or falls back to latest agent-assembly release) and \`inputs.npm_version\`. \`repository_dispatch\` derives both from \`client_payload.release_tag\` (back-compat preserved for the coordinated release flow).

    ```yaml
    workflow_dispatch:
      inputs:
        npm_version:       # required: true
        binary_source_tag: # required: false (defaults to latest)
        publish_mode:      # required: true, choice [all, main-only]

    publish:
      outputs:
        tag: \${{ steps.tag.outputs.binary_source_tag }}   # alias, kept for version-docs back-compat
        binary_source_tag: \${{ steps.tag.outputs.binary_source_tag }}
        npm_version: \${{ steps.tag.outputs.npm_version }}
    # ...
    - name: Resolve release tag
      env:
        DISPATCH_BINARY_TAG: \${{ inputs.binary_source_tag }}
        DISPATCH_NPM_VERSION: \${{ inputs.npm_version }}
        DISPATCH_PAYLOAD_TAG: \${{ github.event.client_payload.release_tag }}
        GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
      run: |
        if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
          if [[ -n "\${DISPATCH_BINARY_TAG:-}" ]]; then
            binary_source_tag="$DISPATCH_BINARY_TAG"
          else
            binary_source_tag=$(gh release view --repo ai-agent-assembly/agent-assembly --json tagName --jq .tagName)
          fi
          npm_version="$DISPATCH_NPM_VERSION"
        elif [[ "$EVENT_NAME" == "repository_dispatch" ]]; then
          binary_source_tag="$DISPATCH_PAYLOAD_TAG"
          npm_version="\${DISPATCH_PAYLOAD_TAG#v}"
        fi
        # validation against semver patterns
        echo "binary_source_tag=$binary_source_tag" >> "$GITHUB_OUTPUT"
        echo "npm_version=$npm_version" >> "$GITHUB_OUTPUT"
    ```

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [x] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [x] ♻️ Refactoring something
    * [ ] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [ ] 🤖 Framework hooks
    * [ ] 🫀 Data model and types
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
        * [ ] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
    * [ ] 📚 Documentation
* Additional description:
    Workflow-only change to one file. No TS / JS / Rust touched. \`repository_dispatch\` flow (the coordinated release path fired by agent-assembly's \`notify-downstream\`) behaves identically to today — back-compat verified via the bash logic that derives both outputs from \`client_payload.release_tag\`.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

13 atomic commits — each one logical concern (per project granularity rule):

**Phase 1 — Add new behavior alongside old** (commits 1–5):

* \`9fdde0e\` `♻️ (release-node): Add binary_source_tag output to Resolve step`
* \`7b45be0\` `♻️ (release-node): Add npm_version output to Resolve step`
* \`c1a05eb\` `✨ (release-node): Add latest-release fallback for binary_source_tag`
* \`d22835b\` `✨ (release-node): Validate binary_source_tag against v*.*.* semver`
* \`a8f2c4e\` `✨ (release-node): Validate npm_version against X.Y.Z semver`

**Phase 2 — Wire downstream consumers to new outputs** (commits 6–9):

* \`03e9673\` `♻️ (release-node): Expose binary_source_tag + npm_version on publish outputs`
* \`187788b\` `♻️ (release-node): Switch Download step to read binary_source_tag`
* \`63446df\` `♻️ (release-node): Switch Bump versions step to read npm_version`
* \`a9a18a1\` `♻️ (release-node): Remap publish.outputs.tag to mirror binary_source_tag`

**Phase 3 — Remove deprecated plumbing** (commits 10–13):

* \`f277a29\` `🗑️ (release-node): Drop legacy tag + version outputs from Resolve step`
* \`d21181c\` `✨ (release-node): Flip npm_version workflow_dispatch input to required`
* \`8bef02b\` `✨ (release-node): Flip publish_mode workflow_dispatch input to required`
* \`c02fa39\` `🗑️ (release-node): Remove deprecated release_tag plumbing`

### Acceptance criteria coverage

| AC (from AAASM-2853) | Status |
|---|---|
| `repository_dispatch` produces identical outputs to today (regression-safe) | ✅ Resolve step's repository_dispatch branch maps `client_payload.release_tag` → `binary_source_tag` + `npm_version (stripped v)` — semantically identical |
| `workflow_dispatch` with `npm_version=0.0.1-alpha.8.1` + `binary_source_tag=v0.0.1-alpha.8` produces correctly-split outputs | ✅ Explicit-input branch reads `DISPATCH_BINARY_TAG` + `DISPATCH_NPM_VERSION` directly |
| `workflow_dispatch` with `binary_source_tag` omitted falls back to latest agent-assembly release | ✅ Commit `c1a05eb` adds the `gh release view --jq .tagName` fallback |
| Invalid `npm_version` fails the step | ✅ Commit `a8f2c4e` adds `^[0-9]+\.[0-9]+\.[0-9]+` regex |
| Invalid `binary_source_tag` fails the step | ✅ Commit `d22835b` adds `^v[0-9]+\.[0-9]+\.[0-9]+` regex |
| All downstream steps reference new output names | ✅ Download → `outputs.binary_source_tag`; Bump versions → `outputs.npm_version`; `publish.outputs.tag` kept as alias mirroring `binary_source_tag` for version-docs back-compat until AAASM-2855 |

### Self-verification

* `actionlint .github/workflows/release-node.yml` → clean (empty output)
* `yaml.safe_load` parses: 3 inputs (no `release_tag`), 3 publish outputs (`tag` mirror + `binary_source_tag` + `npm_version`), Resolve step bash decoupled
* No TS / JS / Rust touched → pre-commit hooks (eslint / prettier / vitest) trivially pass

### What's preserved (intentionally)

* `client_payload.release_tag` — that's the dispatcher contract from agent-assembly's `notify-downstream`. Removing it would break coordinated releases.
* `publish.outputs.tag` alias mirroring `binary_source_tag` — kept for the `version-docs` job which still reads `needs.publish.outputs.tag`. AAASM-2855 refactors version-docs to use the explicit new outputs, then this alias can be removed.