### PR TITLE
[AAASM-2881] ⬆️ (aa-ffi-node): Bump aa-sdk-client pin to alpha-9 SHA

### DIFF
--- a/native/aa-ffi-node/Cargo.lock
+++ b/native/aa-ffi-node/Cargo.lock
@@ -16,8 +16,8 @@ dependencies = [
 
 [[package]]
 name = "aa-proto"
-version = "0.0.1-alpha.5"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=9cf8a033d39c870ba46a0929b62261d125a00a09#9cf8a033d39c870ba46a0929b62261d125a00a09"
+version = "0.0.1-alpha.9"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=62237d6b469ade830a16bc79b61d3d4edf9df5c4#da3571aa5addb9932e61b47ecaad52138ad33750"
 dependencies = [
  "prost",
  "tonic",
@@ -27,8 +27,8 @@ dependencies = [
 
 [[package]]
 name = "aa-sdk-client"
-version = "0.0.1-alpha.5"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=9cf8a033d39c870ba46a0929b62261d125a00a09#9cf8a033d39c870ba46a0929b62261d125a00a09"
+version = "0.0.1-alpha.9"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=62237d6b469ade830a16bc79b61d3d4edf9df5c4#da3571aa5addb9932e61b47ecaad52138ad33750"
 dependencies = [
  "aa-proto",
  "aa-security",
@@ -39,8 +39,8 @@ dependencies = [
 
 [[package]]
 name = "aa-security"
-version = "0.0.1-alpha.5"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=9cf8a033d39c870ba46a0929b62261d125a00a09#9cf8a033d39c870ba46a0929b62261d125a00a09"
+version = "0.0.1-alpha.9"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=62237d6b469ade830a16bc79b61d3d4edf9df5c4#da3571aa5addb9932e61b47ecaad52138ad33750"
 dependencies = [
  "aho-corasick",
 ]

--- a/native/aa-ffi-node/Cargo.toml
+++ b/native/aa-ffi-node/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 # `rev`); advisory preflight arrives transitively via its default `preflight`
 # feature. AAASM-2559 will formalize a published/pinned distribution + a
 # standalone-build CI smoke check on the agent-assembly side.
-aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "9cf8a033d39c870ba46a0929b62261d125a00a09", package = "aa-sdk-client" }
+aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "62237d6b469ade830a16bc79b61d3d4edf9df5c4", package = "aa-sdk-client" }
 napi = { version = "3", default-features = false, features = ["napi8", "tokio_rt", "serde-json"] }
 napi-derive = "3"
 serde_json = "1"


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Backfill the `aa-sdk-client` git-SHA pin in `native/aa-ffi-node/Cargo.toml` from the 8-day-old AAASM-2627-verify alpha-7-era SHA to the `v0.0.1-alpha.9` tag commit, closing the pin-drift gap identified in AAASM-2880 (drift audit).

    - Old SHA: `9cf8a033d39c870ba46a0929b62261d125a00a09` (AAASM-2627 verify, alpha-7 era, 2026-06-05)
    - New SHA: `62237d6b469ade830a16bc79b61d3d4edf9df5c4` (`v0.0.1-alpha.9` tag commit, 2026-06-13)

    `Cargo.lock` regenerated via `cargo update -p aa-sdk-client` to lock the transitive `aa-proto`/`aa-security` to alpha-9 as well.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: [AAASM-2881](https://lightning-dust-mite.atlassian.net/browse/AAASM-2881).
    * Relative task IDs:
        * [x] [AAASM-2880](https://lightning-dust-mite.atlassian.net/browse/AAASM-2880) — parent drift-audit Story that identified this gap.
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    Single-line `rev = "..."` bump in `native/aa-ffi-node/Cargo.toml` plus the matching `Cargo.lock` regeneration. No source or test changes.

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
* Scopes:
    * [x] 🚀 Building
        * [x] 🔗 Dependencies
* Additional description:
    The bump pulls in any `aa-sdk-client` fixes / API alignments shipped between alpha-7 and alpha-9. Verified locally with `cargo build`, `pnpm native:build`, and `pnpm test` (all green).

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* `native/aa-ffi-node/Cargo.toml`: bump `aa-sdk-client` `rev` pin from `9cf8a033…` to `62237d6b…` (the `v0.0.1-alpha.9` tag commit).
* `native/aa-ffi-node/Cargo.lock`: regenerated via `cargo update -p aa-sdk-client`; `aa-proto`, `aa-sdk-client`, `aa-security` now resolve to `v0.0.1-alpha.9`.

[AAASM-2881]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-2880]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