### PR TITLE
[AAASM-2922] ✨ (sdk): Export framework patch hooks from public API

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts"
+    },
+    "./hooks": {
+      "import": "./dist/esm/hooks/index.js",
+      "require": "./dist/cjs/hooks/index.js",
+      "types": "./dist/types/hooks/index.d.ts"
     }
   },
   "scripts": {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Public re-exports for the per-framework governance patch hooks
+ * (AAASM-2922).
+ *
+ * These let consumers apply a single framework's governance hook manually,
+ * instead of relying on `initAssembly()` to patch every detected framework.
+ * Only the user-facing patch/unpatch/has surface and the option/module
+ * interfaces those functions take as parameters are re-exported here;
+ * internal helpers (wrappers, patch-state, capture/record utilities) stay
+ * private to their hook modules.
+ */
+
+// Vercel AI SDK
+export { patchVercelAiSdk, unpatchVercelAiSdk } from "./ai-sdk.js";
+export type { PatchVercelAiSdkOptions, VercelAiSdkModule } from "./ai-sdk.js";
+export { hasVercelAiSdk } from "./ai-sdk-detection.js";
+
+// LangGraph
+export { patchLangGraph, unpatchLangGraph } from "./langgraph.js";
+export type { PatchLangGraphOptions, LangGraphModule } from "./langgraph.js";
+export { hasLangGraph } from "./langgraph-detection.js";
+
+// Mastra
+export { patchMastra, unpatchMastra } from "./mastra.js";
+export type { PatchMastraOptions, MastraModule } from "./mastra.js";
+export { hasMastra } from "./mastra-detection.js";
+
+// LangChain
+export { patchLangChain } from "./langchain.js";
+
+// OpenAI Agents
+export { patchOpenAIAgents, unpatchOpenAIAgents } from "./openai-agents.js";
+export type { PatchOpenAIAgentsOptions } from "./openai-agents.js";
+export { hasOpenAIAgentsSDK } from "./openai-agents-detection.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,3 +37,8 @@ export type {
 } from "./types/index.js";
 export { createNoopGatewayClient } from "./gateway/index.js";
 export { PolicyViolationError } from "./errors/index.js";
+// Per-framework governance patch hooks (AAASM-2922). The curated public
+// surface lives in src/hooks/index.ts; re-export it here and via the
+// `@agent-assembly/sdk/hooks` subpath so consumers can apply a single
+// framework's hook manually.
+export * from "./hooks/index.js";

--- a/tests/hooks-public-exports.test.ts
+++ b/tests/hooks-public-exports.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Public-API surface tests for the per-framework patch hooks (AAASM-2922).
+ *
+ * These hooks were previously internal to src/core/init-assembly.ts. This
+ * suite asserts that the curated patch/unpatch/has surface is reachable from
+ * the package entry point (`../src/index.js`) so consumers can apply a single
+ * framework's governance hook manually, and that internal helpers are NOT
+ * leaked through the public barrel.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import * as sdk from "../src/index.js";
+import * as hooks from "../src/hooks/index.js";
+
+describe("public framework hook exports", () => {
+  const publicSymbols = [
+    "patchVercelAiSdk",
+    "unpatchVercelAiSdk",
+    "patchLangGraph",
+    "unpatchLangGraph",
+    "patchMastra",
+    "unpatchMastra",
+    "patchLangChain",
+    "patchOpenAIAgents",
+    "unpatchOpenAIAgents",
+    "hasVercelAiSdk",
+    "hasLangGraph",
+    "hasMastra",
+    "hasOpenAIAgentsSDK"
+  ] as const;
+
+  it.each(publicSymbols)("exposes %s as a function from the package entry", (name) => {
+    expect(typeof (sdk as Record<string, unknown>)[name]).toBe("function");
+  });
+
+  it.each(publicSymbols)("exposes %s from the ./hooks barrel", (name) => {
+    expect(typeof (hooks as Record<string, unknown>)[name]).toBe("function");
+  });
+
+  const internalHelpers = [
+    "createWrappedExecute",
+    "createPatchedToolFactory",
+    "captureOriginalToolFactory",
+    "recordToolResultNonBlocking",
+    "wrapCompiledGraph",
+    "parseToolCallArguments",
+    "vercelAiSdkPatchState",
+    "langGraphPatchState",
+    "mastraPatchState",
+    "openAIAgentsPatchState"
+  ] as const;
+
+  it.each(internalHelpers)("does not leak internal helper %s through the barrel", (name) => {
+    expect((hooks as Record<string, unknown>)[name]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    The per-framework patch hooks in `src/hooks/` were used internally by
    `src/core/init-assembly.ts` but were not re-exported from the public
    package API. This PR exposes the user-facing patch/unpatch/detection
    surface (and the option/module interfaces those functions take) so
    consumers can apply a single framework's governance hook manually
    instead of relying on `initAssembly()` to patch every detected framework.

* ### Task tickets:

    * Task ID: AAASM-2922.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    * **As-is:** Hooks (`patchVercelAiSdk`, `patchLangGraph`, `patchMastra`,
      `patchLangChain`, `patchOpenAIAgents`, and the `has*` detectors) were
      internal-only — reachable solely through `initAssembly()`.
    * **To-be:** A curated barrel `src/hooks/index.ts` re-exports only the
      public patch/unpatch/has surface plus the option/module interfaces.
      It is re-exported from the package entry and via a new
      `@agent-assembly/sdk/hooks` subpath. Internal helpers
      (`createWrappedExecute`, `*PatchState`, `captureOriginal*`,
      `wrapCompiledGraph`, `parseToolCallArguments`, etc.) remain private.

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [x] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [x] 🤖 Framework hooks
    * [ ] 🫀 Data model and types
    * [ ] ⛑️ Error handling
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [x] 🚀 Building
        * [ ] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [x] 📦 Project configurations
    * [ ] 📚 Documentation
* Additional description:
    Additive only — no existing export is changed or removed. The new
    `./hooks` subpath is added alongside the existing `.` entry in the
    `exports` map (`package.json`).

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* `✨ (hooks)`: Add `src/hooks/index.ts` barrel re-exporting the public
  patch/unpatch surface and the option/module interfaces:
  `patchVercelAiSdk`/`unpatchVercelAiSdk` + `PatchVercelAiSdkOptions`/`VercelAiSdkModule`,
  `patchLangGraph`/`unpatchLangGraph` + `PatchLangGraphOptions`/`LangGraphModule`,
  `patchMastra`/`unpatchMastra` + `PatchMastraOptions`/`MastraModule`,
  `patchLangChain`, `patchOpenAIAgents`/`unpatchOpenAIAgents` +
  `PatchOpenAIAgentsOptions`, and the detectors `hasVercelAiSdk`,
  `hasLangGraph`, `hasMastra`, `hasOpenAIAgentsSDK`.
* `✨ (sdk)`: Re-export the curated barrel from `src/index.ts`.
* `🔧 (pkg)`: Add the `./hooks` subpath to the `exports` map, mirroring the
  `.` entry shape (import/require/types into `dist/esm`, `dist/cjs`,
  `dist/types`).
* `✅ (hooks)`: Add `tests/hooks-public-exports.test.ts` asserting the
  public symbols are reachable from the package entry and the `./hooks`
  barrel, and that internal helpers are not leaked.

### How to verify

```
pnpm install
pnpm build      # ESM + CJS — emits dist/{esm,cjs}/hooks/index.js + dist/types/hooks/index.d.ts
pnpm typecheck  # clean
pnpm lint       # clean
pnpm test       # all green, incl. tests/hooks-public-exports.test.ts
```

Closes AAASM-2922.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
