### PR TITLE
[AAASM-2858] 📝 (release): Document SDK-only hotfix mode in release runbook

### DIFF
--- a/docs/release/RUNBOOK.md
+++ b/docs/release/RUNBOOK.md
@@ -56,7 +56,82 @@ Use coordinated releases whenever the change touches the `aasm` binary,
 any shared Rust crate, or a wire-protocol-level surface that spans the
 SDK and the sidecar. This is the normal product-line cadence.
 
-## 2. Verification
+## 2. SDK-only hotfix mode
+
+If only the JavaScript surface of `@agent-assembly/sdk` needs a fix (the
+`aasm` sidecar binary and the runtime sub-packages are healthy), you can
+publish a new SDK version **without** cutting a new agent-assembly tag.
+
+### When to use
+
+- A bug exists only in the TypeScript / JavaScript code in `src/`.
+- The bundled `aasm` binary (in the 4 runtime sub-packages) is correct.
+- You want to ship the fix fast without re-publishing 14 Rust crates,
+  rebuilding Docker images, opening a Homebrew tap PR, etc.
+
+### How to dispatch
+
+```bash
+gh workflow run release-node.yml \
+  --repo ai-agent-assembly/node-sdk \
+  --ref master \
+  -f npm_version=0.0.1-alpha.8.1 \
+  -f binary_source_tag=v0.0.1-alpha.8 \
+  -f publish_mode=main-only
+```
+
+What happens:
+
+1. The workflow runs against master.
+2. `npm_version` (e.g. `0.0.1-alpha.8.1`) is what gets stamped on
+   `@agent-assembly/sdk`'s `package.json`.
+3. `binary_source_tag` (e.g. `v0.0.1-alpha.8`) is the agent-assembly
+   GitHub Release whose `aasm-*` binaries are bundled — but in
+   `main-only` mode they're not actually downloaded because no runtime
+   sub-package publishes. The input is still required so the pre-flight
+   check can verify the matching `@agent-assembly/runtime-*` already
+   exist on npm at that version.
+4. `publish_mode=main-only` causes the workflow to **skip** the 4 runtime
+   sub-package publish steps. The 4 runtime packages stay at their
+   existing `0.0.1-alpha.8` versions on npm.
+5. Only `@agent-assembly/sdk@0.0.1-alpha.8.1` lands on npm.
+6. Users running `npm install @agent-assembly/sdk@0.0.1-alpha.8.1` get the
+   new SDK; their `optionalDependencies` resolve to the existing
+   `@agent-assembly/runtime-*@0.0.1-alpha.8` on npm.
+
+### When NOT to use (use the coordinated agent-assembly release instead)
+
+- A bug exists in the `aasm` binary or any shared Rust crate.
+- New features that span SDK + binary (e.g. a new gRPC method).
+- Routine version bumps that should ship across the whole product line.
+
+### Version naming convention
+
+Use a `.N` suffix on the parent SDK version: `0.0.1-alpha.8.1`,
+`0.0.1-alpha.8.2`, etc. Reserve `0.0.1-alpha.9` (and other clean
+`-alpha.N` slots) for coordinated agent-assembly releases. The `.N`
+suffix is a valid semver pre-release identifier and sorts after the bare
+`0.0.1-alpha.8` so existing pin-to-exact installs stay on the parent
+version until they explicitly upgrade.
+
+### Pre-flight checks
+
+The workflow runs a pre-flight check before publishing that calls
+`npm view @agent-assembly/runtime-<platform>@<binary_source_tag-stripped-v>`
+for each of the 4 sub-packages. This verifies that the
+`optionalDependencies['@agent-assembly/runtime-*']` versions currently
+listed in `package.json` actually exist on npm. If they don't (e.g.
+you're trying to publish a main-only update with `optionalDependencies`
+pointing at a future runtime version that hasn't been published yet),
+the workflow fails fast before touching the `@agent-assembly/sdk`
+publish step.
+
+The pre-flight also confirms that `npm_version` itself does **not** yet
+exist on the `@agent-assembly/sdk` registry entry — npm publishes are
+effectively immutable within minutes of upload, so re-publishing the
+same version is treated as a fatal user error rather than a no-op.
+
+## 3. Verification
 
 After the workflow completes, verify on the npm registry:
 
