### PR TITLE
[AAASM-2855] ♻️ (release-node): Refactor version-docs job to use npm_version + binary_source_tag

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -34,7 +34,7 @@ on:
         required: false
         type: string
       publish_mode:
-        description: "Which packages to publish. 'all' = main SDK + 4 runtime sub-packages (coordinated release). 'main-only' = only @agent-assembly/sdk (SDK hotfix mode). AAASM-2852: accepted but unused until AAASM-2854 gates the publish steps."
+        description: "Which packages to publish. 'all' = main SDK + 4 runtime sub-packages (coordinated release). 'main-only' = only @agent-assembly/sdk (SDK hotfix mode)."
         required: true
         type: choice
         default: "all"

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -380,7 +380,7 @@ jobs:
             --base master \
             --head "$branch" \
             --title "📸 (docs): Cut docs snapshot for ${NPM_VERSION}" \
-            --body "Automated docs version snapshot cut by release-node.yml after the npm publish of \`${RELEASE_TAG}\`. Freezes \`docs/\` into \`website/versioned_docs/version-${RELEASE_TAG}\` and repoints the version channels (labels, banners, \`lastVersion\`)."
+            --body "Automated docs version snapshot cut by release-node.yml after the npm publish of \`${NPM_VERSION}\`. Freezes \`docs/\` into \`website/versioned_docs/version-${NPM_VERSION}\` and repoints the version channels (labels, banners, \`lastVersion\`).%0A%0ABundled aasm: \`${BINARY_SOURCE_TAG}\` (the agent-assembly Release whose per-platform binaries were bundled into the @agent-assembly/runtime-* sub-packages for this npm publish)."
 
       # AAASM-2794: self-approve + enable auto-merge so the snapshot lands on
       # master without a per-release manual merge. The approve step MUST use a

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -51,11 +51,6 @@ jobs:
     name: Publish @agent-assembly/sdk + 4 runtime sub-packages to npm
     runs-on: ubuntu-latest
     outputs:
-      # AAASM-2853: tag mirrors binary_source_tag for back-compat with the
-      # version-docs job. AAASM-2855 refactors version-docs to use
-      # binary_source_tag + npm_version directly, after which this alias
-      # can be removed.
-      tag: ${{ steps.tag.outputs.binary_source_tag }}
       binary_source_tag: ${{ steps.tag.outputs.binary_source_tag }}
       npm_version: ${{ steps.tag.outputs.npm_version }}
       publish_mode: ${{ steps.tag.outputs.publish_mode }}

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -316,12 +316,6 @@ jobs:
   version-docs:
     name: Cut docs version snapshot and repoint channels
     needs: publish
