### PR TITLE
[AAASM-2862] ✨ (release-node): Add dry-run workflow_dispatch input for parity with python-sdk

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -283,7 +283,11 @@ jobs:
       # phase produces "no matching version" warnings during the brief
       # window before all sub-packages land on the registry.
       - name: Publish 4 runtime sub-packages
-        if: steps.tag.outputs.publish_mode == 'all'
+        # AAASM-2862: combine the existing publish_mode gate with a dry_run
+        # gate. workflow_dispatch with dry-run=true must skip every step
+        # that mutates the npm registry; coordinated repository_dispatch
+        # hard-codes dry_run='false' upstream so this stays a no-op there.
+        if: steps.tag.outputs.publish_mode == 'all' && steps.tag.outputs.dry_run != 'true'
         env:
           NPM_CONFIG_PROVENANCE: "true"
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -59,6 +59,7 @@ jobs:
       binary_source_tag: ${{ steps.tag.outputs.binary_source_tag }}
       npm_version: ${{ steps.tag.outputs.npm_version }}
       publish_mode: ${{ steps.tag.outputs.publish_mode }}
+      dry_run: ${{ steps.tag.outputs.dry_run }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v4.2.2
 

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -81,6 +81,7 @@ jobs:
           DISPATCH_BINARY_TAG: ${{ inputs.binary_source_tag }}
           DISPATCH_NPM_VERSION: ${{ inputs.npm_version }}
           DISPATCH_PUBLISH_MODE: ${{ inputs.publish_mode }}
+          DISPATCH_DRY_RUN: ${{ inputs.dry-run }}
           DISPATCH_PAYLOAD_TAG: ${{ github.event.client_payload.release_tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -96,6 +97,11 @@ jobs:
             fi
             npm_version="$DISPATCH_NPM_VERSION"
             publish_mode="$DISPATCH_PUBLISH_MODE"
+            # `dry-run` input is a boolean — workflow_dispatch sends 'true'
+            # or 'false' (string-form on the env). Default is false, so the
+            # legacy dispatch behavior is preserved when the operator does
+            # not tick the checkbox.
+            dry_run="$DISPATCH_DRY_RUN"
           elif [[ "$EVENT_NAME" == "repository_dispatch" ]]; then
             # Coordinated release path. Both come from the same dispatched tag.
             # publish_mode is hard-coded to 'all' — coordinated releases always
@@ -103,6 +109,12 @@ jobs:
             binary_source_tag="$DISPATCH_PAYLOAD_TAG"
             npm_version="${DISPATCH_PAYLOAD_TAG#v}"
             publish_mode="all"
+            # Coordinated releases from agent-assembly's notify-downstream job
+            # must ALWAYS publish for real. Hard-coding dry_run='false' here
+            # makes this regression-safe: even if a future workflow change
+            # adds a new dry-run code path, repository_dispatch will continue
+            # to publish.
+            dry_run="false"
           else
             echo "::error::unexpected event_name '$EVENT_NAME' — release-node should only fire on repository_dispatch or workflow_dispatch"
             exit 1
@@ -119,8 +131,9 @@ jobs:
             echo "binary_source_tag=${binary_source_tag}"
             echo "npm_version=${npm_version}"
             echo "publish_mode=${publish_mode}"
+            echo "dry_run=${dry_run}"
           } >> "$GITHUB_OUTPUT"
-          echo "Resolved binary_source_tag=${binary_source_tag} npm_version=${npm_version} publish_mode=${publish_mode}"
+          echo "Resolved binary_source_tag=${binary_source_tag} npm_version=${npm_version} publish_mode=${publish_mode} dry_run=${dry_run}"
 
       # AAASM-2854: Pre-flight gate for main-only mode. The SDK hotfix path
       # reuses the @agent-assembly/runtime-* sub-packages already on npm

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -310,6 +310,12 @@ jobs:
           done
 
       - name: Publish main @agent-assembly/sdk
+        # AAASM-2862: this step previously had no `if:` (it runs in BOTH
+        # publish_mode='all' and 'main-only'). Gate ONLY on dry_run so
+        # both modes still skip cleanly when the operator dispatches with
+        # dry-run=true. repository_dispatch hard-codes dry_run='false' so
+        # coordinated releases continue to publish.
+        if: steps.tag.outputs.dry_run != 'true'
         env:
           NPM_CONFIG_PROVENANCE: "true"
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -340,6 +340,11 @@ jobs:
   version-docs:
     name: Cut docs version snapshot and repoint channels
     needs: publish
+    # AAASM-2862: don't cut an immutable docs snapshot for a version that
+    # was never published. Skip the entire docs-version job when the
+    # publish job ran in dry-run mode. repository_dispatch hard-codes
+    # dry_run='false' upstream so coordinated releases still cut snapshots.
+    if: needs.publish.outputs.dry_run != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -41,6 +41,11 @@ on:
         options:
           - all
           - main-only
+      dry-run:
+        description: "Skip the npm publish steps and the docs-version snapshot. Builds run normally; nothing reaches the registry or master. Defaults to false so today's dispatch behavior is unchanged."
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Adds a `dry-run` boolean `workflow_dispatch` input to `.github/workflows/release-node.yml` so operators can safely live-trace the workflow (Resolve → Pre-flight → Bump → Build) without anything reaching the npm registry or master. Mirrors the python-sdk pattern from AAASM-2856 + AAASM-2857. Default `false`, so today's `workflow_dispatch` and `repository_dispatch` paths are byte-identical to the pre-change behavior. Unblocks the partial AC on AAASM-2851 (live-dispatch validation of the SDK-only hotfix mode).

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: AAASM-2862.
    * Relative task IDs:
        * [x] AAASM-2851 (parent gap — SDK release decoupling; this closes follow-up #1 from the sign-off comment).
        * [x] AAASM-2857 (symmetric python-sdk implementation, commit `40c5882`).
        * [x] AAASM-2856 (added `dry-run` input on python-sdk).
        * [x] AAASM-2854 (introduced `publish_mode` on this workflow — combined here via `&&`).
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    **As-is** — `workflow_dispatch.inputs` (3 inputs, every dispatch either publishes for real or errors out):

    ` ` `yaml
    workflow_dispatch:
      inputs:
        npm_version: { description: "...", required: true,  type: string }
        binary_source_tag: { description: "...", required: false, type: string }
        publish_mode: { description: "...", required: true,  type: choice, default: "all", options: [all, main-only] }
    ` ` `

    Publish steps:
    ` ` `yaml
    - name: Publish 4 runtime sub-packages
      if: steps.tag.outputs.publish_mode == 'all'
    - name: Publish main @agent-assembly/sdk
      # (no `if:` — runs in both publish_mode='all' AND 'main-only')
    ` ` `

    `version-docs` job has no `if:` — always runs after a successful `publish`.

    **To-be** — `workflow_dispatch.inputs` (4 inputs, new `dry-run` boolean):

    ` ` `yaml
    workflow_dispatch:
      inputs:
        npm_version: { ..., required: true,  type: string }
        binary_source_tag: { ..., required: false, type: string }
        publish_mode: { ..., required: true,  type: choice, default: "all", options: [all, main-only] }
        dry-run:
          description: "Skip the npm publish steps and the docs-version snapshot. Builds run normally; nothing reaches the registry or master. Defaults to false so today's dispatch behavior is unchanged."
          required: false
          type: boolean
          default: false
    ` ` `

    Resolve step wires `dry_run` per branch (workflow_dispatch reads `DISPATCH_DRY_RUN`; repository_dispatch hard-codes `dry_run=\"false\"` for regression safety) and emits it to `$GITHUB_OUTPUT`. Publish job exposes it as `outputs.dry_run` for the downstream `version-docs` job.

    Publish steps:
    ` ` `yaml
    - name: Publish 4 runtime sub-packages
      if: steps.tag.outputs.publish_mode == 'all' && steps.tag.outputs.dry_run != 'true'
    - name: Publish main @agent-assembly/sdk
      if: steps.tag.outputs.dry_run != 'true'
    ` ` `

    And the docs-snapshot job:
    ` ` `yaml
    version-docs:
      needs: publish
      if: needs.publish.outputs.dry_run != 'true'
    ` ` `

    **Behavior matrix:**

    | Trigger | `dry-run` | Pre-flight | Bump | Build | Publish runtime | Publish main | version-docs |
    |---|---|---|---|---|---|---|---|
    | `repository_dispatch` (coordinated) | hard-coded `false` | — | run | run | run (publish_mode=`all`) | run | run |
    | `workflow_dispatch` `dry-run=false` (default) | `false` | run if `main-only` | run | run | run if `publish_mode=all` | run | run |
    | `workflow_dispatch` `dry-run=true` | `true` | run if `main-only` | run | run | **skip** | **skip** | **skip** |

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [ ] 🤖 Framework hooks
    * [ ] 🫀 Data model and types
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
        * [ ] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
    * [ ] 📚 Documentation
* Additional description:
    Only `.github/workflows/release-node.yml` changes. No source / package / dependency / docs changes. The `repository_dispatch` path (coordinated releases from `agent-assembly`'s `notify-downstream` job) is hard-coded `dry_run='false'` in the Resolve step — regression-safe even if a future change adds another dry-run code path.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* **`✨ (release-node): Add dry-run workflow_dispatch input`** — declare `dry-run: { type: boolean, default: false, required: false }` alongside `npm_version` / `binary_source_tag` / `publish_mode`.
* **`♻️ (release-node): Add dry_run output to Resolve step`** — `workflow_dispatch` reads `DISPATCH_DRY_RUN`; `repository_dispatch` hard-codes `dry_run=\"false\"`; both branches emit `dry_run` to `$GITHUB_OUTPUT`.
* **`♻️ (release-node): Expose dry_run on publish job outputs`** — surface `dry_run: \${{ steps.tag.outputs.dry_run }}` on the `publish` job's `outputs:` block so `version-docs` can read `needs.publish.outputs.dry_run`.
* **`♻️ (release-node): Gate Publish 4 runtime sub-packages on dry_run`** — combine with the existing `publish_mode == 'all'` gate via `&&`.
* **`♻️ (release-node): Gate Publish main SDK on dry_run`** — add `if: steps.tag.outputs.dry_run != 'true'` (this step previously had no `if:` because it runs in both `publish_mode=all` AND `main-only`).
* **`♻️ (release-node): Gate version-docs job on dry_run`** — `if: needs.publish.outputs.dry_run != 'true'` so a dry-run dispatch does NOT cut a Docusaurus snapshot or open a docs-version PR (which would otherwise self-merge to master against a never-published version).

**Verification performed locally:**

* `actionlint .github/workflows/release-node.yml` → clean after every commit.
* `yaml.safe_load` structural assertions: 4 `workflow_dispatch.inputs` (`npm_version`, `binary_source_tag`, `publish_mode`, `dry-run`); 4 `publish.outputs` (`binary_source_tag`, `npm_version`, `publish_mode`, `dry_run`); `Publish 4 runtime sub-packages.if == \"steps.tag.outputs.publish_mode == 'all' && steps.tag.outputs.dry_run != 'true'\"`; `Publish main @agent-assembly/sdk.if == \"steps.tag.outputs.dry_run != 'true'\"`; `version-docs.if == \"needs.publish.outputs.dry_run != 'true'\"`.
* Manual trace through the Resolve step's bash for all three rows of the behavior matrix above.

**Acceptance criteria coverage (AAASM-2862):**

* [x] `release-node.yml` parses with `actionlint` cleanly.
* [x] `dry-run` input added with `type: boolean`, `default: false`, description naming the publish-skip semantic.
* [x] Resolve step emits `dry_run` to `GITHUB_OUTPUT` and exposes it on `publish` job outputs.
* [x] `Publish 4 runtime sub-packages` and `Publish main @agent-assembly/sdk` steps gated `if: steps.tag.outputs.dry_run != 'true'` (combined with their existing `publish_mode` gate where present).
* [x] `repository_dispatch` flow regression-safe (always `dry_run = false`).
* [x] No publish-flow behavior change when operators dispatch with default `dry-run=false`.

Closes AAASM-2862.