@@ -73,7 +148,11 @@ for plat in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
 done
 ```
 
-## 3. Recovery — when a publish fails
+For SDK-only hotfix runs, only the first command should return a value;
+the four runtime sub-packages stay at their previous `binary_source_tag`
+version on npm.
+
+## 4. Recovery — when a publish fails
 
 npm publishes are effectively immutable. A failed publish that uploaded
 partial state (e.g. some runtime sub-packages but not `@agent-assembly/sdk`)
@@ -81,3 +160,9 @@ is recovered by bumping `npm_version` to the next available slot and
 re-running the workflow with the same `binary_source_tag`. Do not attempt
 `npm unpublish` — the 72-hour grace window is not a contract and other
 operators may already be depending on the partial state.
+
+If the failure is in the pre-flight (e.g. the runtime sub-packages don't
+yet exist on npm at the expected `binary_source_tag` version), fix the
+underlying coordination problem first — usually that means running the
+coordinated release for `binary_source_tag` before attempting the
+SDK-only hotfix.

--- a/docs/release/RUNBOOK.md
+++ b/docs/release/RUNBOOK.md
@@ -1,0 +1,83 @@
+# node-sdk release runbook
+
+> Step-by-step procedure for cutting a `@agent-assembly/sdk` release.
+> Companion to `agent-assembly/docs/release/RUNBOOK.md` for the coordinated
+> product-line release path. Tracked under AAASM-2851 (decoupled release
+> story) and AAASM-2858 (this runbook).
+
+This runbook assumes the operator has push rights to
+`AI-agent-assembly/node-sdk` and that the five `@agent-assembly/*` npm
+packages have `@agent-assembly/release-bot` configured as their npm
+Trusted Publisher with the node-sdk repo + `release-node.yml` workflow path.
+
+The node-sdk releases two flavours of artifact in one workflow run:
+
+| Package | Contents |
+| --- | --- |
+| `@agent-assembly/sdk` | TypeScript / JavaScript source (ESM + CJS dual build) |
+| `@agent-assembly/runtime-{linux-x64,linux-arm64,darwin-x64,darwin-arm64}` | Per-platform `aasm` sidecar binary, downloaded from an agent-assembly GitHub Release |
+
+The `@agent-assembly/sdk` package declares the 4 runtime sub-packages in
+`optionalDependencies`. npm resolves the matching platform at install time.
+
+---
+
+## 1. Coordinated release (the default path)
+
+The coordinated release publishes all 5 packages at the same version, in
+lock-step with an agent-assembly tag. This is the path that fires
+automatically when `agent-assembly`'s `release.yml` sends a
+`repository_dispatch` event after a tag push — see
+`agent-assembly/docs/release/RUNBOOK.md` section 3 for the dispatcher
+contract. To dispatch manually:
+
+```bash
+gh workflow run release-node.yml \
+  --repo ai-agent-assembly/node-sdk \
+  --ref master \
+  -f npm_version=0.0.1-alpha.9 \
+  -f binary_source_tag=v0.0.1-alpha.9 \
+  -f publish_mode=all
+```
+
+What happens:
+
+1. The workflow checks out master and stamps `npm_version` on the root
+   `package.json`'s `version` field and on each `optionalDependencies`
+   entry pointing at `@agent-assembly/runtime-*`.
+2. The 4 platform `aasm-*.tar.gz` binaries from the
+   `binary_source_tag` agent-assembly GitHub Release are downloaded and
+   staged into each runtime sub-package.
+3. Each runtime sub-package is published to npm at `npm_version`.
+4. The main `@agent-assembly/sdk` package is built (ESM + CJS) and published
+   to npm at `npm_version`.
+
+Use coordinated releases whenever the change touches the `aasm` binary,
+any shared Rust crate, or a wire-protocol-level surface that spans the
+SDK and the sidecar. This is the normal product-line cadence.
+
+## 2. Verification
+
+After the workflow completes, verify on the npm registry:
+
+```bash
+npm view @agent-assembly/sdk@<npm_version> version
+npm view @agent-assembly/sdk@<npm_version> optionalDependencies
+```
+
+For coordinated releases, also verify each runtime sub-package landed:
+
+```bash
+for plat in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
+  npm view "@agent-assembly/runtime-${plat}@<npm_version>" version
+done
+```
+
+## 3. Recovery — when a publish fails
+
+npm publishes are effectively immutable. A failed publish that uploaded
+partial state (e.g. some runtime sub-packages but not `@agent-assembly/sdk`)
+is recovered by bumping `npm_version` to the next available slot and
+re-running the workflow with the same `binary_source_tag`. Do not attempt
+`npm unpublish` — the 72-hour grace window is not a contract and other
+operators may already be depending on the partial state.


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Adds a new `docs/release/RUNBOOK.md` to node-sdk that documents both the coordinated release path and the SDK-only hotfix mode landed in AAASM-2852..AAASM-2855. Operators now have a self-contained per-repo runbook for the decoupled `publish_mode=main-only` flow that ships `@agent-assembly/sdk` without re-cutting agent-assembly.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: AAASM-2858 (subtask of Story AAASM-2851 — decouple SDK releases from agent-assembly core).
    * Relative task IDs:
        * [x] AAASM-2851 — parent story
        * [x] AAASM-2852..AAASM-2855 — node-sdk decoupled-release implementation (the behavior this runbook documents)
    * Relative PRs:
        * python-sdk symmetric runbook PR — opened in parallel from this ticket
        * agent-assembly cross-link PR — opened in parallel from this ticket

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    Two granular commits:

    1. `📝 (release): Add docs/release/RUNBOOK.md scaffolding for node-sdk` — creates the file with intro, artifact table, coordinated-release section, verification, and recovery.
    2. `📝 (release): Add SDK-only hotfix mode section to node-sdk runbook` — adds the "SDK-only hotfix mode" section (section 2) covering when to use, the exact `gh workflow run` invocation with `npm_version=0.0.1-alpha.8.1` + `binary_source_tag=v0.0.1-alpha.8` + `publish_mode=main-only`, the 6-step walkthrough, when NOT to use, the `.N` semver pre-release suffix version-naming convention, and the `npm view` pre-flight check explanation.

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [ ] 🤖 Framework hooks
    * [ ] 🫀 Data model and types
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
        * [ ] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [ ] 🚀 Building
        * [ ] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
    * [x] 📚 Documentation
* Additional description:

    Docs-only change. No source code, no workflow YAML, no tests touched. Operator-facing artifact for the decoupled SDK release path.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Adds `docs/release/RUNBOOK.md` (170 lines) with four sections:
  1. **Coordinated release (the default path)** — exact `gh workflow run release-node.yml` invocation with `publish_mode=all`, 4-step walkthrough mapping `npm_version` and `binary_source_tag` to where they land.
  2. **SDK-only hotfix mode** — when to use / how to dispatch / 6-step walkthrough / when NOT to use / `.N` semver pre-release version-naming convention / `npm view` pre-flight check explanation.
  3. **Verification** — `npm view` queries for both `@agent-assembly/sdk` and per-platform `@agent-assembly/runtime-*`, with the asymmetry noted for hotfix runs (only the SDK query returns the new version).
  4. **Recovery — when a publish fails** — bump to the next `.N` slot rather than retrying because npm publishes are effectively immutable.

### Acceptance criteria coverage (from AAASM-2858)

* [x] AC1: node-sdk runbook has "SDK-only hotfix mode" section with exact `gh workflow run` invocation, when-to-use/when-not-to-use guidance, version naming, pre-flight check explanation.
* [x] PR bases `master`.
* [x] Granular GitEmoji commits — one scaffolding commit + one hotfix-section commit.

### Verification

* `markdownlint` not configured at repo root; visual inspection passes (no trailing whitespace, fences closed, consistent heading hierarchy).
* `python3 -c "import pathlib; print(pathlib.Path('docs/release/RUNBOOK.md').read_text()[:200])"` — parses as plain text without binary garbage.
* Pre-commit hooks ran clean on both commits (no source files staged → eslint/prettier/vitest skip with "no matching staged files").