### PR TITLE
[AAASM-2865] ✅ (verify): Live F1 verification — dispatched bad-pin pre-flight failure

### DIFF
--- a/verification-reports/AAASM-2851/F1.log
+++ b/verification-reports/AAASM-2851/F1.log
@@ -1,0 +1,126 @@
+# AAASM-2851 / F1 — live verification log
+#
+# Dispatched run: https://github.com/ai-agent-assembly/node-sdk/actions/runs/27471607887
+# Job ID:         81203426168
+# Workflow:       .github/workflows/release-node.yml
+# Trigger:        workflow_dispatch
+# Dispatch ref:   verify/AAASM-2865/f1-live  (temp branch off remote/master @ 707818d, deleted after capture)
+# Inputs:
+#   npm_version       = 0.0.1-alpha.8.1
+#   binary_source_tag = v0.0.1-alpha.8
+#   publish_mode      = main-only
+# Branch tip commit (bad-pin commit):
+#   ef93b3a (verify): Set bad runtime-linux-x64 pin to demonstrate F1 pre-flight failure
+# Branch package.json optionalDependencies (excerpt):
+#   {
+#     "@agent-assembly/runtime-darwin-arm64": "0.0.1-alpha.8",   <- exists on npm
+#     "@agent-assembly/runtime-darwin-x64":   "0.0.1-alpha.8",   <- exists on npm
+#     "@agent-assembly/runtime-linux-arm64":  "0.0.1-alpha.8",   <- exists on npm
+#     "@agent-assembly/runtime-linux-x64":    "99.99.99-fake"    <- does NOT exist on npm
+#   }
+# Result:           failure (exit code 1 at the pre-flight step — no publish step ever ran)
+# Captured from:    gh api repos/AI-agent-assembly/node-sdk/actions/jobs/81203426168/logs
+#
+# Trim window:      lines 225..320 of the raw job log — covers the full Resolve step,
+#                   full Pre-flight step (script body + loop output + error annotation),
+#                   and the trailing exit code + post-job cleanup markers. Steps before
+#                   (checkout / pnpm setup / setup-node / pnpm install --frozen-lockfile)
+#                   are omitted; they all passed. Steps after were skipped because of the
+#                   non-zero exit at pre-flight.
+
+2026-06-13T15:55:38.1131048Z ##[group]Run set -euo pipefail
+2026-06-13T15:55:38.1131428Z [36;1mset -euo pipefail[0m
+2026-06-13T15:55:38.1131750Z [36;1mif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then[0m
+2026-06-13T15:55:38.1132225Z [36;1m  # Operator path. Precedence for binary_source_tag: explicit[0m
+2026-06-13T15:55:38.1132697Z [36;1m  # DISPATCH_BINARY_TAG > latest agent-assembly release.[0m
+2026-06-13T15:55:38.1133436Z [36;1m  if [[ -n "${DISPATCH_BINARY_TAG:-}" ]]; then[0m
+2026-06-13T15:55:38.1133793Z [36;1m    binary_source_tag="$DISPATCH_BINARY_TAG"[0m
+2026-06-13T15:55:38.1134092Z [36;1m  else[0m
+2026-06-13T15:55:38.1134562Z [36;1m    binary_source_tag=$(gh release view --repo ai-agent-assembly/agent-assembly --json tagName --jq .tagName)[0m
+2026-06-13T15:55:38.1135325Z [36;1m    echo "::notice::binary_source_tag omitted; defaulting to latest agent-assembly release: $binary_source_tag"[0m
+2026-06-13T15:55:38.1135841Z [36;1m  fi[0m
+2026-06-13T15:55:38.1136097Z [36;1m  npm_version="$DISPATCH_NPM_VERSION"[0m
+2026-06-13T15:55:38.1136441Z [36;1m  publish_mode="$DISPATCH_PUBLISH_MODE"[0m
+2026-06-13T15:55:38.1136812Z [36;1melif [[ "$EVENT_NAME" == "repository_dispatch" ]]; then[0m
+2026-06-13T15:55:38.1137270Z [36;1m  # Coordinated release path. Both come from the same dispatched tag.[0m
+2026-06-13T15:55:38.1137778Z [36;1m  # publish_mode is hard-coded to 'all' — coordinated releases always[0m
+2026-06-13T15:55:38.1138187Z [36;1m  # publish the full 5-package set.[0m
+2026-06-13T15:55:38.1138520Z [36;1m  binary_source_tag="$DISPATCH_PAYLOAD_TAG"[0m
+2026-06-13T15:55:38.1138873Z [36;1m  npm_version="${DISPATCH_PAYLOAD_TAG#v}"[0m
+2026-06-13T15:55:38.1139181Z [36;1m  publish_mode="all"[0m
+2026-06-13T15:55:38.1139426Z [36;1melse[0m
+2026-06-13T15:55:38.1139957Z [36;1m  echo "::error::unexpected event_name '$EVENT_NAME' — release-node should only fire on repository_dispatch or workflow_dispatch"[0m
+2026-06-13T15:55:38.1140547Z [36;1m  exit 1[0m
+2026-06-13T15:55:38.1140755Z [36;1mfi[0m
+2026-06-13T15:55:38.1141044Z [36;1mif [[ ! "$binary_source_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then[0m
+2026-06-13T15:55:38.1141595Z [36;1m  echo "::error::binary_source_tag '$binary_source_tag' does not match v*.*.* (semver) pattern"[0m
+2026-06-13T15:55:38.1142062Z [36;1m  exit 1[0m
+2026-06-13T15:55:38.1142263Z [36;1mfi[0m
+2026-06-13T15:55:38.1142523Z [36;1mif [[ ! "$npm_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then[0m
+2026-06-13T15:55:38.1143306Z [36;1m  echo "::error::npm_version '$npm_version' does not match X.Y.Z semver pattern (must NOT include leading v)"[0m
+2026-06-13T15:55:38.1143813Z [36;1m  exit 1[0m
+2026-06-13T15:55:38.1144015Z [36;1mfi[0m
+2026-06-13T15:55:38.1144211Z [36;1m{[0m
+2026-06-13T15:55:38.1144458Z [36;1m  echo "binary_source_tag=${binary_source_tag}"[0m
+2026-06-13T15:55:38.1144799Z [36;1m  echo "npm_version=${npm_version}"[0m
+2026-06-13T15:55:38.1145119Z [36;1m  echo "publish_mode=${publish_mode}"[0m
+2026-06-13T15:55:38.1145423Z [36;1m} >> "$GITHUB_OUTPUT"[0m
+2026-06-13T15:55:38.1145924Z [36;1mecho "Resolved binary_source_tag=${binary_source_tag} npm_version=${npm_version} publish_mode=${publish_mode}"[0m
+2026-06-13T15:55:38.1178238Z shell: /usr/bin/bash -e {0}
+2026-06-13T15:55:38.1178661Z env:
+2026-06-13T15:55:38.1178933Z   PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin
+2026-06-13T15:55:38.1179323Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+2026-06-13T15:55:38.1179672Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+2026-06-13T15:55:38.1179968Z   EVENT_NAME: workflow_dispatch
+2026-06-13T15:55:38.1180231Z   DISPATCH_BINARY_TAG: v0.0.1-alpha.8
+2026-06-13T15:55:38.1180518Z   DISPATCH_NPM_VERSION: 0.0.1-alpha.8.1
+2026-06-13T15:55:38.1180797Z   DISPATCH_PUBLISH_MODE: main-only
+2026-06-13T15:55:38.1181058Z   DISPATCH_PAYLOAD_TAG: 
+2026-06-13T15:55:38.1184085Z   GH_TOKEN: ***
+2026-06-13T15:55:38.1184322Z ##[endgroup]
+2026-06-13T15:55:38.1239537Z Resolved binary_source_tag=v0.0.1-alpha.8 npm_version=0.0.1-alpha.8.1 publish_mode=main-only
+2026-06-13T15:55:38.1284918Z ##[group]Run set -euo pipefail
+2026-06-13T15:55:38.1285341Z [36;1mset -euo pipefail[0m
+2026-06-13T15:55:38.1285618Z [36;1mnode <<'NODE'[0m
+2026-06-13T15:55:38.1285872Z [36;1mconst fs = require("node:fs");[0m
+2026-06-13T15:55:38.1286241Z [36;1mconst { execSync } = require("node:child_process");[0m
+2026-06-13T15:55:38.1286701Z [36;1mconst pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));[0m
+2026-06-13T15:55:38.1287134Z [36;1mconst opt = pkg.optionalDependencies ?? {};[0m
+2026-06-13T15:55:38.1287550Z [36;1mconst runtimePkgs = Object.entries(opt).filter(([name]) =>[0m
+2026-06-13T15:55:38.1287962Z [36;1m  name.startsWith("@agent-assembly/runtime-"),[0m
+2026-06-13T15:55:38.1288298Z [36;1m);[0m
+2026-06-13T15:55:38.1288521Z [36;1mif (runtimePkgs.length === 0) {[0m
+2026-06-13T15:55:38.1288800Z [36;1m  console.error([0m
+2026-06-13T15:55:38.1289192Z [36;1m    "::error::no @agent-assembly/runtime-* entries in optionalDependencies — " +[0m
+2026-06-13T15:55:38.1289772Z [36;1m    "main-only mode requires existing runtime sub-packages to reuse",[0m
+2026-06-13T15:55:38.1290157Z [36;1m  );[0m
+2026-06-13T15:55:38.1290375Z [36;1m  process.exit(1);[0m
+2026-06-13T15:55:38.1290622Z [36;1m}[0m
+2026-06-13T15:55:38.1290830Z [36;1mlet failed = false;[0m
+2026-06-13T15:55:38.1291128Z [36;1mfor (const [name, version] of runtimePkgs) {[0m
+2026-06-13T15:55:38.1291433Z [36;1m  try {[0m
+2026-06-13T15:55:38.1291750Z [36;1m    execSync(`npm view ${name}@${version} version`, { stdio: "pipe" });[0m
+2026-06-13T15:55:38.1292200Z [36;1m    console.log(`OK: ${name}@${version} exists on npm`);[0m
+2026-06-13T15:55:38.1292539Z [36;1m  } catch {[0m
+2026-06-13T15:55:38.1293002Z [36;1m    console.error([0m
+2026-06-13T15:55:38.1293415Z [36;1m      `::error::main-only publish blocked — ${name}@${version} is not on npm. ` +[0m
+2026-06-13T15:55:38.1293990Z [36;1m      `Use publish_mode=all to publish the runtime sub-packages alongside the SDK.`,[0m
+2026-06-13T15:55:38.1294427Z [36;1m    );[0m
+2026-06-13T15:55:38.1294641Z [36;1m    failed = true;[0m
+2026-06-13T15:55:38.1294873Z [36;1m  }[0m
+2026-06-13T15:55:38.1295067Z [36;1m}[0m
+2026-06-13T15:55:38.1295280Z [36;1mif (failed) process.exit(1);[0m
+2026-06-13T15:55:38.1295556Z [36;1mNODE[0m
+2026-06-13T15:55:38.1323507Z shell: /usr/bin/bash -e {0}
+2026-06-13T15:55:38.1323771Z env:
+2026-06-13T15:55:38.1324041Z   PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin
+2026-06-13T15:55:38.1324441Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+2026-06-13T15:55:38.1324793Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+2026-06-13T15:55:38.1325075Z ##[endgroup]
+2026-06-13T15:55:39.0118463Z OK: @agent-assembly/runtime-darwin-arm64@0.0.1-alpha.8 exists on npm
+2026-06-13T15:55:39.4744643Z OK: @agent-assembly/runtime-darwin-x64@0.0.1-alpha.8 exists on npm
+2026-06-13T15:55:39.9372533Z OK: @agent-assembly/runtime-linux-arm64@0.0.1-alpha.8 exists on npm
+2026-06-13T15:55:40.4725459Z ##[error]main-only publish blocked — @agent-assembly/runtime-linux-x64@99.99.99-fake is not on npm. Use publish_mode=all to publish the runtime sub-packages alongside the SDK.
+2026-06-13T15:55:40.4741266Z ##[error]Process completed with exit code 1.
+2026-06-13T15:55:40.4858027Z Post job cleanup.
+2026-06-13T15:55:40.6272451Z Pruning is unnecessary.

--- a/verification-reports/AAASM-2851/summary.md
+++ b/verification-reports/AAASM-2851/summary.md
@@ -34,7 +34,7 @@ The verification matrix's happy-path rows (R1, R2, H1, H2) would publish real ve
 | H1 | node-sdk | `workflow_dispatch` | `npm_version=0.0.1-alpha.8.1`, `binary_source_tag=v0.0.1-alpha.8`, `publish_mode=main-only` | Only main SDK publishes at `0.0.1-alpha.8.1`; runtime steps SKIPPED | ✅ Static — traced |
 | H2 | node-sdk | `workflow_dispatch` | same but `publish_mode=all` | 5 packages bump + publish at `0.0.1-alpha.8.1` | ✅ Static — traced |
 | H3 | python-sdk | `workflow_dispatch` | `pypi_version=0.0.1a8.post1`, `binary_source_tag=v0.0.1-alpha.8`, `dry-run=true` | wheel built, no upload | ✅ Static — see python-sdk report |
-| F1 | node-sdk | `workflow_dispatch` | `publish_mode=main-only` + runtime pin to non-existent version | Pre-flight fails fast | ✅ Static — traced |
+| F1 | node-sdk | `workflow_dispatch` | `publish_mode=main-only` + runtime pin to non-existent version | Pre-flight fails fast | ✅ Live — [F1.log](./F1.log) |
 | F2 | python-sdk | `workflow_dispatch` | `dry-run=false`, no `pypi_version` | Resolve fails fast | ✅ Static — see python-sdk report |
 | F3 | node-sdk | `workflow_dispatch` | `npm_version=foo.bar` | Resolve validation fails | ✅ Static — traced |
 | F4 | python-sdk | `workflow_dispatch` | `pypi_version=0.0.1-alpha.8.1` (hyphen) | PEP 440 validation fails | ✅ Static — see python-sdk report |
@@ -132,7 +132,26 @@ The verification matrix's happy-path rows (R1, R2, H1, H2) would publish real ve
 
 **Trace source:** Commit `8e97711` (`✨ (release-node): Add pre-flight check that runtime sub-packages exist on npm`) — see review comment on PR #113.
 
-**Verdict: ✅** Fail-fast on bad runtime-* pin works as designed.
+**Live verification (AAASM-2865):** dispatched the workflow against a temporary branch (`verify/AAASM-2865/f1-live`, since deleted) whose root `package.json` `optionalDependencies` set `runtime-linux-x64` to `99.99.99-fake` and left the other 3 runtime-* pinned at the existing `0.0.1-alpha.8` publish. Inputs: `npm_version=0.0.1-alpha.8.1`, `binary_source_tag=v0.0.1-alpha.8`, `publish_mode=main-only`.
+
+- Dispatched run: <https://github.com/ai-agent-assembly/node-sdk/actions/runs/27471607887>
+- Captured log: [`F1.log`](./F1.log)
+
+Key excerpt from the captured log (pre-flight step output):
+
+```
+Resolved binary_source_tag=v0.0.1-alpha.8 npm_version=0.0.1-alpha.8.1 publish_mode=main-only
+...
+OK: @agent-assembly/runtime-darwin-arm64@0.0.1-alpha.8 exists on npm
+OK: @agent-assembly/runtime-darwin-x64@0.0.1-alpha.8 exists on npm
+OK: @agent-assembly/runtime-linux-arm64@0.0.1-alpha.8 exists on npm
+##[error]main-only publish blocked — @agent-assembly/runtime-linux-x64@99.99.99-fake is not on npm. Use publish_mode=all to publish the runtime sub-packages alongside the SDK.
+##[error]Process completed with exit code 1.
+```
+
+The pre-flight iterates all 4 entries and emits the exact AC-prescribed error string for the one missing pin; exit 1 stops the job at the pre-flight step (no download / stage / bump / build / publish step ran). No npm publish occurred.
+
+**Verdict: ✅** Fail-fast on bad runtime-* pin works as designed (live-confirmed).
 
 ### F3 — invalid `npm_version` rejection
 
@@ -160,8 +179,8 @@ All 5 node-sdk rows trace through the SAME Resolve step at master HEAD. The `pub
 
 ## Limitations acknowledged
 
-- **No live dispatch:** would publish real versions or burn CI minutes. Verdaccio / TestPyPI / fork-with-registry setup is out of scope here. Adding a `dry-run` boolean input on node-sdk (parity with python-sdk) would enable safe live H1/H2/F1 verification in a follow-up.
-- **F1 setup invasive:** verifying F1 live requires committing a deliberately bad `optionalDependencies` pin to a feature branch + dispatching against it. Static trace through the pre-flight code is the lower-cost alternative.
+- **No live dispatch for happy-path rows:** would publish real versions or burn CI minutes. Verdaccio / TestPyPI / fork-with-registry setup is out of scope here. Adding a `dry-run` boolean input on node-sdk (parity with python-sdk) would enable safe live H1/H2 verification in a follow-up.
+- **F1 setup invasive but completed:** AAASM-2865 closed this row's "Live ✅" cell by dispatching against a temp `verify/AAASM-2865/f1-live` branch with a deliberately bad pin. The temp branch was deleted after the failing-run log was captured to `F1.log`. Static trace through the pre-flight code remains in this report for self-contained reading.
 - **Snapshot label observable for coordinated releases:** the AAASM-2855 callout (`version-v0.0.1-alpha.8` → `version-0.0.1-alpha.8`) is documented in PR #114's review. Worth verifying on the next coordinated release tag fire.
 
 ## Sign-off


### PR DESCRIPTION
## _Target_

* ### Task summary:

    AAASM-2865 — Close the live-verification gap that AAASM-2859 left open for the F1 row of the AAASM-2851 verification matrix. AAASM-2859 verified F1 statically (trace through the merged pre-flight bash). This PR commits a real GitHub Actions run log captured by dispatching `release-node.yml` against a temporary branch with a deliberately broken `optionalDependencies['@agent-assembly/runtime-linux-x64']` pin, and updates `verification-reports/AAASM-2851/summary.md` so the F1 row reads `✅ Live — F1.log` instead of `✅ Static — traced`.

* ### Task tickets:

    * Task ID: AAASM-2865.
    * Relative task IDs:
        * [x] AAASM-2851 — Parent Story (verification matrix this row belongs to)
        * [x] AAASM-2859 — Subtask that produced the original static-only F1 verdict
        * [x] AAASM-2854 — Subtask that introduced the pre-flight gate now live-verified here
    * Relative PRs:
        * #116 — AAASM-2859 verification report (this PR amends its F1 row)
        * #113 — AAASM-2854 pre-flight check implementation

* ### Key point change (optional):

    Dispatched run: <https://github.com/ai-agent-assembly/node-sdk/actions/runs/27471607887>

    Captured pre-flight excerpt (full content in `verification-reports/AAASM-2851/F1.log`):

    ```
    Resolved binary_source_tag=v0.0.1-alpha.8 npm_version=0.0.1-alpha.8.1 publish_mode=main-only
    ...
    OK: @agent-assembly/runtime-darwin-arm64@0.0.1-alpha.8 exists on npm
    OK: @agent-assembly/runtime-darwin-x64@0.0.1-alpha.8 exists on npm
    OK: @agent-assembly/runtime-linux-arm64@0.0.1-alpha.8 exists on npm
    ##[error]main-only publish blocked — @agent-assembly/runtime-linux-x64@99.99.99-fake is not on npm. Use publish_mode=all to publish the runtime sub-packages alongside the SDK.
    ##[error]Process completed with exit code 1.
    ```

    The pre-flight loop iterated all 4 entries and emitted the exact AC-prescribed error string for the one missing pin. Exit code 1 halted the job at the pre-flight step; no Download / Stage / Bump / Build / Publish step ran. **No npm publish occurred** — the gate is genuinely fail-fast as designed.

    The dispatch branch `verify/AAASM-2865/f1-live` (off `remote/master @ 707818d`) was deleted from the remote after the captured log was committed; only this regular feature branch remains.

## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
* Scopes:
    * [x] 📚 Documentation
* Additional description:
    Verification-report-only change. No code, workflow, or package config changes.

## _Description_

* `verification-reports/AAASM-2851/F1.log` — new file. Trimmed extract of the failing GitHub Actions job log (Resolve step + Pre-flight step + exit/post-job cleanup), prefixed with a header that names the dispatched run URL, job ID, dispatch ref, inputs, the bad-pin commit, and the trim window. Steps before pre-flight (checkout / pnpm setup / setup-node / pnpm install --frozen-lockfile) all passed; steps after were skipped.
* `verification-reports/AAASM-2851/summary.md` — F1 row in the matrix table flipped from `✅ Static — traced` to `✅ Live — [F1.log](./F1.log)`. The F1 per-row section gains a `Live verification (AAASM-2865)` subsection naming the dispatched run + quoting the captured error. The `Limitations acknowledged` section's `F1 setup invasive` caveat is rewritten to note it was closed by this ticket; the `no live dispatch` caveat is narrowed to apply only to the H1/H2 happy-path rows.