-    # AAASM-2854: skip on main-only because today this job cuts a snapshot
-    # labelled by publish.outputs.tag (= binary_source_tag), which collides
-    # with the prior coordinated release's snapshot. AAASM-2855 refactors
-    # version-docs to use npm_version (distinct per main-only release) and
-    # will drop this gate.
-    if: needs.publish.outputs.publish_mode == 'all'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -327,9 +327,13 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      # `publish` resolved + validated this tag against the v*.*.* semver
-      # pattern, so it is safe to use below.
-      RELEASE_TAG: ${{ needs.publish.outputs.tag }}
+      # `publish` resolved + validated these against semver, so they are safe
+      # to use below. NPM_VERSION drives the Docusaurus snapshot label (it is
+      # what users see in the dropdown + URL); BINARY_SOURCE_TAG is carried
+      # purely as metadata so the docs-version PR records which agent-assembly
+      # Release the bundled aasm binaries came from.
+      NPM_VERSION: ${{ needs.publish.outputs.npm_version }}
+      BINARY_SOURCE_TAG: ${{ needs.publish.outputs.binary_source_tag }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v4.2.2
         with:

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -357,7 +357,7 @@ jobs:
         working-directory: website
 
       - name: Cut docs snapshot for the release tag
-        run: pnpm docusaurus docs:version "$RELEASE_TAG"
+        run: pnpm docusaurus docs:version "$NPM_VERSION"
         working-directory: website
 
       - name: Repoint version channels (labels, banners, lastVersion)
@@ -368,18 +368,18 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          branch="docs/version-${RELEASE_TAG}"
+          branch="docs/version-${NPM_VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$branch"
           git add website/versioned_docs website/versioned_sidebars \
             website/versions.json website/versionChannels.json
-          git commit -m "📸 (docs): Cut docs snapshot for ${RELEASE_TAG} and repoint channels"
+          git commit -m "📸 (docs): Cut docs snapshot for ${NPM_VERSION} and repoint channels"
           git push origin "$branch"
           gh pr create \
             --base master \
             --head "$branch" \
-            --title "📸 (docs): Cut docs snapshot for ${RELEASE_TAG}" \
+            --title "📸 (docs): Cut docs snapshot for ${NPM_VERSION}" \
             --body "Automated docs version snapshot cut by release-node.yml after the npm publish of \`${RELEASE_TAG}\`. Freezes \`docs/\` into \`website/versioned_docs/version-${RELEASE_TAG}\` and repoints the version channels (labels, banners, \`lastVersion\`)."
 
       # AAASM-2794: self-approve + enable auto-merge so the snapshot lands on
@@ -394,7 +394,7 @@ jobs:
           GH_TOKEN: ${{ secrets.DOCS_BOT_PAT }}
         run: |
           set -euo pipefail
-          branch="docs/version-${RELEASE_TAG}"
+          branch="docs/version-${NPM_VERSION}"
           gh pr review "$branch" --approve --body "Auto-approving deterministic docs snapshot (AAASM-2794)."
 
       - name: Enable auto-merge on docs-version PR
@@ -402,5 +402,5 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          branch="docs/version-${RELEASE_TAG}"
+          branch="docs/version-${NPM_VERSION}"
           gh pr merge "$branch" --auto --squash --delete-branch

--- a/scripts/version-channels.mjs
+++ b/scripts/version-channels.mjs
@@ -36,8 +36,13 @@ import {readFileSync, writeFileSync, existsSync} from "node:fs";
 import {fileURLToPath} from "node:url";
 import {dirname, join} from "node:path";
 
-const STABLE_RE = /^v\d+\.\d+\.\d+$/;
-const PRERELEASE_RE = /^v\d+\.\d+\.\d+-.+$/;
+// Tags may be either `vX.Y.Z[-pre]` (the historical agent-assembly
+// release-tag form used before AAASM-2855) or `X.Y.Z[-pre]` (the npm
+// version form adopted by AAASM-2855's version-docs refactor). Make the
+// leading `v` optional so both representations classify into the same
+// channel.
+const STABLE_RE = /^v?\d+\.\d+\.\d+$/;
+const PRERELEASE_RE = /^v?\d+\.\d+\.\d+-.+$/;
 
 export function channelOf(tag) {
   if (STABLE_RE.test(tag)) return "stable";

--- a/scripts/version-channels.test.mjs
+++ b/scripts/version-channels.test.mjs
@@ -44,6 +44,15 @@ test("channelOf classifies stable vs pre-release", () => {
   assert.equal(channelOf("v0.1.0-rc.1"), "pre-release");
 });
 
+// AAASM-2855: version-docs now labels snapshots by the npm version
+// (`X.Y.Z[-pre]`, no leading `v`) instead of the agent-assembly release
+// tag (`vX.Y.Z[-pre]`). Both forms must classify into the same channel.
+test("channelOf handles npm-version form (no leading v)", () => {
+  assert.equal(channelOf("0.0.2"), "stable");
+  assert.equal(channelOf("0.1.0-rc.1"), "pre-release");
+  assert.equal(channelOf("0.0.1-alpha.8.1"), "pre-release");
+});
+
 // Scenario 1: pre-releases ahead of the only stable -> pre-release shown.
 test("scenario 1: pre-release ahead of stable is the headline channel", () => {
   const snapshots = [


### PR DESCRIPTION
## _Target_

Refactor `release-node.yml`'s `version-docs` job to consume the new `publish.outputs.npm_version` + `publish.outputs.binary_source_tag` outputs (added in AAASM-2852/2853), drop the back-compat scaffolding that AAASM-2853 and AAASM-2854 left in place, and update `scripts/version-channels.mjs` so it correctly classifies npm-version-form snapshot labels.

* ### Task summary:

    * Switch `version-docs.env` from `RELEASE_TAG` (mirror of the old `publish.outputs.tag` alias) to `NPM_VERSION` + `BINARY_SOURCE_TAG`, sourced directly from the new `publish.outputs` keys.
    * Move every `version-docs` step body — Docusaurus `docs:version` label, branch name, commit subject, PR title, PR body, self-approve + auto-merge step branch names — onto `$NPM_VERSION`. The cut snapshot now lives at `website/versioned_docs/version-{npm_version}/` (e.g. `version-0.0.1-alpha.8.1/`) and the docs PR branch is `docs/version-{npm_version}`.
    * Preserve `BINARY_SOURCE_TAG` as visible metadata: the docs-version PR body now appends a `Bundled aasm: ${BINARY_SOURCE_TAG} (…)` line so the snapshot's permanent record links back to the agent-assembly Release the bundled runtime binaries came from.
    * Drop the `if: needs.publish.outputs.publish_mode == 'all'` gate on the `version-docs` job — `npm_version` is always distinct per main-only release, so the snapshot-collision concern that motivated the gate (AAASM-2854) is gone.
    * Drop the `publish.outputs.tag` back-compat alias and its leading explanatory comment (no consumer left).
    * Drop the stale `"AAASM-2852: accepted but unused until AAASM-2854 gates the publish steps."` caveat from the `publish_mode` workflow_dispatch input description (AAASM-2854 has merged).
    * Relax `scripts/version-channels.mjs` so `STABLE_RE` + `PRERELEASE_RE` accept an optional leading `v`. Otherwise an npm-version-form label (no `v`) classifies as `other` and the snapshot gets demoted to an `unmaintained`-bannered archived version. Adds a `channelOf` regression test for the npm-version form.

* ### Task tickets:

    * Task ID: AAASM-2855.
    * Relative task IDs:
        * [x] AAASM-2851 (parent Story).
        * [x] AAASM-2852 (added `npm_version` + `binary_source_tag` + `publish_mode` inputs).
        * [x] AAASM-2853 (added `publish.outputs.npm_version` + `binary_source_tag`).
        * [x] AAASM-2854 (added `publish_mode` output + gated runtime sub-package steps).
    * Relative PRs:
        * https://github.com/ai-agent-assembly/node-sdk/pull/111 (AAASM-2852).
        * https://github.com/ai-agent-assembly/node-sdk/pull/112 (AAASM-2853).
        * https://github.com/ai-agent-assembly/node-sdk/pull/113 (AAASM-2854).

* ### Key point change (optional):

    **`version-docs.env` (as-is → to-be)**

    ```yaml
    # as-is (post-AAASM-2853)
    env:
      RELEASE_TAG: ${{ needs.publish.outputs.tag }}  # alias = binary_source_tag

    # to-be
    env:
      NPM_VERSION: ${{ needs.publish.outputs.npm_version }}
      BINARY_SOURCE_TAG: ${{ needs.publish.outputs.binary_source_tag }}
    ```

    **`publish.outputs` (as-is → to-be)**

    ```yaml
    # as-is (post-AAASM-2853)
    outputs:
      tag: ${{ steps.tag.outputs.binary_source_tag }}  # back-compat alias
      binary_source_tag: ${{ steps.tag.outputs.binary_source_tag }}
      npm_version: ${{ steps.tag.outputs.npm_version }}
      publish_mode: ${{ steps.tag.outputs.publish_mode }}

    # to-be
    outputs:
      binary_source_tag: ${{ steps.tag.outputs.binary_source_tag }}
      npm_version: ${{ steps.tag.outputs.npm_version }}
      publish_mode: ${{ steps.tag.outputs.publish_mode }}
    ```

    **Snapshot directory layout (as-is → to-be)**

    * as-is: `website/versioned_docs/version-v0.0.1-alpha.8/` (binary_source_tag, with leading `v`)
    * to-be: `website/versioned_docs/version-0.0.1-alpha.8.1/` (npm_version, no leading `v`)

    **Coordinated `repository_dispatch` path back-compat note**

    On the coordinated release path the Resolve step sets `npm_version = binary_source_tag.lstrip('v')`, so the snapshot label is the same content as before minus the leading `v`. Concretely a coordinated release of `v0.0.1-alpha.9` cut a snapshot at `version-v0.0.1-alpha.9/` before this PR and will cut `version-0.0.1-alpha.9/` after. `versions.json` + `versionChannels.json` are regenerated each run, so the older `vX.Y.Z`-form entries continue to coexist with the new `X.Y.Z`-form entries — the relaxed `version-channels.mjs` regex classifies both forms identically.

## _Effecting Scope_

* Action Types:
    * [x] ♻️ Refactoring something
    * [x] 🚮 Removing something
* Scopes:
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
* Additional description:

    No SDK runtime code touched. Single workflow file (`release-node.yml`) + one docs helper script (`scripts/version-channels.mjs`) + its sibling test.

## _Description_

Seven granular commits, each one logical concern:

1. `152bf94 ♻️ (release-node): Switch version-docs env from RELEASE_TAG to NPM_VERSION + BINARY_SOURCE_TAG`
2. `6ff751c ♻️ (release-node): Use NPM_VERSION for Docusaurus snapshot label, branch, PR title, commit`
3. `08d662c 📝 (release-node): Add Bundled aasm metadata line to docs-version PR body`
4. `1e54400 🗑️ (release-node): Drop version-docs publish_mode == 'all' gate`
5. `d115283 🗑️ (release-node): Drop publish.outputs.tag back-compat alias`
6. `e189ef2 📝 (release-node): Drop "accepted but unused" caveat from publish_mode description`
7. `8ab39f0 ♻️ (docs): Make version-channels.mjs accept tags without leading v`

### Acceptance-criteria coverage

| AC (from AAASM-2855) | Status |
|---|---|
| `version-docs` snapshot directory now ends up at `website/versioned_docs/version-{npm_version}/` | ✅ commit 2 |
| `versions.json` + `versionChannels.json` get the npm version, not the binary source tag (via the docusaurus CLI + the regex-relaxed channel script) | ✅ commits 2 + 7 |
| `binary_source_tag` preserved somewhere visible in the snapshot metadata (the docs-version PR body's `Bundled aasm:` line) | ✅ commit 3 |
| `publish.outputs.tag` no longer declared anywhere | ✅ commit 5 (verified with `yaml.safe_load`: `publish outputs: ['binary_source_tag', 'npm_version', 'publish_mode']`) |
| `version-docs` job no longer has the `if: needs.publish.outputs.publish_mode == 'all'` gate | ✅ commit 4 (verified with `yaml.safe_load`: `version-docs if: (none)`) |
| `publish_mode` input description no longer mentions "AAASM-2852: accepted but unused" | ✅ commit 6 |
| Coordinated `repository_dispatch` releases still produce a valid snapshot | ✅ documented above — the only visible difference is the missing leading `v` in the snapshot directory name; the relaxed channel regex classifies both forms identically |

### Local verification

* `actionlint .github/workflows/release-node.yml` — clean exit (actionlint 1.7.12).
* `python3 -c "import yaml; ..."` — confirms `publish outputs: ['binary_source_tag', 'npm_version', 'publish_mode']` and `version-docs if: (none)`.
* `node --test scripts/version-channels.test.mjs` — 10/10 tests pass (including the new `channelOf handles npm-version form (no leading v)` regression test).