### PR TITLE
[AAASM-2955] 🐛 (readme): Fix stale version badges + cut node-sdk GitHub Release

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -55,6 +55,9 @@ jobs:
   publish:
     name: Publish @agent-assembly/sdk + 4 runtime sub-packages to npm
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # AAASM-2955: create the git tag + GitHub Release for the published version
+      id-token: write  # npm OIDC Trusted Publishing + SLSA provenance
     outputs:
       binary_source_tag: ${{ steps.tag.outputs.binary_source_tag }}
       npm_version: ${{ steps.tag.outputs.npm_version }}
@@ -359,6 +362,39 @@ jobs:
           echo "Publishing main SDK at version=$VERSION dist-tag arg='$DIST_TAG'"
           # shellcheck disable=SC2086
           pnpm publish --access public --no-git-checks $DIST_TAG
+
+      # AAASM-2955: cut a git tag + GitHub Release at the published npm
+      # version so the README "GitHub release" badge tracks the current
+      # release. Runs only on the real-publish path (dry-run skips it, same
+      # gate as the publish steps above). Idempotent: if the tag/release
+      # already exists (e.g. a workflow_dispatch re-run for a partial
+      # publish), it is left untouched rather than failing the job.
+      - name: Cut git tag + GitHub Release for published version
+        if: steps.tag.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_VERSION: ${{ steps.tag.outputs.npm_version }}
+          BINARY_SOURCE_TAG: ${{ steps.tag.outputs.binary_source_tag }}
+        run: |
+          set -euo pipefail
+          tag="v${NPM_VERSION}"
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::notice::GitHub Release $tag already exists — leaving it untouched (idempotent re-run)."
+            exit 0
+          fi
+          # Mark pre-release for any SemVer pre-release identifier (e.g.
+          # 0.0.1-beta.1); a bare X.Y.Z is a stable release.
+          prerelease_flag=""
+          if [[ "$NPM_VERSION" == *-* ]]; then
+            prerelease_flag="--prerelease"
+          fi
+          # shellcheck disable=SC2086
+          gh release create "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "$tag" \
+            $prerelease_flag \
+            --notes "node-sdk @agent-assembly/sdk@${NPM_VERSION} (bundled aasm binaries from agent-assembly ${BINARY_SOURCE_TAG})."
 
   # AAASM-2751: cut the immutable Docusaurus docs snapshot for this release
   # and repoint the channel metadata. This runs ONLY after `publish` succeeds,

--- a/README.md
+++ b/README.md
@@ -17,16 +17,17 @@ TypeScript/Node.js SDK for Agent Assembly, licensed under Apache 2.0.
 
 ## Project status
 
