### PR TITLE
[AAASM-2876] 👨‍💻 (skill): Add sdk-only-release SKILL.md

### DIFF
--- a/.claude/skills/sdk-only-release/SKILL.md
+++ b/.claude/skills/sdk-only-release/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: sdk-only-release
+description: Publish an SDK-only @agent-assembly/sdk release (no agent-assembly core bump) via release-node.yml workflow_dispatch.
+---
+
+# sdk-only-release
+
+Publish a new `@agent-assembly/sdk` version on npm **without** cutting a new
+`agent-assembly` core tag, by dispatching `release-node.yml` directly with
+`workflow_dispatch` inputs.
+
+This skill codifies the dispatch interface that landed via the AAASM-2851
+chain (AAASM-2862–2867 alpha-8.1 validation). The mechanism is identical for
+every SDK-only publish — **the trigger reason is broader than "hotfix"**.
+
+## When to use this skill
+
+An SDK-only release is valid whenever the JavaScript / TypeScript surface of
+`@agent-assembly/sdk` needs a new published version and the `aasm` binary +
+the 4 runtime sub-packages on npm are healthy. Common cases:
+
+- **Hotfix** — bug fix in `src/`, no Rust change.
+- **New SDK feature** — TS-only feature that does not touch the protocol.
+- **Refactor** — SDK internal cleanup without core changes.
+- **Dependency bump** — npm dep upgrade contained to the SDK package.
+- **Doc rebuild for a published JS API** — re-cut to ship a corrected README
+  / typings file.
+- **Pre-release iteration** — `0.0.1-alpha.8.1`, `.2`, … between coordinated
+  releases.
+
+If the change touches the `aasm` binary, any shared Rust crate, or a
+wire-protocol surface, **do not use this skill** — run the coordinated
+`agent-assembly` release instead so the runtime sub-packages re-publish.
+
+Cross-reference: [`docs/release/RUNBOOK.md`](../../../docs/release/RUNBOOK.md)
+§ "SDK-only release".
+
+## The four `workflow_dispatch` input axes
+
+`release-node.yml`'s `workflow_dispatch` exposes four inputs. **Each one
+controls a distinct axis**; coupling them by accident is the source of every
+common mistake.
+
+| Input | Purpose | Common mistake |
+|---|---|---|
+| `npm_version` | Version published on npm for `@agent-assembly/sdk` (and runtime sub-packages in `all` mode). Bare semver, **no leading `v`**. e.g. `0.0.1-alpha.8.1`. | Confused with the agent-assembly binary tag. |
+| `binary_source_tag` | The `agent-assembly` GitHub Release tag whose `aasm-*` tarballs feed the 4 runtime sub-packages. **Has the leading `v`.** e.g. `v0.0.1-alpha.8`. | Confused with `npm_version`; setting these equal defeats the whole point of an SDK-only release. |
+| `publish_mode` | `all` = main SDK + 4 runtime sub-packages. `main-only` = only `@agent-assembly/sdk`; its `optionalDependencies` are rewritten to pin to runtime versions derived from `binary_source_tag` (the leading `v` stripped). | Picking `all` for an SDK-only release re-publishes the runtimes unnecessarily and burns a runtime version slot. |
+| `dry-run` | `true` skips actual npm publish (and the docs-version snapshot). Builds still run; nothing reaches the registry. | Forgetting to run a dry-run first; or shipping the real publish before reviewing the Pre-flight output. |
+
+**Rule of thumb for an SDK-only release**: `npm_version` and
+`binary_source_tag` differ; `publish_mode=main-only`; do `dry-run=true`
+first, then `dry-run=false`.
+
+## Pre-conditions (verify before dispatching)
+
+Run these checks first. Do not dispatch without all three.
+
+1. **`npm_version` is higher than the latest published `@agent-assembly/sdk`
+   and is not yet taken on the registry.** npm publishes are effectively
+   immutable; re-using a version is a fatal error in the workflow's
+   Pre-flight step.
+
+   ```bash
+   npm view @agent-assembly/sdk versions --json | tail -20
+   npm view @agent-assembly/sdk@<npm_version> version  # must 404
+   ```
+
+2. **`binary_source_tag` is an existing `agent-assembly` tag with
+   published GitHub Release assets**, and the corresponding
+   `@agent-assembly/runtime-*@<binary_source_tag_no_v>` packages
+   already exist on npm.
+
+   ```bash
+   gh release view <binary_source_tag> --repo ai-agent-assembly/agent-assembly
+   for plat in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
+     npm view "@agent-assembly/runtime-${plat}@${BINARY_SOURCE_TAG#v}" version
+   done
+   ```
+
+3. **You have already run `dry-run=true` and reviewed the output** —
+   particularly the Pre-flight step's optionalDependencies rewrite. (For
+   the first attempt of any new `npm_version`, this is your first run; the
+   second run flips `dry-run=false`.)
+
+## Executable plan
+
+1. **Dispatch the dry-run.**
+
+   ```bash
+   gh workflow run release-node.yml \
+     --repo ai-agent-assembly/node-sdk \
+     --ref master \
+     -f npm_version=<X> \
+     -f binary_source_tag=<Y> \
+     -f publish_mode=main-only \
+     -f dry-run=true
+   ```
+
+2. **Watch the run and surface the Pre-flight output.** Confirm:
+
+   ```bash
+   gh run watch --repo ai-agent-assembly/node-sdk
+   ```
+
+   - The **Bump main SDK version only (main-only mode)** step rewrote
+     `optionalDependencies['@agent-assembly/runtime-*']` from `workspace:*`
+     to the pinned `<binary_source_tag-no-v>` value.
+   - The **Pre-flight verify runtime sub-packages exist on npm** step
+     resolved all four pinned runtimes.
+   - The publish steps skipped because `dry-run=true`.
+
+3. **If dry-run is green, re-run with `dry-run=false`.**
+
+   ```bash
+   gh workflow run release-node.yml \
+     --repo ai-agent-assembly/node-sdk \
+     --ref master \
+     -f npm_version=<X> \
+     -f binary_source_tag=<Y> \
+     -f publish_mode=main-only \
+     -f dry-run=false
+   ```
+
+4. **Verify the published version.**
+
+   ```bash
+   npm view @agent-assembly/sdk@<X> version
+   npm view @agent-assembly/sdk@<X> optionalDependencies
+   ```
+
+   The four runtime sub-package entries must pin to
+   `<binary_source_tag-no-v>` (not `workspace:*`, not `<X>`).
+
+## Post-conditions
+
+- **dist-tag promotion is a separate, operator-driven step.** If `<X>` should
+  become the default for the alpha channel, the operator runs from their own
+  authenticated npm terminal:
+
+  ```bash
+  npm dist-tag add @agent-assembly/sdk@<X> alpha
+  ```
+
+  This skill names the command but does **not** run it — npm auth is the
+  operator's responsibility.
+
+- Workflow run is green; no operator follow-up is required for the publish
+  itself.
+
+## Known quirks (encode these — do not relearn them)
+
+### Bump step must run before Pre-flight
+
+AAASM-2867: the Pre-flight step historically read
+`optionalDependencies['@agent-assembly/runtime-*']` literally as
+`workspace:*` from `package.json` and failed because `workspace:*` is not a
+valid npm version selector. The fix in `main-only` mode is that the **Bump
+main SDK version only** step now runs **before** Pre-flight and rewrites
+those entries to the pinned `<binary_source_tag-no-v>` value. If a future
+refactor reorders these steps, dry-run will fail on the same symptom. Keep
+the Pre-flight check downstream of the Bump step.
+
+### Docs cascade does NOT fire on `workflow_dispatch`
+
+AAASM-2868 / AAASM-2869: the `deploy_release_documentation` job in the docs
+cascade is gated on the `repository_dispatch` event. A
+`workflow_dispatch`-triggered SDK-only release will **not** push docs.
+
+This is intentional — coordinated releases drive the docs cascade. For an
+SDK-only release that needs documentation updates, the docs PR is opened
+and merged separately (the docs-version snapshot is also skipped by
+`dry-run=true`, and on a real `dry-run=false` run the snapshot lands but
+the cross-repo docs cascade does not).
+
+### `npm_version` has no leading `v`; `binary_source_tag` does
+
+The workflow validates both. A leading `v` on `npm_version` will fail the
+input regex with `npm_version '…' does not match X.Y.Z semver pattern (must
+NOT include leading v)`. A missing leading `v` on `binary_source_tag` will
+fail with `binary_source_tag '…' does not match v*.*.* (semver) pattern`.
+
+### `.N` suffix is the conventional SDK-only version slot
+
+Use `<parent>.<N>` — e.g. `0.0.1-alpha.8.1`, `0.0.1-alpha.8.2` — so the
+SDK-only version sorts after the parent SDK release and existing
+pin-to-exact installs are unaffected until they explicitly upgrade.
+Reserve clean `-alpha.N` slots for coordinated `agent-assembly` releases.


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Add `.claude/skills/sdk-only-release/SKILL.md` codifying the `workflow_dispatch` interface for any **SDK-only** `@agent-assembly/sdk` release (not just hotfixes — new feature, refactor, dep bump, doc rebuild, pre-release iteration all qualify). The skill encodes the four input axes (`npm_version`, `binary_source_tag`, `publish_mode`, `dry-run`), the common-mistake coupling, pre/post-conditions, the executable dispatch plan, and the known quirks landed via the AAASM-2851 chain (AAASM-2862–2867 alpha-8.1 validation).

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: AAASM-2876.
    * Relative task IDs:
        * [x] AAASM-2851 (parent dispatch-interface chain).
        * [x] AAASM-2862, AAASM-2863, AAASM-2864, AAASM-2865, AAASM-2866, AAASM-2867 (dry-run input + Bump-before-Pre-flight fix; alpha-8.1 live validation).
        * [x] AAASM-2868, AAASM-2869 (docs cascade gated on `repository_dispatch` — encoded as a known quirk).
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    Single new file: `.claude/skills/sdk-only-release/SKILL.md`. Frontmatter `name: sdk-only-release`. Cross-links `docs/release/RUNBOOK.md` § "SDK-only release". No source / config / workflow changes.

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [ ] 🤖 Framework hooks
    * [ ] 🫀 Data model and types
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
        * [ ] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [ ] 🚀 Building
        * [ ] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
    * [x] 📚 Documentation
