### PR TITLE
[AAASM-2854] ♻️ (release-node): Gate runtime sub-package publish on publish_mode (SDK-only hotfix mode)

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -181,6 +181,7 @@ jobs:
           ls -la bin-staging/
 
       - name: Stage runtime binaries into runtime-* sub-packages
+        if: steps.tag.outputs.publish_mode == 'all'
         run: |
           set -euo pipefail
           # Map Rust target triples to the matching node-sdk runtime

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -267,6 +267,7 @@ jobs:
       # phase produces "no matching version" warnings during the brief
       # window before all sub-packages land on the registry.
       - name: Publish 4 runtime sub-packages
+        if: steps.tag.outputs.publish_mode == 'all'
         env:
           NPM_CONFIG_PROVENANCE: "true"
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -163,6 +163,7 @@ jobs:
           NODE
 
       - name: Download aasm binaries from agent-assembly release
+        if: steps.tag.outputs.publish_mode == 'all'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.tag.outputs.binary_source_tag }}

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -205,6 +205,25 @@ jobs:
           # up in the published tarball alongside the real binary.
           rm -f packages/*/bin/.gitkeep
 
+      # AAASM-2854: main-only mode — bump ONLY the root package.json's version
+      # field. Leaves optionalDependencies['@agent-assembly/runtime-*'] pins
+      # untouched so the published SDK keeps resolving to the existing runtime
+      # sub-packages on npm.
+      - name: Bump main SDK version only (main-only mode)
+        if: steps.tag.outputs.publish_mode == 'main-only'
+        env:
+          VERSION: ${{ steps.tag.outputs.npm_version }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require("node:fs");
+          const version = process.env.VERSION;
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          pkg.version = version;
+          fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+          console.log(`bumped package.json -> ${version}`);
+          NODE
+
       - name: Bump versions across the 5 packages
         env:
           VERSION: ${{ steps.tag.outputs.npm_version }}

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -58,6 +58,7 @@ jobs:
       tag: ${{ steps.tag.outputs.binary_source_tag }}
       binary_source_tag: ${{ steps.tag.outputs.binary_source_tag }}
       npm_version: ${{ steps.tag.outputs.npm_version }}
+      publish_mode: ${{ steps.tag.outputs.publish_mode }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v4.2.2
 

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -227,6 +227,7 @@ jobs:
           NODE
 
       - name: Bump versions across the 5 packages
+        if: steps.tag.outputs.publish_mode == 'all'
         env:
           VERSION: ${{ steps.tag.outputs.npm_version }}
         run: |

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -115,9 +115,11 @@ jobs:
             echo "::error::npm_version '$npm_version' does not match X.Y.Z semver pattern (must NOT include leading v)"
             exit 1
           fi
-          echo "binary_source_tag=${binary_source_tag}" >> "$GITHUB_OUTPUT"
-          echo "npm_version=${npm_version}" >> "$GITHUB_OUTPUT"
-          echo "publish_mode=${publish_mode}" >> "$GITHUB_OUTPUT"
+          {
+            echo "binary_source_tag=${binary_source_tag}"
+            echo "npm_version=${npm_version}"
+            echo "publish_mode=${publish_mode}"
+          } >> "$GITHUB_OUTPUT"
           echo "Resolved binary_source_tag=${binary_source_tag} npm_version=${npm_version} publish_mode=${publish_mode}"
 
       # AAASM-2854: Pre-flight gate for main-only mode. The SDK hotfix path

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -314,6 +314,12 @@ jobs:
   version-docs:
     name: Cut docs version snapshot and repoint channels
     needs: publish
+    # AAASM-2854: skip on main-only because today this job cuts a snapshot
+    # labelled by publish.outputs.tag (= binary_source_tag), which collides
+    # with the prior coordinated release's snapshot. AAASM-2855 refactors
+    # version-docs to use npm_version (distinct per main-only release) and
+    # will drop this gate.
+    if: needs.publish.outputs.publish_mode == 'all'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -79,6 +79,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           DISPATCH_BINARY_TAG: ${{ inputs.binary_source_tag }}
           DISPATCH_NPM_VERSION: ${{ inputs.npm_version }}
+          DISPATCH_PUBLISH_MODE: ${{ inputs.publish_mode }}
           DISPATCH_PAYLOAD_TAG: ${{ github.event.client_payload.release_tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -93,10 +94,14 @@ jobs:
               echo "::notice::binary_source_tag omitted; defaulting to latest agent-assembly release: $binary_source_tag"
             fi
             npm_version="$DISPATCH_NPM_VERSION"
+            publish_mode="$DISPATCH_PUBLISH_MODE"
           elif [[ "$EVENT_NAME" == "repository_dispatch" ]]; then
             # Coordinated release path. Both come from the same dispatched tag.
+            # publish_mode is hard-coded to 'all' — coordinated releases always
+            # publish the full 5-package set.
             binary_source_tag="$DISPATCH_PAYLOAD_TAG"
             npm_version="${DISPATCH_PAYLOAD_TAG#v}"
+            publish_mode="all"
           else
             echo "::error::unexpected event_name '$EVENT_NAME' — release-node should only fire on repository_dispatch or workflow_dispatch"
             exit 1
@@ -111,7 +116,8 @@ jobs:
           fi
           echo "binary_source_tag=${binary_source_tag}" >> "$GITHUB_OUTPUT"
           echo "npm_version=${npm_version}" >> "$GITHUB_OUTPUT"
-          echo "Resolved binary_source_tag=${binary_source_tag} npm_version=${npm_version}"
+          echo "publish_mode=${publish_mode}" >> "$GITHUB_OUTPUT"
+          echo "Resolved binary_source_tag=${binary_source_tag} npm_version=${npm_version} publish_mode=${publish_mode}"
 
       - name: Download aasm binaries from agent-assembly release
         env:

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -120,6 +120,48 @@ jobs:
           echo "publish_mode=${publish_mode}" >> "$GITHUB_OUTPUT"
           echo "Resolved binary_source_tag=${binary_source_tag} npm_version=${npm_version} publish_mode=${publish_mode}"
 
+      # AAASM-2854: Pre-flight gate for main-only mode. The SDK hotfix path
+      # reuses the @agent-assembly/runtime-* sub-packages already on npm
+      # (their versions pinned in this repo's package.json optionalDependencies).
+      # If any of those pinned versions does not exist on npm — e.g. operator
+      # forgot to publish them, or the pin points at a future release — fail
+      # fast here rather than ship a broken main SDK that resolves to nothing
+      # at install time.
+      - name: Pre-flight verify runtime sub-packages exist on npm
+        if: steps.tag.outputs.publish_mode == 'main-only'
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require("node:fs");
+          const { execSync } = require("node:child_process");
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          const opt = pkg.optionalDependencies ?? {};
+          const runtimePkgs = Object.entries(opt).filter(([name]) =>
+            name.startsWith("@agent-assembly/runtime-"),
+          );
+          if (runtimePkgs.length === 0) {
+            console.error(
+              "::error::no @agent-assembly/runtime-* entries in optionalDependencies — " +
+              "main-only mode requires existing runtime sub-packages to reuse",
+            );
+            process.exit(1);
+          }
+          let failed = false;
+          for (const [name, version] of runtimePkgs) {
+            try {
+              execSync(`npm view ${name}@${version} version`, { stdio: "pipe" });
+              console.log(`OK: ${name}@${version} exists on npm`);
+            } catch {
+              console.error(
+                `::error::main-only publish blocked — ${name}@${version} is not on npm. ` +
+                `Use publish_mode=all to publish the runtime sub-packages alongside the SDK.`,
+              );
+              failed = true;
+            }
+          }
+          if (failed) process.exit(1);
+          NODE
+
       - name: Download aasm binaries from agent-assembly release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Wire the \`publish_mode\` input added in AAASM-2852 through the publish pipeline. When \`publish_mode == 'main-only'\`, the workflow now skips the runtime sub-package version-bump + publish steps and instead bumps only the root \`package.json\`'s \`version\` field — producing an SDK-only hotfix on npm that reuses the already-published \`@agent-assembly/runtime-*\` sub-packages via the existing \`optionalDependencies\` pins.

    Adds a pre-flight step that verifies every \`optionalDependencies['@agent-assembly/runtime-*']\` version currently exists on npm, failing fast with a clear error message if any pin is stale or wrong.

    Third of the AAASM-2851 implementation chain. AAASM-2855 will refactor the \`version-docs\` job to use \`npm_version\` so main-only docs snapshots become possible — until then, this PR gates version-docs on \`publish_mode == 'all'\` so the main-only hotfix path produces a clean npm publish without a colliding docs snapshot.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: **AAASM-2854** (Subtask)
    * Relative task IDs:
        * [x] Parent Story: AAASM-2851
        * [x] Predecessor: AAASM-2852 (schema, merged in [#111](https://github.com/ai-agent-assembly/node-sdk/pull/111))
        * [x] Predecessor: AAASM-2853 (Resolve refactor, merged in [#112](https://github.com/ai-agent-assembly/node-sdk/pull/112))
        * [ ] Next subtask: AAASM-2855 (version-docs uses npm_version + binary_source_tag)
    * Relative PRs:
        * [#111](https://github.com/ai-agent-assembly/node-sdk/pull/111), [#112](https://github.com/ai-agent-assembly/node-sdk/pull/112)

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    **As-is** — every dispatch runs the full 5-package publish pipeline. Download binaries → Stage → Bump 5 packages → Build → Publish 4 runtime → Publish main SDK → cut docs snapshot. Operators cannot ship a JS-only fix without re-running the entire pipeline.

    **To-be (after this PR) — when \`publish_mode == 'main-only'\`**:

    ```text
    Resolve release tag    (emits publish_mode='main-only')
    └─ Pre-flight verify runtime sub-packages exist on npm  ← NEW
    └─ Bump main SDK version only (root package.json)       ← NEW
    └─ Build main SDK
    └─ Publish main @agent-assembly/sdk

    [SKIPPED] Download aasm binaries from agent-assembly release
    [SKIPPED] Stage runtime binaries into runtime-* sub-packages
    [SKIPPED] Bump versions across the 5 packages
    [SKIPPED] Publish 4 runtime sub-packages
    [SKIPPED] version-docs job (deferred to AAASM-2855)
    ```

    **To-be — when \`publish_mode == 'all'\`** (the default, plus all \`repository_dispatch\` coordinated releases): identical to today's behavior. Every gate evaluates to true. Pre-flight and main-only Bump are skipped.

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [x] ♻️ Refactoring something
    * [ ] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [ ] 🤖 Framework hooks
    * [ ] 🫀 Data model and types
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
        * [ ] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
    * [ ] 📚 Documentation
* Additional description:
    Workflow-only change. \`repository_dispatch\` (the coordinated release flow) hard-codes \`publish_mode = 'all'\` in the Resolve step so every gate passes — regression-safe. \`workflow_dispatch\` with default \`publish_mode = 'all'\` matches today's behavior.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

10 atomic commits (per project granularity rule):

**Phase 1 — Resolve + outputs surface** (2 commits):

* \`da9e9a5\` `♻️ (release-node): Add publish_mode output to Resolve step`
* \`3eeefcd\` `♻️ (release-node): Expose publish_mode on publish job outputs`

**Phase 2 — New main-only steps** (2 commits):

* \`8e97711\` `✨ (release-node): Add pre-flight check that runtime sub-packages exist on npm`
* \`23348bd\` `✨ (release-node): Add main-only Bump step that touches only the root package.json`

**Phase 3 — Gate existing all-mode steps** (4 commits):

* \`401e399\` `♻️ (release-node): Gate Download aasm binaries step on publish_mode == 'all'`
* \`f109b10\` `♻️ (release-node): Gate Stage runtime binaries step on publish_mode == 'all'`
* \`3359586\` `♻️ (release-node): Gate Bump versions across the 5 packages step on publish_mode == 'all'`
* \`fd6c39f\` `♻️ (release-node): Gate Publish 4 runtime sub-packages step on publish_mode == 'all'`

**Phase 4 — Cross-job gate + lint** (2 commits):

* \`8709b0e\` `♻️ (release-node): Gate version-docs job on publish_mode == 'all'`
* \`cd4c14b\` `🚨 (release-node): Batch GITHUB_OUTPUT redirects to silence SC2129`

### Acceptance criteria coverage

| AC (from AAASM-2854) | Status |
|---|---|
| `publish_mode = all` (or default): existing 5-package publish flow runs unchanged | ✅ Every new `if:` clause evaluates to true on `all`. Regression-safe. |
| `publish_mode = main-only`: runtime-sub-package version-bump + publish steps are skipped | ✅ All 4 existing steps gated on `'all'`. Visible as "skipped" in the run summary. |
| `publish_mode = main-only`: pre-flight check fails fast if any optionalDependencies runtime-* doesn't exist on npm | ✅ New pre-flight step iterates the pins, runs `npm view`, exits 1 with the offending name + version in the error. |
| `publish_mode = main-only`: only `@agent-assembly/sdk` ends up on npm at `npm_version`; no runtime-* versions change | ✅ The 4 runtime steps are skipped; the main-only Bump step touches only the root `package.json`; the existing "Publish main SDK" step runs unchanged. |

### Self-verification

* `actionlint .github/workflows/release-node.yml` → clean (empty output)
* `yaml.safe_load` confirms 6 `if:`-gated steps + the cross-job gate on `version-docs`, all reading from the unified `publish_mode` output
* No TS / JS / Rust touched → pre-commit hooks (eslint / prettier / vitest) trivially pass

### Intentional handoff to AAASM-2855

The `version-docs` job is skipped in main-only mode for now because today's snapshot label (`publish.outputs.tag` mirroring `binary_source_tag`) would collide with the prior coordinated release's snapshot. AAASM-2855 refactors `version-docs` to use `npm_version` (distinct per main-only release like `0.0.1-alpha.8.1`) and drops this gate. Until then, main-only mode produces a clean npm publish without trying to cut docs.