### PR TITLE
[AAASM-2864] 📝 (release): Add AAASM-2855 snapshot-label verification to post-release checklist

### DIFF
--- a/docs/release/RUNBOOK.md
+++ b/docs/release/RUNBOOK.md
@@ -152,6 +152,16 @@ For SDK-only hotfix runs, only the first command should return a value;
 the four runtime sub-packages stay at their previous `binary_source_tag`
 version on npm.
 
+### Post-release checks
+
+- [ ] **AAASM-2855 carryover:** verify the docs-version PR's snapshot
+  directory is named `version-<npm_version>` (e.g.
+  `website/versioned_docs/version-0.0.1-alpha.8/`) — **NOT**
+  `version-v0.0.1-alpha.8`. AAASM-2855 intentionally dropped the leading
+  `v` so the snapshot label matches the npm semver; if you see the `v`
+  back, the AAASM-2855 refactor regressed somewhere in the
+  `version-docs` job.
+
 ## 4. Recovery — when a publish fails
 
 npm publishes are effectively immutable. A failed publish that uploaded


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

* ### Task summary:

    Add a one-line post-release verification item to `node-sdk/docs/release/RUNBOOK.md` so the operator catches any regression in AAASM-2855's Docusaurus snapshot-label change (`version-<npm_version>` instead of `version-v<npm_version>`).

* ### Task tickets:

    * Task ID: AAASM-2864.
    * Relative task IDs:
        * [x] AAASM-2855 (origin of the snapshot-label change being guarded).
        * [x] AAASM-2858 (runbook scaffolding this item extends).
        * [x] AAASM-2851 (parent decoupled-release story / follow-up gap source).
    * Relative PRs:
        * #115 (AAASM-2858 — runbook scaffolding, merged).

* ### Key point change (optional):

    Adds a `### Post-release checks` subsection under section `3. Verification` with one checklist item naming AAASM-2855 as the origin so a future operator can trace the why.

## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
* Scopes:
    * [x] 📚 Documentation
* Additional description:
    Pure Markdown addition to the release runbook. No code, workflow, or build change.

## _Description_

* `docs/release/RUNBOOK.md`: add `### Post-release checks` subsection under `3. Verification` with an AAASM-2855 snapshot-label regression check (`version-<npm_version>` not `version-v<npm_version>`).