### PR TITLE
[AAASM-2872] 🐛 (init-assembly): Lazy-load LangChain adapter so the SDK imports without @langchain/core

### DIFF
--- a/src/core/init-assembly.ts
+++ b/src/core/init-assembly.ts
@@ -1,9 +1,8 @@
 import { createRequire } from "node:module";
 import type { Adapter } from "../adapters/adapter.js";
-import {
+import type {
   AssemblyCallbackHandler,
-  wrapToolWithAssembly,
-  type WrapToolWithAssemblyOptions
+  WrapToolWithAssemblyOptions
 } from "../adapters/langchain/index.js";
 import { createNoopGatewayClient, type GatewayClient } from "../gateway/client.js";
 import { createNativeClient, type NativeClient } from "../native/client.js";
@@ -121,30 +120,34 @@ function ensureLangChainTools(config: AssemblyConfig): Record<string, LangChainT
   return config.langchain.tools;
 }
 
-function registerLangChainHandler(
+async function registerLangChainHandler(
   config: AssemblyConfig,
   client: GatewayClient,
   frameworks: readonly string[]
-): AssemblyCallbackHandler | undefined {
+): Promise<AssemblyCallbackHandler | undefined> {
   if (!frameworks.includes("langchain-js") && !config.langchain) {
     return undefined;
   }
 
+  // Lazy-load the LangChain adapter only on the langchain code path so importing
+  // the SDK (and using withAssembly) never pulls in the optional @langchain/core.
+  const { AssemblyCallbackHandler } = await import("../adapters/langchain/index.js");
   const callbacks = ensureLangChainCallbacks(config);
   const handler = new AssemblyCallbackHandler(client);
   callbacks.push(handler);
   return handler;
 }
 
-function wrapLangChainTools(
+async function wrapLangChainTools(
   config: AssemblyConfig,
   client: GatewayClient,
   frameworks: readonly string[]
-): string[] {
+): Promise<string[]> {
   if (!frameworks.includes("langchain-js") && !config.langchain) {
     return [];
   }
 
+  const { wrapToolWithAssembly } = await import("../adapters/langchain/index.js");
   const tools = ensureLangChainTools(config);
   const wrapperOptions: WrapToolWithAssemblyOptions = {
     ...(config.langchain?.approvalTimeoutMs
@@ -249,8 +252,8 @@ export async function initAssembly(config: AssemblyConfig = {}): Promise<Assembl
     nativeClient.sendEvent(buildRegistrationEvent(resolvedConfig));
   }
 
-  const langChainHandler = registerLangChainHandler(resolvedConfig, client, frameworks);
-  const wrappedLangChainTools = wrapLangChainTools(resolvedConfig, client, frameworks);
+  const langChainHandler = await registerLangChainHandler(resolvedConfig, client, frameworks);
+  const wrappedLangChainTools = await wrapLangChainTools(resolvedConfig, client, frameworks);
   const vercelAiSdkPatched = await patchDetectedVercelAiSdk(client, frameworks, resolvedConfig.agentId);
   const openAIAgentsPatched = await patchDetectedOpenAIAgents(client, frameworks);
   const langGraphPatched = await patchDetectedLangGraph(frameworks, resolvedConfig.agentId);

--- a/tests/packaging/langchain-lazy-load.test.ts
+++ b/tests/packaging/langchain-lazy-load.test.ts
@@ -1,0 +1,26 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withPackagingLock } from "./lock.js";
+
+describe("packaging langchain lazy-load", () => {
+  it("init-assembly does not statically import the LangChain adapter", async () => {
+    await withPackagingLock(() => {
+      execSync("pnpm run build:esm", { stdio: "pipe" });
+
+      const initAssembly = fs.readFileSync(
+        path.resolve(process.cwd(), "dist/esm/core/init-assembly.js"),
+        "utf8"
+      );
+
+      // A top-level static import of the adapter would eagerly pull in the
+      // optional @langchain/core peer and break `import "@agent-assembly/sdk"`
+      // for consumers that don't use LangChain (AAASM-2872).
+      expect(initAssembly).not.toMatch(/^\s*import\s[^;]*adapters\/langchain/m);
+
+      // It must instead be loaded lazily, only on the langchain code path.
+      expect(initAssembly).toMatch(/await import\(\s*["']\.\.\/adapters\/langchain/);
+    });
+  }, 60000);
+});


### PR DESCRIPTION
## _Target_

Importing `@agent-assembly/sdk` — even just `{ withAssembly }` / `{ createNoopGatewayClient }` — threw `Cannot find package '@langchain/core'` when that (declared **optional**) peer wasn't installed. Root cause: `src/core/init-assembly.ts` **statically** imported the LangChain adapter barrel, whose `assembly-callback-handler.ts` does `import { BaseCallbackHandler } from "@langchain/core/callbacks/base"`. Since the package only exports `"."`, any root import eagerly evaluated that chain. This blocks AAASM-2846 (running `withAssembly` in non-LangChain examples).

* ### Task summary:

    Make the LangChain adapter **lazy-loaded** — switch the static import to `import type` (erased at runtime) and `await import("../adapters/langchain/index.js")` inside the two langchain-guarded paths (`registerLangChainHandler` / `wrapLangChainTools`), mirroring the existing lazy `@openai/agents` hook. The adapter now loads only when LangChain is detected (and thus `@langchain/core` is present).

* ### Task tickets:

    * Task ID: AAASM-2872.
    * Relative task IDs:
        * [x] AAASM-2842 — added the public gateway client
        * [ ] AAASM-2846 — restore `withAssembly` in node examples (**unblocked by this**, resumes after release)
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    **As-is:** `import { withAssembly } from "@agent-assembly/sdk"` → eager `@langchain/core` load → `ERR_MODULE_NOT_FOUND` without it.
    **To-be:** the SDK imports and `withAssembly` runs with `@langchain/core` absent; the adapter is fetched lazily only on the LangChain path.

## _Effecting Scope_

* Action Types:
    * [x] 🔧 Fixing bug
        * [x] 🟢 No breaking change
* Scopes:
    * [x] 🧩 SDK public API
    * [x] 🤖 Framework hooks
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
* Additional description:
    Behaviour-preserving for LangChain users (the adapter still loads when LangChain is present); it just stops loading for everyone else. No API surface change.

## _Description_

* `♻️ (init-assembly)` Lazy-load the LangChain adapter (`import type` + `await import()` on the guarded paths; `await` the now-async calls).
* `✅ (packaging)` Regression test asserting the built `init-assembly.js` has **no** static `adapters/langchain` import and uses `await import(...)` instead.

**Validation:** `pnpm typecheck` clean · `pnpm lint` clean · `pnpm test` → **182 passed / 2 skipped / 0 failed** (LangChain tests still green). **Runtime proof:** with `@langchain/core` hidden from `node_modules`, importing the built SDK and running `withAssembly({…}, { gatewayClient: createNoopGatewayClient("sdk-only") })` succeeds (previously threw `ERR_MODULE_NOT_FOUND`).