* Additional description:
    Operator-facing release runbook only — no runtime, build, CI, or wire-protocol surface touched. Adds a new `.claude/skills/` skill so future operator sessions can invoke the SDK-only release procedure without relearning the four-axis dispatch interface and the AAASM-2867 Bump-before-Pre-flight ordering quirk.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Create `.claude/skills/sdk-only-release/SKILL.md` with frontmatter `name: sdk-only-release` and `description` matching the ticket.
* Document the four `workflow_dispatch` input axes (`npm_version`, `binary_source_tag`, `publish_mode`, `dry-run`) with the common-mistake column verbatim from AAASM-2876.
* Specify pre-conditions: `npm_version` is higher than the latest published and unused; `binary_source_tag` is an existing `agent-assembly` tag with published assets and matching `@agent-assembly/runtime-*` packages on npm; operator has run `dry-run=true` first and reviewed the output.
* Specify the executable plan: dispatch `dry-run=true` → watch Pre-flight + Bump output → re-dispatch `dry-run=false` → `npm view @agent-assembly/sdk@<X>` to verify.
* Specify the post-condition: `npm dist-tag add @agent-assembly/sdk@<X> alpha` is operator-driven from their authenticated terminal — the skill names the command but does not run it.
* Encode the AAASM-2867 quirk: the **Bump main SDK version only (main-only mode)** step must run before **Pre-flight verify runtime sub-packages exist on npm** so the `optionalDependencies` are rewritten away from `workspace:*` before Pre-flight reads them; reordering breaks dry-run.
* Encode the AAASM-2868 / AAASM-2869 quirk: `documentation.yaml`'s `deploy_release_documentation` job is gated on `repository_dispatch`, so a `workflow_dispatch`-triggered SDK-only release will not push docs.
* Encode the input-format quirks: `npm_version` must have no leading `v`; `binary_source_tag` must have a leading `v`; workflow regex rejects either error.
* Encode the `.N` suffix convention (`0.0.1-alpha.8.1`, `.2`, …) so SDK-only versions sort after their parent and clean `-alpha.N` slots stay reserved for coordinated releases.
* Cross-link `docs/release/RUNBOOK.md` § "SDK-only release".