### PR TITLE
🤖 (aa-ffi-node): Bump aa-sdk-client pin to v0.0.1-beta.1

### DIFF
--- a/native/aa-ffi-node/Cargo.lock
+++ b/native/aa-ffi-node/Cargo.lock
@@ -16,8 +16,8 @@ dependencies = [
 
 [[package]]
 name = "aa-proto"
-version = "0.0.1-alpha.9"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=62237d6b469ade830a16bc79b61d3d4edf9df5c4#da3571aa5addb9932e61b47ecaad52138ad33750"
+version = "0.0.1-beta.1"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=cfb7342bbbda6224a6f0f10d52776f75ba6cb78b#cfb7342bbbda6224a6f0f10d52776f75ba6cb78b"
 dependencies = [
  "prost",
  "tonic",
@@ -27,8 +27,8 @@ dependencies = [
 
 [[package]]
 name = "aa-sdk-client"
-version = "0.0.1-alpha.9"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=62237d6b469ade830a16bc79b61d3d4edf9df5c4#da3571aa5addb9932e61b47ecaad52138ad33750"
+version = "0.0.1-beta.1"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=cfb7342bbbda6224a6f0f10d52776f75ba6cb78b#cfb7342bbbda6224a6f0f10d52776f75ba6cb78b"
 dependencies = [
  "aa-proto",
  "aa-security",
@@ -39,8 +39,8 @@ dependencies = [
 
 [[package]]
 name = "aa-security"
-version = "0.0.1-alpha.9"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=62237d6b469ade830a16bc79b61d3d4edf9df5c4#da3571aa5addb9932e61b47ecaad52138ad33750"
+version = "0.0.1-beta.1"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=cfb7342bbbda6224a6f0f10d52776f75ba6cb78b#cfb7342bbbda6224a6f0f10d52776f75ba6cb78b"
 dependencies = [
  "aho-corasick",
 ]

--- a/native/aa-ffi-node/Cargo.toml
+++ b/native/aa-ffi-node/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 # `rev`); advisory preflight arrives transitively via its default `preflight`
 # feature. AAASM-2559 will formalize a published/pinned distribution + a
 # standalone-build CI smoke check on the agent-assembly side.
-aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "62237d6b469ade830a16bc79b61d3d4edf9df5c4", package = "aa-sdk-client" }
+aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "cfb7342bbbda6224a6f0f10d52776f75ba6cb78b", package = "aa-sdk-client" }
 napi = { version = "3", default-features = false, features = ["napi8", "tokio_rt", "serde-json"] }
 napi-derive = "3"
 serde_json = "1"


### PR DESCRIPTION
Auto-bump `aa-sdk-client` git-SHA pin in `native/aa-ffi-node/Cargo.toml`
to track agent-assembly release `v0.0.1-beta.1` (commit
`cfb7342bbbda6224a6f0f10d52776f75ba6cb78b`).

Why: without this PR, the SDK source pin drifts behind the published
agent-assembly binaries (AAASM-2880 observed an 8-day drift behind
alpha-9). Merging this PR on `node-sdk` realigns the native shim
with the matching upstream tag.

Upstream tag: https://github.com/ai-agent-assembly/agent-assembly/releases/tag/v0.0.1-beta.1
Source workflow: https://github.com/ai-agent-assembly/agent-assembly/actions/runs/27501607345