### PR TITLE
[AAASM-2935] 📝 (docs): Add Examples section linking agent-assembly-examples

### DIFF
--- a/docs/09-examples/_category_.json
+++ b/docs/09-examples/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Examples",
+  "position": 9
+}

--- a/docs/09-examples/custom-tool-policy.md
+++ b/docs/09-examples/custom-tool-policy.md
@@ -1,0 +1,125 @@
+---
+sidebar_position: 3
+---
+
+# Custom tool policy
+
+Source: [`node/custom-tool-policy`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/custom-tool-policy)
+
+## What this example demonstrates
+
+A minimal TypeScript example that uses Agent Assembly governance directly, with **no
+agent framework**. It governs two raw TypeScript tools with `withAssembly()` and a
+custom `GatewayClient` that enforces a local policy:
+
+- `read_file` is **allowed** — it executes and returns mock file contents.
+- `write_file` is **denied** — it is blocked at the policy layer before the tool body runs.
+
+The governance point: you do not need an agent framework to get policy enforcement.
+`withAssembly` wraps any object of `{ execute }` tools and checks each call against
+the policy first.
+
+## The framework / library
+
+None. The example depends only on `@agent-assembly/sdk` (version `0.0.1-alpha.9.1`
+in its `package.json`). It runs fully offline — no gateway and no `@langchain/core`.
+
+## How it works
+
+`src/policy.ts` defines two rules (`read_file` → allow, `write_file` → deny) and
+builds an in-process `GatewayClient` whose `check` returns `{ denied: true, reason }`
+for denied tools. `src/index.ts` passes that client to `withAssembly` along with the
+two tool definitions. When `tools.write_file.execute(...)` is called, `withAssembly`
+runs the policy check, sees a deny, and throws a `PolicyViolationError` — the
+`write_file` body never runs.
+
+## Prerequisites & running it
+
+See [Preparing the runtime environment](./setup.md) for the shared prerequisites.
+Then:
+
+```bash
+cd node/custom-tool-policy
+pnpm install
+pnpm start
+```
+
+This example is mock/offline only — no provider keys or gateway URL are needed. To
+connect to a real gateway, set `AAASM_GATEWAY_URL` in your environment directly. Run
+`pnpm test` for the offline smoke test and `pnpm typecheck` for the type check.
+
+## Code walkthrough
+
+The policy is a simple rule table, evaluated by tool name:
+
+```ts title="src/policy.ts"
+export const POLICY_RULES: PolicyRule[] = [
+  { tool: "read_file", action: "allow", reason: "Read-only file access is safe to execute." },
+  { tool: "write_file", action: "deny", reason: "Write operations to the filesystem require explicit approval." },
+];
+```
+
+The local-policy `GatewayClient` turns a deny rule into a denied check result:
+
+```ts title="src/policy.ts"
+check: async (request) => {
+  const rule = evaluate(request.toolName ?? "");
+  return rule.action === "deny"
+    ? { denied: true, reason: rule.reason }
+    : { denied: false };
+},
+```
+
+`index.ts` wraps the tools and handles the denied call by catching
+`PolicyViolationError`:
+
+```ts title="src/index.ts"
+const tools = withAssembly(
+  {
+    read_file: { execute: async (args) => readFile(String(args.path ?? "")).output },
+    write_file: { execute: async (args) => writeFile(String(args.path ?? ""), String(args.content ?? "")).output },
+  },
+  { gatewayClient: createPolicyGatewayClient(), agentId: "custom-tool-policy-agent" }
+);
+
+try {
+  await tools.write_file.execute({ path: "/etc/config", content: "override settings" });
+} catch (err) {
+  if (err instanceof PolicyViolationError) {
+    console.log(`  [BLOCKED] ${err.message}`);
+  }
+}
+```
+
+## Notes & caveats
+
+:::note Offline by design
+The example uses only mock/offline mode. No provider keys or gateway URL are needed,
+and all tests run offline.
+:::
+
+:::tip Default-deny
+The policy's `evaluate()` returns a deny rule for any unlisted tool — unknown tools
+are denied by default.
+:::
+
+## Expected behavior
+
+```text
+=== Custom Tool Policy — Minimal TypeScript Example ===
+
+No agent framework required. Using @agent-assembly/sdk directly.
+
+Calling allowed tool: read_file
+  [ALLOW] Contents of "/data/report.txt": [mock file contents line 1, line 2]
+
+Calling denied tool: write_file
+  [BLOCKED] Tool 'write_file' blocked: Write operations to the filesystem require explicit approval.
+
+All tool calls governed by withAssembly + the local policy.
+```
+
+## Links
+
+- Example directory: [`node/custom-tool-policy`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/custom-tool-policy)
+- Example README: [`README.md`](https://github.com/ai-agent-assembly/agent-assembly-examples/blob/master/node/custom-tool-policy/README.md)

--- a/docs/09-examples/index.md
+++ b/docs/09-examples/index.md
@@ -4,30 +4,44 @@ sidebar_position: 1
 
 # Examples
 
-Runnable, end-to-end Node examples live in the central
+This section walks through the runnable Node examples that ship in the central
 [`agent-assembly-examples`](https://github.com/ai-agent-assembly/agent-assembly-examples)
-repository, under its [`node/`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node)
-directory. Each example is a self-contained project with its own `README` that lists the
-exact install and run steps.
+repository, under its
+[`node/`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node)
+directory. Each example is a self-contained TypeScript project with its own `README`;
+the pages here explain what each one demonstrates, how the governance flow works, and
+walk through the real source.
 
-Every example uses the same wrapping pattern documented in the
-[Guides](../04-guides/index.md): you call `initAssembly()` once to start governance (it
-auto-detects your agent framework), and either pass your tools through `initAssembly` or
-wrap them explicitly with `withAssembly()` so each tool call is policy-checked before it
-runs. The examples differ only in which framework (or none) they integrate with.
+## The shared governance pattern
+
+Every Node example uses the same wrapping pattern documented in the
+[Guides](../04-guides/index.md): you wrap your tools with `withAssembly()` so each
+tool call is policy-checked **before** it runs. A denied call never executes its tool
+body — `withAssembly` throws a `PolicyViolationError` whose message carries the tool
+name and the policy's reason.
+
+To keep the examples deterministic and runnable offline in CI, each one supplies a
+small in-process `GatewayClient` (`mode: "sdk-only"`) that enforces a local
+allow/deny policy without a running gateway. The examples differ only in which
+framework (or none) defines the tools that `withAssembly` governs.
+
+Before running any example, see
+[Preparing the runtime environment](./setup.md) for the shared prerequisites,
+install/run commands, and mock vs. real-provider mode.
 
 ## Node examples
 
-| Example | What it demonstrates |
-| --- | --- |
-| [`custom-tool-policy`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/custom-tool-policy) | Tool-policy governance with no agent framework. |
-| [`langchain-js-basic-agent`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/langchain-js-basic-agent) | A governed LangChain.js ReAct agent. |
-| [`langgraph-js`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/langgraph-js) | Governance over a LangGraph.js state graph. |
-| [`mastra`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/mastra) | Mastra framework integration. |
-| [`openai-node-tool-policy`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/openai-node-tool-policy) | OpenAI Node SDK tool-policy enforcement. |
-| [`vercel-ai`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/vercel-ai) | Vercel AI SDK governance hook. |
+| Example | Framework | Page | Source |
+| --- | --- | --- | --- |
+| `custom-tool-policy` | — (none) | [Custom tool policy](./custom-tool-policy.md) | [dir](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/custom-tool-policy) |
+| `openai-node-tool-policy` | OpenAI Node SDK | [OpenAI Node tool policy](./openai-node-tool-policy.md) | [dir](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/openai-node-tool-policy) |
+| `langchain-js-basic-agent` | LangChain.js | [LangChain.js basic agent](./langchain-js-basic-agent.md) | [dir](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/langchain-js-basic-agent) |
+| `vercel-ai` | Vercel AI SDK | [Vercel AI SDK](./vercel-ai.md) | [dir](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/vercel-ai) |
+| `langgraph-js` | LangGraph.js | [LangGraph.js](./langgraph-js.md) | [dir](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/langgraph-js) |
+| `mastra` | Mastra | [Mastra](./mastra.md) | [dir](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/mastra) |
 
-For full run steps, follow the `README` inside each example directory.
+For the exact run steps, follow the per-example pages above or the `README` inside
+each example directory.
 
 ## Cross-cutting scenarios
 

--- a/docs/09-examples/index.md
+++ b/docs/09-examples/index.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 1
+---
+
+# Examples
+
+Runnable, end-to-end Node examples live in the central
+[`agent-assembly-examples`](https://github.com/ai-agent-assembly/agent-assembly-examples)
+repository, under its [`node/`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node)
+directory. Each example is a self-contained project with its own `README` that lists the
+exact install and run steps.
+
+Every example uses the same wrapping pattern documented in the
+[Guides](../04-guides/index.md): you call `initAssembly()` once to start governance (it
+auto-detects your agent framework), and either pass your tools through `initAssembly` or
+wrap them explicitly with `withAssembly()` so each tool call is policy-checked before it
+runs. The examples differ only in which framework (or none) they integrate with.
+
+## Node examples
+
+| Example | What it demonstrates |
+| --- | --- |
+| [`custom-tool-policy`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/custom-tool-policy) | Tool-policy governance with no agent framework. |
+| [`langchain-js-basic-agent`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/langchain-js-basic-agent) | A governed LangChain.js ReAct agent. |
+| [`langgraph-js`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/langgraph-js) | Governance over a LangGraph.js state graph. |
+| [`mastra`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/mastra) | Mastra framework integration. |
+| [`openai-node-tool-policy`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/openai-node-tool-policy) | OpenAI Node SDK tool-policy enforcement. |
+| [`vercel-ai`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/vercel-ai) | Vercel AI SDK governance hook. |
+
+For full run steps, follow the `README` inside each example directory.
+
+## Cross-cutting scenarios
+
+Beyond the per-framework examples, the
+[`scenarios/`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/scenarios)
+directory contains cross-cutting demos that exercise governance end to end.

--- a/docs/09-examples/langchain-js-basic-agent.md
+++ b/docs/09-examples/langchain-js-basic-agent.md
@@ -1,0 +1,117 @@
+---
+sidebar_position: 5
+---
+
+# LangChain.js basic agent
+
+Source: [`node/langchain-js-basic-agent`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/langchain-js-basic-agent)
+
+## What this example demonstrates
+
+A LangChain.js-style agent that integrates Agent Assembly for tool governance. Every
+tool call is routed through a local policy before execution:
+
+- `get_weather` is **allowed** — it executes and logs output.
+- `delete_file` is **denied** — it is blocked at the policy layer.
+
+The governance point: wrapping an agent's tools with `withAssembly()` enforces policy
+on every tool call the agent makes.
+
+## The framework / library
+
+[LangChain.js](https://js.langchain.com)-style agent. The example depends only on
+`@agent-assembly/sdk` (version `0.0.1-alpha.9.1`); it deliberately avoids
+`@langchain/core` so it runs fully offline in CI with no API keys.
+
+## How it works
+
+`src/tools.ts` defines a `TOOLS` map of mock tool functions. `src/policy.ts` defines
+the allow/deny rules and an in-process `GatewayClient`. `src/index.ts` wraps the tools
+with `withAssembly` and runs each one. The `get_weather` call passes the policy check
+and runs; the `delete_file` call is denied, so `withAssembly` throws
+`PolicyViolationError` before the tool body executes.
+
+## Prerequisites & running it
+
+See [Preparing the runtime environment](./setup.md) for the shared prerequisites.
+Then:
+
+```bash
+cd node/langchain-js-basic-agent
+pnpm install
+pnpm start
+```
+
+Tests run in offline mode — no gateway or API keys required. For **real-provider
+mode**, copy `.env.example` to `.env` and fill in your values:
+
+```bash
+cp .env.example .env
+# Edit .env: set AAASM_GATEWAY_URL and optionally OPENAI_API_KEY
+```
+
+Then `pnpm start` connects to the real gateway and real OpenAI API if configured.
+
+## Code walkthrough
+
+The policy allows the read-only lookup and denies the destructive tool:
+
+```ts title="src/policy.ts"
+export const POLICY_RULES: PolicyRule[] = [
+  { tool: "get_weather", action: "allow", reason: "Read-only external data lookup — safe to execute." },
+  { tool: "delete_file", action: "deny", reason: "Destructive filesystem operations require human approval." },
+];
+```
+
+`index.ts` wraps the tools and handles the denied call:
+
+```ts title="src/index.ts"
+const tools = withAssembly(
+  {
+    get_weather: { execute: async (args) => TOOLS.get_weather(args).output },
+    delete_file: { execute: async (args) => TOOLS.delete_file(args).output },
+  },
+  { gatewayClient: createPolicyGatewayClient(), agentId: "langchain-js-example-agent" }
+);
+
+console.log(`  [ALLOW] ${await tools.get_weather.execute({ location: "Taipei" })}`);
+
+try {
+  await tools.delete_file.execute({ path: "/etc/hosts" });
+} catch (err) {
+  if (err instanceof PolicyViolationError) {
+    console.log(`  [BLOCKED] ${err.message}`);
+  }
+}
+```
+
+## Notes & caveats
+
+:::note No @langchain/core dependency
+The example uses a LangChain.js-style agent without installing `@langchain/core`, so
+it runs offline in CI with no API keys.
+:::
+
+:::caution Gateway connection refused
+If a real gateway is unreachable, omit `AAASM_GATEWAY_URL` to use offline mode.
+:::
+
+## Expected behavior
+
+```text
+=== LangChain.js-style Agent Assembly Example ===
+
+Running allowed tool: get_weather
+  [ALLOW] Weather in Taipei: 22°C, partly cloudy. [mock]
+
+Running denied tool: delete_file
+  [BLOCKED] Tool 'delete_file' blocked: Destructive filesystem operations require human approval.
+
+Done. Tool calls governed by withAssembly + the local policy.
+```
+
+## Links
+
+- Example directory: [`node/langchain-js-basic-agent`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/langchain-js-basic-agent)
+- Example README: [`README.md`](https://github.com/ai-agent-assembly/agent-assembly-examples/blob/master/node/langchain-js-basic-agent/README.md)
+- [LangChain.js](https://js.langchain.com)

--- a/docs/09-examples/langgraph-js.md
+++ b/docs/09-examples/langgraph-js.md
@@ -1,0 +1,131 @@
+---
+sidebar_position: 7
+---
+
+# LangGraph.js
+
+Source: [`node/langgraph-js`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/langgraph-js)
+
+## What this example demonstrates
+
+Governing the tool calls inside a [LangGraph.js](https://langchain-ai.github.io/langgraphjs/)-style
+**state machine** with Agent Assembly. A minimal `StateGraph` (typed state, named
+nodes, edges) runs two nodes, each calling a governed tool:
+
+- The `search` node calls `search_docs` — **allowed**.
+- The `escalate` node calls `execute_shell` — **denied**, blocked with `PolicyViolationError`.
+
+The governance point: governance applies per tool call regardless of where the call
+originates — including from inside a graph node.
+
+## The framework / library
+
+A hand-rolled [LangGraph.js](https://langchain-ai.github.io/langgraphjs/)-style graph.
+The example depends only on `@agent-assembly/sdk` (version `0.0.1-alpha.9.1`).
+
+:::note Why a hand-rolled graph instead of `@langchain/langgraph`
+The real `@langchain/langgraph` package transitively installs `@langchain/core`. These
+non-LangChain examples deliberately avoid that dependency so they run offline in CI
+with no API keys. `src/graph.ts` replays the LangGraph.js shape — a typed state,
+`addNode`/`addEdge`/`setEntryPoint`/`compile`/`invoke` — so the example reads like a
+LangGraph.js graph while staying dependency-free. The governance path is identical to
+a real graph: each node calls a tool wrapped by `withAssembly`.
+:::
+
+## How it works
+
+`src/graph.ts` implements a small `StateGraph`/`CompiledGraph` that walks nodes along
+edges from an entry point. `src/index.ts` builds the governed tools once with
+`withAssembly`, then defines two nodes that call them. `invoke()` runs `search`
+(allowed) then `escalate`; the `escalate` node's `execute_shell` call is denied, so
+`withAssembly` throws `PolicyViolationError`, which the node catches and logs.
+
+## Prerequisites & running it
+
+See [Preparing the runtime environment](./setup.md) for the shared prerequisites.
+Then:
+
+```bash
+cd node/langgraph-js
+pnpm install
+pnpm start
+```
+
+No gateway or API key required — all tests run offline. To connect to a real gateway,
+set `AAASM_GATEWAY_URL` in your environment directly.
+
+## Code walkthrough
+
+The policy allows the knowledge-base search and denies shell execution:
+
+```ts title="src/policy.ts"
+export const POLICY_RULES: PolicyRule[] = [
+  { tool: "search_docs", action: "allow", reason: "Read-only knowledge-base search — safe to execute." },
+  { tool: "execute_shell", action: "deny", reason: "Arbitrary shell execution is never allowed from a graph node." },
+];
+```
+
+Governed tools are built once, then called from inside the graph nodes:
+
+```ts title="src/index.ts"
+const tools = buildGovernedTools(); // withAssembly(...)
+
+const graph = new StateGraph<GraphState>()
+  .addNode("search", async (state) => {
+    const out = await tools.search_docs.execute({ query: state.query });
+    console.log(`  [ALLOW] ${out}`);
+    return { ...state, log: [...state.log, String(out)] };
+  })
+  .addNode("escalate", async (state) => {
+    try {
+      await tools.execute_shell.execute({ command: "rm -rf /" });
+    } catch (err) {
+      if (err instanceof PolicyViolationError) {
+        console.log(`  [BLOCKED] ${err.message}`);
+        return { ...state, log: [...state.log, `BLOCKED: ${err.message}`] };
+      }
+      throw err;
+    }
+    return state;
+  })
+  .setEntryPoint("search")
+  .addEdge("search", "escalate")
+  .addEdge("escalate", END)
+  .compile();
+```
+
+## Notes & caveats
+
+:::note Offline by design
+The example uses only mock/offline mode. No provider key, no live LLM, and no
+`@langchain/core` are required.
+:::
+
+:::tip Governance is location-independent
+The denied `execute_shell` call is blocked the same way whether it is invoked
+top-level or from inside a graph node — `withAssembly` enforces the policy at the call
+site.
+:::
+
+## Expected behavior
+
+```text
+=== LangGraph.js-style Graph — Agent Assembly Governance Example ===
+
+A two-node state machine whose tool calls are governed by withAssembly.
+
+Node "search" — calling allowed tool: search_docs
+  [ALLOW] Top result for "How does Agent Assembly work?": Agent Assembly governs every tool call. [mock]
+
+Node "escalate" — calling denied tool: execute_shell
+  [BLOCKED] Tool 'execute_shell' blocked: Arbitrary shell execution is never allowed from a graph node.
+
+Graph finished with 2 logged steps.
+Done. Graph-node tool calls governed by withAssembly + the local policy.
+```
+
+## Links
+
+- Example directory: [`node/langgraph-js`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/langgraph-js)
+- Example README: [`README.md`](https://github.com/ai-agent-assembly/agent-assembly-examples/blob/master/node/langgraph-js/README.md)
+- [LangGraph.js](https://langchain-ai.github.io/langgraphjs/)

--- a/docs/09-examples/mastra.md
+++ b/docs/09-examples/mastra.md
@@ -1,0 +1,125 @@
+---
+sidebar_position: 8
+---
+
+# Mastra
+
+Source: [`node/mastra`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/mastra)
+
+## What this example demonstrates
+
+Governing tools defined with **[Mastra](https://mastra.ai)'s `createTool`** using
+Agent Assembly. Each tool's `execute` is wrapped by `withAssembly()` + a local-policy
+`GatewayClient`:
+
+- `get_stock_price` is **allowed** — it executes and returns mock output.
+- `place_trade` is **denied** — it is blocked at the policy layer with `PolicyViolationError`.
+
+The governance point: real Mastra tools (defined with `createTool`) can be governed by
+wrapping their `execute` through `withAssembly`.
+
+## The framework / library
+
+[Mastra](https://mastra.ai) — the real `@mastra/core` package (version `^1.0.0` in
+`package.json`), plus `zod` (`^3.25.76`) for the tool schemas and
+`@agent-assembly/sdk` (version `0.0.1-alpha.9.1`). It runs fully offline — no provider
+key and no live LLM.
+
+## How it works
+
+`src/tools.ts` defines two tools with Mastra's `createTool` (each with `inputSchema`,
+`outputSchema`, and a mock `execute`). `src/index.ts` wraps them with `withAssembly`,
+delegating each governed entry to the real Mastra tool's `execute` via a small
+`runMastraTool` helper (Mastra's signature is `(inputData, context) => ...`; the demo
+passes an empty context). Calling the governed `place_trade` triggers a policy deny,
+so `withAssembly` throws `PolicyViolationError` before the Mastra tool runs.
+
+## Prerequisites & running it
+
+See [Preparing the runtime environment](./setup.md) for the shared prerequisites.
+Then:
+
+```bash
+cd node/mastra
+pnpm install
+pnpm start
+```
+
+No gateway or API key required — all tests run offline. To connect to a real gateway,
+set `AAASM_GATEWAY_URL` in your environment directly; to drive a real LLM with a Mastra
+Agent, set `OPENAI_API_KEY`.
+
+## Code walkthrough
+
+Tools are defined with Mastra's `createTool`:
+
+```ts title="src/tools.ts"
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+
+export const getStockPriceTool = createTool({
+  id: "get_stock_price",
+  description: "Look up the latest price for a stock ticker.",
+  inputSchema: z.object({ ticker: z.string() }),
+  outputSchema: z.object({ text: z.string() }),
+  execute: async ({ ticker }) => ({ text: `${ticker}: $123.45 [mock]` }),
+});
+```
+
+`index.ts` wraps the Mastra tools and delegates to their real `execute`:
+
+```ts title="src/index.ts"
+const tools = withAssembly(
+  {
+    get_stock_price: { execute: async (args) => runMastraTool(getStockPriceTool, args) },
+    place_trade: { execute: async (args) => runMastraTool(placeTradeTool, args) },
+  },
+  { gatewayClient: createPolicyGatewayClient(), agentId: "mastra-example-agent" }
+);
+
+const price = await tools.get_stock_price.execute({ ticker: "AASM" });
+console.log(`  [ALLOW] ${JSON.stringify(price)}`);
+
+try {
+  await tools.place_trade.execute({ ticker: "AASM", shares: 100 });
+} catch (err) {
+  if (err instanceof PolicyViolationError) {
+    console.log(`  [BLOCKED] ${err.message}`);
+  }
+}
+```
+
+## Notes & caveats
+
+:::note Uses the real `@mastra/core` package
+This example installs `@mastra/core` and `zod`. It still runs offline because the
+tools return mock output — no provider key or live LLM is involved.
+:::
+
+:::tip withAssembly instead of a framework hook
+The published `@agent-assembly/sdk` alpha exposes governance through the public
+`withAssembly(tools, { gatewayClient })` API, so the example governs each Mastra tool's
+`execute` directly rather than using a framework-specific hook.
+:::
+
+## Expected behavior
+
+```text
+=== Mastra — Agent Assembly Governance Example ===
+
+Tools defined with Mastra's createTool, governed by withAssembly.
+
+Running allowed tool: get_stock_price
+  [ALLOW] {"text":"AASM: $123.45 [mock]"}
+
+Running denied tool: place_trade
+  [BLOCKED] Tool 'place_trade' blocked: Placing trades moves real money — requires human approval.
+
+Done. Mastra tool calls governed by withAssembly + the local policy.
+```
+
+## Links
+
+- Example directory: [`node/mastra`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/mastra)
+- Example README: [`README.md`](https://github.com/ai-agent-assembly/agent-assembly-examples/blob/master/node/mastra/README.md)
+- [Mastra](https://mastra.ai)

--- a/docs/09-examples/openai-node-tool-policy.md
+++ b/docs/09-examples/openai-node-tool-policy.md
@@ -1,0 +1,133 @@
+---
+sidebar_position: 4
+---
+
+# OpenAI Node tool policy
+
+Source: [`node/openai-node-tool-policy`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/openai-node-tool-policy)
+
+## What this example demonstrates
+
+An OpenAI Node SDK-style example that enforces tool policies on tools declared in
+**OpenAI function-calling format**. It governs tool dispatch with `withAssembly()`
+and a custom `GatewayClient` enforcing a local policy:
+
+- `search_web` is **allowed** — it executes and returns mock results.
+- `send_email` is **denied** — it is blocked at the policy layer before execution.
+
+The governance point: tools defined in the OpenAI function-calling schema can be
+dispatched through `withAssembly`, so every dispatch is policy-checked before it runs.
+
+## The framework / library
+
+OpenAI function-calling format (tool schemas), used without a live OpenAI client.
+The example depends only on `@agent-assembly/sdk` (version `0.0.1-alpha.9.1`) and runs
+fully offline — no gateway and no `@langchain/core`.
+
+## How it works
+
+`src/tools.ts` declares two tools in OpenAI `type: "function"` format
+(`TOOL_DEFINITIONS`) plus their mock implementations. `src/policy.ts` defines the
+allow/deny rules and the in-process `GatewayClient`. `src/index.ts` passes both to
+`withAssembly`. When the simulated `send_email` tool call is dispatched, the policy
+check denies it and `withAssembly` throws `PolicyViolationError` before `sendEmail`
+runs.
+
+## Prerequisites & running it
+
+See [Preparing the runtime environment](./setup.md) for the shared prerequisites.
+Then:
+
+```bash
+cd node/openai-node-tool-policy
+pnpm install
+pnpm start
+```
+
+All tests run offline — no gateway or API key required. For **real-provider mode**,
+copy `.env.example` to `.env` and set `AAASM_GATEWAY_URL` and optionally
+`OPENAI_API_KEY`:
+
+```bash
+cp .env.example .env
+# Set AAASM_GATEWAY_URL and optionally OPENAI_API_KEY
+```
+
+## Code walkthrough
+
+Tools are declared in OpenAI function-calling format:
+
+```ts title="src/tools.ts"
+export const TOOL_DEFINITIONS: OpenAITool[] = [
+  {
+    type: "function",
+    function: {
+      name: "search_web",
+      description: "Search the web for information.",
+      parameters: { type: "object", properties: { query: { type: "string", description: "Search query" } }, required: ["query"] },
+    },
+  },
+  // ... send_email ...
+];
+```
+
+The policy allows `search_web` and denies `send_email`:
+
+```ts title="src/policy.ts"
+export const POLICY_RULES: PolicyRule[] = [
+  { tool: "search_web", action: "allow", reason: "Read-only search — safe to execute without approval." },
+  { tool: "send_email", action: "deny", reason: "External communication requires human approval before sending." },
+];
+```
+
+`index.ts` dispatches each governed tool and catches the denied one:
+
+```ts title="src/index.ts"
+const tools = withAssembly(
+  {
+    search_web: { execute: async (args) => searchWeb(String(args.query ?? "")).output },
+    send_email: { execute: async (args) => sendEmail(String(args.to ?? ""), String(args.subject ?? "")).output },
+  },
+  { gatewayClient: createPolicyGatewayClient(), agentId: "openai-node-example-agent" }
+);
+
+try {
+  await tools.send_email.execute({ to: "user@example.com", subject: "Hello from agent" });
+} catch (err) {
+  if (err instanceof PolicyViolationError) {
+    console.log(`  [BLOCKED] ${err.message}`);
+  }
+}
+```
+
+## Notes & caveats
+
+:::note Offline by default
+All tests run offline — no gateway or API key required.
+:::
+
+:::caution Gateway connection refused
+If real-provider mode fails to connect, remove `AAASM_GATEWAY_URL` from `.env` to fall
+back to offline mode.
+:::
+
+## Expected behavior
+
+```text
+=== OpenAI Node SDK-style Agent Assembly Example ===
+
+Available tools: search_web, send_email
+
+Simulating OpenAI tool call: search_web
+  [ALLOW] Search results for "Agent Assembly governance": [mock result 1] [mock result 2]
+
+Simulating OpenAI tool call: send_email (should be denied)
+  [BLOCKED] Tool 'send_email' blocked: External communication requires human approval before sending.
+
+Tool calls governed by withAssembly + the local policy.
+```
+
+## Links
+
+- Example directory: [`node/openai-node-tool-policy`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/openai-node-tool-policy)
+- Example README: [`README.md`](https://github.com/ai-agent-assembly/agent-assembly-examples/blob/master/node/openai-node-tool-policy/README.md)

--- a/docs/09-examples/setup.md
+++ b/docs/09-examples/setup.md
@@ -1,0 +1,90 @@
+---
+sidebar_position: 2
+---
+
+# Preparing the runtime environment
+
+Every Node example in the
+[`agent-assembly-examples`](https://github.com/ai-agent-assembly/agent-assembly-examples)
+repository is a self-contained TypeScript project that shares the same prerequisites
+and run commands. This page collects that common setup once so the per-example pages
+can focus on what each example actually demonstrates.
+
+## Prerequisites
+
+- **Node.js >= 20 LTS** — install from [nodejs.org](https://nodejs.org).
+- **pnpm** — install via `npm install -g pnpm`.
+
+Every example pins `@agent-assembly/sdk` (the [`node-sdk`](https://github.com/ai-agent-assembly/node-sdk)
+package, version `0.0.1-alpha.9.1` at the time of writing) as its only required
+dependency. The framework-specific examples add one extra package each
+(`@mastra/core` for Mastra, `ai` for the Vercel AI SDK).
+
+## Get the examples
+
+Clone the examples monorepo and change into the example you want to run:
+
+```bash
+git clone https://github.com/ai-agent-assembly/agent-assembly-examples.git
+cd agent-assembly-examples/node/<example-name>
+```
+
+The available `<example-name>` directories are listed on the
+[Examples overview](./index.md).
+
+## Common run commands
+
+Each example exposes the same four pnpm scripts:
+
+```bash
+pnpm install     # install @agent-assembly/sdk (+ any framework dependency)
+pnpm start       # run the example (node --import tsx/esm src/index.ts)
+pnpm test        # run the deterministic smoke test (vitest run)
+pnpm typecheck   # type-check with tsc --noEmit
+```
+
+The shortest path to seeing an example work is three commands:
+
+```bash
+cd node/<example-name>
+pnpm install
+pnpm start
+```
+
+## Mock mode vs. real-provider mode
+
+:::tip Examples run offline by default
+Every Node example runs **fully offline** out of the box. The tools return mock
+output and the policy is enforced in-process by a local-policy `GatewayClient`, so
+no gateway, no API key, and no live LLM are required. This is what makes the smoke
+tests deterministic in CI.
+:::
+
+To connect an example to a **real Agent Assembly gateway**, set the gateway
+environment variables in your shell. The examples that ship a `.env.example`
+(every framework example) document the same variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `AAASM_GATEWAY_URL` | URL of a running gateway, e.g. `http://localhost:7391`. Omit to use offline/noop mode. |
+| `AAASM_API_KEY` | API key — required only when the gateway has auth enabled. |
+| `OPENAI_API_KEY` | Provider key — only needed to drive a real LLM. Not used by `custom-tool-policy`. |
+
+For the framework examples, copy the template and edit it:
+
+```bash
+cp .env.example .env
+# Edit .env: set AAASM_GATEWAY_URL and optionally OPENAI_API_KEY
+```
+
+`custom-tool-policy` ships no `.env.example` — it is mock-only. To point it at a
+real gateway, set `AAASM_GATEWAY_URL` in your environment directly.
+
+## Starting or reaching a gateway
+
+Real-provider mode talks to an Agent Assembly **gateway**. As described in the
+[Quick start](../02-quick-start/index.md), you can either let the SDK auto-start a
+local gateway (if the `aasm` binary is on your `PATH`, a zero-config
+`initAssembly()` probes `http://localhost:7391` and starts one for you) or point at
+a gateway you already run by setting `AAASM_GATEWAY_URL`. The examples themselves
+default to offline mode and do not require a gateway to run.

--- a/docs/09-examples/vercel-ai.md
+++ b/docs/09-examples/vercel-ai.md
@@ -1,0 +1,128 @@
+---
+sidebar_position: 6
+---
+
+# Vercel AI SDK
+
+Source: [`node/vercel-ai`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/vercel-ai)
+
+## What this example demonstrates
+
+Governing tools defined with the **Vercel AI SDK `tool()` factory** using Agent
+Assembly. Each tool's `execute` is wrapped by `withAssembly()` + a local-policy
+`GatewayClient`:
+
+- `get_weather` is **allowed** — it executes and returns mock output.
+- `send_email` is **denied** — it is blocked at the policy layer with `PolicyViolationError`.
+
+The governance point: real Vercel AI SDK tools run unchanged; governance is layered on
+top by wrapping the tool map.
+
+## The framework / library
+
+[Vercel AI SDK](https://sdk.vercel.ai) — the real `ai` package (version `^6.0.0` in
+`package.json`), plus `zod` (`^3.25.76`) for input schemas and `@agent-assembly/sdk`
+(version `0.0.1-alpha.9.1`). It runs fully offline — no provider key and no live LLM.
+
+## How it works
+
+`src/tools.ts` defines two tools with the Vercel AI SDK `tool()` factory, each with a
+`zod` `inputSchema` and a mock `execute`. `src/index.ts` passes the tool map to
+`withAssembly`, which keys the policy by the map key (`get_weather`, `send_email`) and
+wraps each tool's `execute`. Calling the governed `send_email` triggers a policy deny,
+so `withAssembly` throws `PolicyViolationError` before the underlying tool runs.
+
+Because these are real Vercel AI SDK tools, `execute` takes the SDK's
+`(input, { toolCallId, messages })` signature.
+
+## Prerequisites & running it
+
+See [Preparing the runtime environment](./setup.md) for the shared prerequisites.
+Then:
+
+```bash
+cd node/vercel-ai
+pnpm install
+pnpm start
+```
+
+No gateway or API key required — all tests run offline. To connect to a real gateway,
+set `AAASM_GATEWAY_URL` in your environment directly; to drive a real LLM, set
+`OPENAI_API_KEY`.
+
+## Code walkthrough
+
+Tools are defined with the Vercel AI SDK `tool()` factory:
+
+```ts title="src/tools.ts"
+import { tool } from "ai";
+import { z } from "zod";
+
+export const getWeatherTool = tool({
+  description: "Look up the current weather for a location.",
+  inputSchema: z.object({ location: z.string() }),
+  execute: async ({ location }): Promise<string> =>
+    `Weather in ${location}: 22°C, partly cloudy. [mock]`,
+});
+```
+
+`index.ts` governs the tool map and invokes each tool with the Vercel AI SDK call
+signature:
+
+```ts title="src/index.ts"
+const tools = withAssembly(
+  { get_weather: getWeatherTool, send_email: sendEmailTool },
+  { gatewayClient: createPolicyGatewayClient(), agentId: "vercel-ai-example-agent" }
+);
+
+const weather = await tools.get_weather.execute?.(
+  { location: "Taipei" },
+  { toolCallId: "call_weather", messages: [] }
+);
+
+try {
+  await tools.send_email.execute?.(
+    { to: "ops@example.com", body: "exfiltrate everything" },
+    { toolCallId: "call_email", messages: [] }
+  );
+} catch (err) {
+  if (err instanceof PolicyViolationError) {
+    console.log(`  [BLOCKED] ${err.message}`);
+  }
+}
+```
+
+## Notes & caveats
+
+:::note Uses the real `ai` package
+This example installs the real Vercel AI SDK (`ai`) and `zod`. It still runs offline
+because the tools return mock output — no provider key or live LLM is involved.
+:::
+
+:::tip withAssembly instead of a framework hook
+The published `@agent-assembly/sdk` alpha exposes governance through the public
+`withAssembly(tools, { gatewayClient })` API, so the example wraps each tool's
+`execute` directly rather than using a framework-specific hook.
+:::
+
+## Expected behavior
+
+```text
+=== Vercel AI SDK — Agent Assembly Governance Example ===
+
+Tools defined with the Vercel AI SDK `tool()` factory, governed by withAssembly.
+
+Running allowed tool: get_weather
+  [ALLOW] Weather in Taipei: 22°C, partly cloudy. [mock]
+
+Running denied tool: send_email
+  [BLOCKED] Tool 'send_email' blocked: Outbound messaging can exfiltrate data — requires human approval.
+
+Done. Vercel AI SDK tool calls governed by withAssembly + the local policy.
+```
+
+## Links
+
+- Example directory: [`node/vercel-ai`](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/vercel-ai)
+- Example README: [`README.md`](https://github.com/ai-agent-assembly/agent-assembly-examples/blob/master/node/vercel-ai/README.md)
+- [Vercel AI SDK](https://sdk.vercel.ai)


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

* ### Task summary:

    The node-sdk docs (Docusaurus) did not document the central runnable examples repo
    `agent-assembly-examples`. This adds a full multi-page **Examples** docs section: an
    overview, a shared setup page, and one detailed page per Node example so readers get
    a working, copy-pasteable starting point grounded in the real example source.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: AAASM-2935.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    * **As-is:** no docs section points at `agent-assembly-examples`; readers cannot
      discover or understand the runnable Node examples from the SDK docs.
    * **To-be:** a new `docs/09-examples/` **section** (placed after Troubleshooting)
      with an overview, a shared "Preparing the runtime environment" page, and a
      detailed page per example. Each example page explains what it demonstrates, the
      framework/version, the governance flow, the real run commands, an annotated code
      walkthrough, caveats, and the expected output — all derived from each example's
      actual `README.md` and `src/*.ts`.

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [ ] 🤖 Framework hooks
    * [ ] 🫀 Data model and types
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
        * [ ] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [ ] 🚀 Building
        * [ ] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
    * [x] 📚 Documentation
* Additional description:
    Docs-only change. New Markdown pages plus the existing Docusaurus `_category_.json`.
    No source, build config, or runtime behavior is touched. The sidebar is
    autogenerated, so ordering is controlled by each page's `sidebar_position`.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

The Examples section (`docs/09-examples/`, sidebar position 9, after Troubleshooting)
now contains:

1. **Overview** (`index.md`, position 1) — what the section is, the shared
   `withAssembly()` governance pattern, and a table linking each per-example page and
   its source directory.
2. **Preparing the runtime environment** (`setup.md`, position 2) — the shared
   prerequisites (Node >= 20 LTS, pnpm), cloning `agent-assembly-examples`, the common
   `pnpm install` / `pnpm start` / `pnpm test` / `pnpm typecheck` commands, the env
   vars (`AAASM_GATEWAY_URL`, `AAASM_API_KEY`, `OPENAI_API_KEY`), and mock vs.
   real-provider mode.
3. **One detailed page per Node example** (positions 3–8), each grounded in the real
   `README.md` + `src/*.ts`:
   * `custom-tool-policy.md` — minimal SDK usage, no framework.
   * `openai-node-tool-policy.md` — OpenAI function-calling tool dispatch.
   * `langchain-js-basic-agent.md` — LangChain.js-style agent.
   * `vercel-ai.md` — Vercel AI SDK `tool()` factory.
   * `langgraph-js.md` — LangGraph.js-style state machine.
   * `mastra.md` — Mastra `createTool` tools.

Each example page covers: what it demonstrates, the framework/library + version, how
the governance flow works, prerequisites & running it, an annotated code walkthrough,
notes & caveats (Docusaurus admonitions), the expected output, and links to the
example directory and README.

### How to verify

* Inspect the diff: it is limited to new/updated Markdown under `docs/09-examples/`,
  no source changes.
* All internal doc links (`./setup.md`, the six per-example pages, `../02-quick-start`,
  `../04-guides`) resolve to existing files.
* Each example link resolves to a real directory under
  `https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node/`.
* Optionally run the Docusaurus build; the Examples section appears after
  Troubleshooting with Overview → Setup → the six example pages in order.

Closes AAASM-2935.