-> **Pre-1.0 / alpha.** The current release line is `0.0.1-alpha.x`, published to npm under
-> the `alpha` dist-tag. The public surface (`initAssembly`, `withAssembly`) is stabilizing
-> but **may change between alpha releases**, and per-platform native packaging is still
-> being hardened. Pin an exact version for reproducible installs and review the
+> **Pre-1.0 / beta.** The current release line is `0.0.1-beta.x`, published to npm under
+> the `beta` dist-tag and cut as a [GitHub Release](https://github.com/ai-agent-assembly/node-sdk/releases).
+> The public surface (`initAssembly`, `withAssembly`) is stabilizing but **may change between
+> pre-releases**, and per-platform native packaging is still being hardened. Pin an exact
+> version for reproducible installs and review the
 > [release notes](https://github.com/ai-agent-assembly/node-sdk/releases) before upgrading.
 > Production deployments should track the first `0.1.0` release.
 
 ```bash
-pnpm add @agent-assembly/sdk@alpha             # latest alpha (tracks @alpha dist-tag)
-pnpm add @agent-assembly/sdk@<X.Y.Z-alpha.N>   # pin exact — replace the placeholder with the
+pnpm add @agent-assembly/sdk@beta              # latest beta (tracks @beta dist-tag)
+pnpm add @agent-assembly/sdk@<X.Y.Z-beta.N>    # pin exact — replace the placeholder with the
                                                # desired version from npmjs.com/package/@agent-assembly/sdk
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/test-matrix.yml/badge.svg?branch=master&logo=githubactions)](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/test-matrix.yml)
 [![Docs](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/publish-docs.yml/badge.svg?branch=master&logo=githubactions)](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/publish-docs.yml)
 [![npm version](https://img.shields.io/npm/v/%40agent-assembly%2Fsdk/beta?logo=npm)](https://www.npmjs.com/package/@agent-assembly/sdk/v/beta)
+[![GitHub release](https://img.shields.io/github/v/release/ai-agent-assembly/node-sdk?include_prereleases&sort=semver&label=release&logo=github)](https://github.com/ai-agent-assembly/node-sdk/releases)
 [![TypeScript types](https://img.shields.io/npm/types/@agent-assembly/sdk?logo=typescript)](https://www.npmjs.com/package/@agent-assembly/sdk)
 [![Bundle size](https://img.shields.io/bundlephobia/min/@agent-assembly/sdk?logo=webpack&label=min)](https://bundlephobia.com/package/@agent-assembly/sdk)
 [![Downloads](https://img.shields.io/npm/dm/@agent-assembly/sdk?logo=npm&label=downloads%2Fmo)](https://www.npmjs.com/package/@agent-assembly/sdk)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/test-matrix.yml/badge.svg?branch=master&logo=githubactions)](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/test-matrix.yml)
 [![Docs](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/publish-docs.yml/badge.svg?branch=master&logo=githubactions)](https://github.com/ai-agent-assembly/node-sdk/actions/workflows/publish-docs.yml)
-[![npm version](https://img.shields.io/npm/v/@agent-assembly/sdk/alpha?logo=npm)](https://www.npmjs.com/package/@agent-assembly/sdk/v/alpha)
+[![npm version](https://img.shields.io/npm/v/%40agent-assembly%2Fsdk/beta?logo=npm)](https://www.npmjs.com/package/@agent-assembly/sdk/v/beta)
 [![TypeScript types](https://img.shields.io/npm/types/@agent-assembly/sdk?logo=typescript)](https://www.npmjs.com/package/@agent-assembly/sdk)
 [![Bundle size](https://img.shields.io/bundlephobia/min/@agent-assembly/sdk?logo=webpack&label=min)](https://bundlephobia.com/package/@agent-assembly/sdk)
 [![Downloads](https://img.shields.io/npm/dm/@agent-assembly/sdk?logo=npm&label=downloads%2Fmo)](https://www.npmjs.com/package/@agent-assembly/sdk)


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    The README version badges were stale: the npm "version" badge was hard-pinned to the `alpha` dist-tag (rendering `0.0.1-alpha.9.1`) while the current coordinated release line is the `beta` channel (`@agent-assembly/sdk@0.0.1-beta.1`), and there was no badge tracking this repo's own GitHub Release. Per the owner's direction each SDK should cut its own GitHub Release and have its badges track the current release.

    This PR repoints the npm badge to the `beta` dist-tag, adds a GitHub release badge, refreshes the alpha-only "Project status" prose to the beta channel, and teaches `release-node.yml` to cut a git tag + GitHub Release at the published npm version after every real publish so the release badge stays current automatically. The current `v0.0.1-beta.1` GitHub Release was also backfilled out-of-band so the new badge resolves immediately.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: AAASM-2955.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    * npm version badge: `…/npm/v/@agent-assembly/sdk/alpha` → `…/npm/v/%40agent-assembly%2Fsdk/beta` (link to `…/package/@agent-assembly/sdk/v/beta`).
    * Added GitHub release badge: `…/github/v/release/ai-agent-assembly/node-sdk?include_prereleases&sort=semver` → resolves to `v0.0.1-beta.1`.
    * "Project status" callout + install snippet: `alpha` → `beta` channel.
    * `release-node.yml`: new idempotent step cuts `v<npm_version>` tag + GitHub Release on the real-publish path (skipped on dry-run); `publish` job granted `contents: write`.

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [ ] ✨ Adding new something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [x] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [ ] 🤖 Framework hooks
    * [ ] 🫀 Data model and types
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
        * [ ] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
    * [x] 📚 Documentation
* Additional description:
    No runtime/SDK code changed. Changes are limited to `README.md` and the release CI workflow. The new release-cutting step is gated on the real-publish path (dry-run is skipped) and is idempotent, so workflow re-runs do not fail.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* `🐛 (readme): Track beta dist-tag in npm version badge`
* `📝 (readme): Add GitHub release badge tracking current release`
* `📝 (readme): Update project-status callout to beta channel`
* `🔧 (release): Cut git tag + GitHub Release at published npm version`

Closes AAASM-2955.
