### PR TITLE
[AAASM-2866] 🐛 (release-node): Fix %0A%0A URL-encoded newlines in docs-version PR body

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -403,7 +403,11 @@ jobs:
             --base master \
             --head "$branch" \
             --title "📸 (docs): Cut docs snapshot for ${NPM_VERSION}" \
-            --body "Automated docs version snapshot cut by release-node.yml after the npm publish of \`${NPM_VERSION}\`. Freezes \`docs/\` into \`website/versioned_docs/version-${NPM_VERSION}\` and repoints the version channels (labels, banners, \`lastVersion\`).%0A%0ABundled aasm: \`${BINARY_SOURCE_TAG}\` (the agent-assembly Release whose per-platform binaries were bundled into the @agent-assembly/runtime-* sub-packages for this npm publish)."
+            --body-file - <<EOF
+          Automated docs version snapshot cut by release-node.yml after the npm publish of \`${NPM_VERSION}\`. Freezes \`docs/\` into \`website/versioned_docs/version-${NPM_VERSION}\` and repoints the version channels (labels, banners, \`lastVersion\`).
+
+          Bundled aasm: \`${BINARY_SOURCE_TAG}\` (the agent-assembly Release whose per-platform binaries were bundled into the @agent-assembly/runtime-* sub-packages for this npm publish).
+          EOF
 
       # AAASM-2794: self-approve + enable auto-merge so the snapshot lands on
       # master without a per-release manual merge. The approve step MUST use a

--- a/verification-reports/AAASM-2851/summary.md
+++ b/verification-reports/AAASM-2851/summary.md
@@ -151,6 +151,8 @@ OK: @agent-assembly/runtime-linux-arm64@0.0.1-alpha.8 exists on npm
 
 The pre-flight iterates all 4 entries and emits the exact AC-prescribed error string for the one missing pin; exit 1 stops the job at the pre-flight step (no download / stage / bump / build / publish step ran). No npm publish occurred.
 
+**Operator note for future reproductions (AAASM-2866):** to get `pnpm install --frozen-lockfile` past `ERR_PNPM_OUTDATED_LOCKFILE` on the bad-pin temp branch, two prep commits on the temp branch were needed — regenerate `pnpm-lock.yaml` after the `package.json` edit, then inject a placeholder lockfile entry for the bad-version pin (mark `optional` + cpu/os-pinned so pnpm doesn't actually fetch it). Without those, the workflow fails at the `pnpm install` step BEFORE the pre-flight step ever runs, which would obscure what the F1 verification is meant to demonstrate. Both prep commits live only on the deleted temp branch — they are NOT in this report repo.
+
 **Verdict: ✅** Fail-fast on bad runtime-* pin works as designed (live-confirmed).
 
 ### F3 — invalid `npm_version` rejection


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

* ### Task summary:

    AAASM-2855 commit `08d662c` added a \"Bundled aasm\" metadata line to the docs-version PR body with `%0A%0A` as the paragraph separator. `gh pr create --body` does NOT URL-decode its argument, so the rendered PR body would have shown literal `%0A%0A` characters between paragraphs. Fix: switch to `--body-file -` with a bash heredoc.

    Also folds in the AAASM-2865 closure disclosure (the pnpm-lockfile hurdle for F1 live verification) as a note in the existing summary report.

* ### Task tickets:

    * Task ID: **AAASM-2866**
    * Parent: AAASM-2851 sign-off follow-up gap #5
    * Origin: AAASM-2855 commit `08d662c`
    * Related closure note carried forward: AAASM-2865

* ### Key point change (optional):

    **As-is** — body passed as a single line with `%0A%0A` URL-encoded newlines that `gh pr create --body` writes literally:

    \`\`\`yaml
    --body \"Automated docs version snapshot cut by release-node.yml ... lastVersion\\\`).%0A%0ABundled aasm: \\\`\${BINARY_SOURCE_TAG}\\\` ...\"
    \`\`\`

    **To-be** — body piped from stdin via a heredoc that preserves real newlines:

    \`\`\`yaml
    --body-file - <<EOF
    Automated docs version snapshot cut by release-node.yml after the npm publish of \\\`\${NPM_VERSION}\\\` ...

    Bundled aasm: \\\`\${BINARY_SOURCE_TAG}\\\` ...
    EOF
    \`\`\`

    Variable expansion (`\${NPM_VERSION}`, `\${BINARY_SOURCE_TAG}`) still works inside `<<EOF` (unquoted) heredoc. Backticks around versions are still backslash-escaped (`\\\``) to embed as literal markdown code-spans rather than triggering command substitution.

## _Effecting Scope_

* Action Types:
    * [x] 🔧 Fixing bug
* Scopes:
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
    * [x] 📚 Documentation
* Additional description:
    The bug fix lands on the workflow; the documentation update lands on the existing F1 verification report (AAASM-2865 carryover note).

## _Description_

2 atomic commits:

1. \`8a7bfc4\` \`🐛 (release-node): Use heredoc + --body-file for docs-version PR body to fix %0A%0A\`
2. \`cdb7bb4\` \`📝 (verify): Document pnpm-lockfile hurdle in F1 Live verification subsection\`

### Self-verification

* \`actionlint .github/workflows/release-node.yml\` → clean
* Heredoc-body rendering tested by manually simulating the bash heredoc with the same indentation conventions YAML's \`run: |\` block uses — newlines preserved.
* Visible effect on next docs-version PR: the body will show as two distinct paragraphs, with the \"Bundled aasm\" metadata as the second paragraph. The literal \`%0A%0A\` string will not appear.

### Acceptance criteria

| AC (from AAASM-2866) | Status |
|---|---|
| \`release-node.yml\` parses with \`actionlint\` cleanly | ✅ |
| \`%0A%0A\` no longer appears in the body argument string | ✅ |
| Body construction produces a string with real newlines | ✅ — heredoc-based |
| Docs-version PR body displays \"Bundled aasm\" as a properly-separated paragraph | ⏳ Verifiable on the next docs-version PR after a real coordinated release fires; non-blocking |