### PR TITLE
[AAASM-2896] 📝 (runbook): Document the auto-bump aa-sdk-client pin PR

### DIFF
--- a/docs/release/RUNBOOK.md
+++ b/docs/release/RUNBOOK.md
@@ -131,7 +131,31 @@ exist on the `@agent-assembly/sdk` registry entry — npm publishes are
 effectively immutable within minutes of upload, so re-publishing the
 same version is treated as a fatal user error rather than a no-op.
 
-## 3. Verification
+## 3. Automatic aa-sdk-client pin bump (from agent-assembly)
+
+After each `agent-assembly` release, `agent-assembly`'s `release.yml`
+(`update-node-sdk-ffi-pin` job) **auto-opens a bot PR on this repo** that
+bumps the `aa-sdk-client` git-SHA pin in `native/aa-ffi-node/Cargo.toml` to
+the just-tagged commit.
+
+A few things to keep in mind about that PR:
+
+- **Merging it does NOT republish the npm package.** `release-node.yml`
+  triggers only on `repository_dispatch`
+  (`agent-assembly-release-published`) and `workflow_dispatch` — never on
+  `push`. The npm publish already happened at agent-assembly tag time via
+  the coordinated `repository_dispatch` fan-out (section 1).
+- The bump PR is **source-sync only**: it keeps the FFI shim's pinned
+  `aa-sdk-client` current so the next release — or any from-source build —
+  compiles against the right revision.
+- To avoid the one-cycle source lag (the SDK published at vX was built from
+  the *previous* pin), merge the bump PR **before** the next agent-assembly
+  tag is cut.
+
+See `agent-assembly/docs/release/RUNBOOK.md` sections 3 and 8 for the
+dispatcher and source-pin contract on the agent-assembly side.
+
+## 4. Verification
 
 After the workflow completes, verify on the npm registry:
 
@@ -162,7 +186,7 @@ version on npm.
   back, the AAASM-2855 refactor regressed somewhere in the
   `version-docs` job.
 
-## 4. Recovery — when a publish fails
+## 5. Recovery — when a publish fails
 
 npm publishes are effectively immutable. A failed publish that uploaded
 partial state (e.g. some runtime sub-packages but not `@agent-assembly/sdk`)


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

Document the agent-assembly-driven auto-bump PR that keeps the node-sdk FFI
shim's `aa-sdk-client` git-SHA pin current after each agent-assembly release,
so operators understand it is source-sync only and does not republish npm.

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Added a new section "Automatic aa-sdk-client pin bump (from agent-assembly)"
    to `docs/release/RUNBOOK.md` cross-referencing `agent-assembly`'s
    `release.yml` (`update-node-sdk-ffi-pin` job) and the agent-assembly
    RUNBOOK sections 3 and 8. Renumbered the following sections accordingly.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: AAASM-2896.
    * Relative task IDs:
        * [x] AAASM-2894 (parent).
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    Clarifies that merging the auto-bump PR does NOT republish npm
    (`release-node.yml` triggers only on `repository_dispatch` +
    `workflow_dispatch`), that it is source-sync only, and that it should be
    merged before the next agent-assembly tag to avoid the one-cycle source lag.

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [ ] 🤖 Framework hooks
    * [ ] 🫀 Data model and types
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
        * [ ] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [ ] 🚀 Building
        * [ ] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
    * [x] 📚 Documentation
* Additional description:
    Documentation-only change. No code, build, or CI behaviour affected.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Added a "Automatic aa-sdk-client pin bump (from agent-assembly)" section to
  `docs/release/RUNBOOK.md` describing the `update-node-sdk-ffi-pin` bot PR,
  why merging it does not republish npm, its source-sync-only nature, and the
  recommended merge timing. Cross-references agent-assembly RUNBOOK sections 3
  and 8. Renumbered Verification (now 4) and Recovery (now 5).