### PR TITLE
[AAASM-3007] 📝 (sdk-only-release): Add release-coordination SOP for agent-assembly cycles

### DIFF
--- a/.claude/skills/sdk-only-release/EXAMPLES.md
+++ b/.claude/skills/sdk-only-release/EXAMPLES.md
@@ -64,3 +64,63 @@ the skill named the command but did **not** run it:
 ```bash
 npm dist-tag add @agent-assembly/sdk@0.0.1-alpha.8.1 alpha
 ```
+
+---
+
+## Two cases — when to use this skill
+
+The `sdk-only-release` skill's [SKILL.md SOP](SKILL.md#release-coordination-sop--when-agent-assembly-is-also-releasing) defines two release shapes. The worked example above (`alpha-8.1`) is a **Case B** scenario — SDK-only release with healthy binaries from the previous coordinated cycle. The walkthrough below shows the **Case A** coordinated cycle.
+
+## Case A — coordinated cycle (wait for agent-assembly)
+
+Worked example for the SOP. **Scenario**: operator wants to publish `@agent-assembly/sdk@0.0.1-beta.3` **alongside** agent-assembly `v0.0.1-beta.3` — both carry the same content cycle. The SOP requires the SDK dispatch to wait for the upstream tag + the auto-bump PR.
+
+**1. Verify the agent-assembly tag exists and `release.yml` finished green.**
+
+```bash
+$ gh release view v0.0.1-beta.3 --repo ai-agent-assembly/agent-assembly \
+    --json tagName,publishedAt
+{"tagName":"v0.0.1-beta.3","publishedAt":"2026-..."}
+
+$ gh run list --repo ai-agent-assembly/agent-assembly --workflow release.yml \
+    --branch v0.0.1-beta.3 --limit 1 --json conclusion,name
+[{"name":"Release","conclusion":"success"}]
+```
+
+If the release is missing or the run is still in progress, STOP — do not dispatch the SDK release yet.
+
+**2. Verify the `bot/aa-ffi-pin-v0.0.1-beta.3` PR opened on this repo.**
+
+```bash
+$ gh pr list --repo ai-agent-assembly/node-sdk --head bot/aa-ffi-pin-v0.0.1-beta.3 \
+    --json number,title,mergedAt
+[{"number":NNN,"title":"🤖 (aa-ffi-node): Bump aa-sdk-client pin to v0.0.1-beta.3","mergedAt":null}]
+```
+
+If no PR is listed, the upstream `update-node-sdk-ffi-pin` job (AAASM-2883) hasn't run yet. Wait, then re-probe.
+
+**3. Review + merge the auto-bump PR.** The PR moves `native/aa-ffi-node/Cargo.toml`'s `aa-sdk-client` rev to the new agent-assembly tag commit (and regenerates `Cargo.lock`). After merge, master carries the binary-matching SHA pin.
+
+**4. ONLY NOW dispatch `release-node.yml`.** Same mechanics as the alpha-8.1 example above — `dry-run=true` first, then `dry-run=false`. Critically, use `binary_source_tag=v0.0.1-beta.3` (NOT the previous tag) so the runtime sub-packages resolve against the new agent-assembly Release, and `publish_mode=all` because this is a coordinated release with new binaries (the `main-only` mode is the Case B shape).
+
+```bash
+gh workflow run release-node.yml \
+  --repo ai-agent-assembly/node-sdk \
+  --ref master \
+  -f npm_version=0.0.1-beta.3 \
+  -f binary_source_tag=v0.0.1-beta.3 \
+  -f publish_mode=all \
+  -f dry-run=true
+```
+
+**5. Verify on the registry** (same probes as the alpha-8.1 example: `npm view @agent-assembly/sdk@0.0.1-beta.3 version`, `npm view @agent-assembly/sdk@0.0.1-beta.3 optionalDependencies`).
+
+### Anti-example — what happens if you skip steps 1-3
+
+This is the 2026-06-15 foot-gun the SOP prevents:
+
+- **02:21 UTC** — operator dispatched `release-node.yml` with `npm_version=0.0.1-beta.2` while agent-assembly's latest release was still `v0.0.1-beta.1`. `binary_source_tag` defaulted to "latest agent-assembly release" → resolved to `v0.0.1-beta.1`. `dry-run` defaulted to false. **npm accepted the publish**, bundling the runtime sub-packages from the previous tag's GitHub Release.
+- **09:36 UTC** — agent-assembly's actual `v0.0.1-beta.2` tag cut (commit `0aa9c945`, AAASM-3004) → `notify-downstream` fired the coordinated republish. `release-node.yml` tried to re-publish `0.0.1-beta.2` with the new content carrying the AAASM-3000 IPC fix. **npm 403'd** with `You cannot publish over the previously published versions: 0.0.1-beta.2`.
+- **Net**: `@agent-assembly/sdk@0.0.1-beta.2` on npm carries the OLD content (no AAASM-3000 fix). The version slot is permanently burnt — npm allows unpublish within 72h but disallows republish at the same version even after unpublish. The fix had to ship under a different SDK version cut later.
+
+The verification probes in steps 1-3 above make this impossible to repeat: any of them failing forces the operator to stop and resolve before dispatch.

--- a/.claude/skills/sdk-only-release/SKILL.md
+++ b/.claude/skills/sdk-only-release/SKILL.md
@@ -59,6 +59,34 @@ doc rebuild for a published JS API, or pre-release iteration
 Cross-reference: [`docs/release/RUNBOOK.md`](../../../docs/release/RUNBOOK.md)
 § "SDK-only release".
 
+## Release-coordination SOP — when agent-assembly is ALSO releasing
+
+This is the canonical ordering rule operators MUST follow whenever `agent-assembly` is cutting a release in the same version cycle as this SDK. Codified after the 2026-06-15 incident (AAASM-3007).
+
+### Case A — agent-assembly is ALSO releasing this version cycle
+
+The SDK release MUST wait. Required order:
+
+1. Cut the `agent-assembly` tag (e.g. `v0.0.1-beta.3`) and wait for its `Release` workflow to complete (build → publish → `notify-downstream`).
+2. Wait for the auto-bump PR (`bot/aa-ffi-pin-<tag>`) to open on this repo (AAASM-2883 for node/python; AAASM-3006 extends the same fan-out to go-sdk).
+3. Review + merge the auto-bump PR. This brings `master` in line with the `aa-sdk-client` SHA carried by the new agent-assembly tag.
+4. ONLY THEN cut the SDK tag (matching version) — by tag-push OR `workflow_dispatch` — to fire this skill.
+
+Do NOT pre-publish the SDK tag against the previous agent-assembly content. Doing so:
+
+- Burns the version slot on the registry (npm / PyPI refuse re-publish).
+- Means users installing that SDK version get content that does NOT carry the agent-assembly fix they expect.
+
+### Case B — SDK-only release (no agent-assembly cut in this cycle)
+
+This skill may be triggered freely via `workflow_dispatch`. No coordination required, because the existing `aa-sdk-client` SHA pin on `master` is already what we want to ship.
+
+### Why this SOP exists (the 2026-06-15 incident)
+
+On 2026-06-15 02:21 UTC, `@agent-assembly/sdk@0.0.1-beta.2` was published to npm via `workflow_dispatch` while `agent-assembly`'s latest release was still `v0.0.1-beta.1` (pre-AAASM-3000 IPC fix). The bundle on npm at version `0.0.1-beta.2` therefore does NOT carry the AAASM-3000 fix that users would reasonably expect from that version label. Same incident on PyPI at 02:22 UTC.
+
+The fix is operator discipline (this SOP), not a workflow-code restriction — `workflow_dispatch` is kept open for legitimate Case B releases.
+
 ## How to use
 
 Dispatch `release-node.yml` from the `node-sdk` repository with


### PR DESCRIPTION
## Summary

Adds a **Release-coordination SOP** section to `.claude/skills/sdk-only-release/SKILL.md` codifying the ordering rule operators MUST follow whenever `agent-assembly` is cutting a release in the same version cycle as this SDK.

The SOP defines two cases:

- **Case A** — agent-assembly is ALSO releasing this cycle: the SDK release MUST wait until the agent-assembly tag is cut, `notify-downstream` completes, and the auto-bump PR (`bot/aa-ffi-pin-<tag>`, AAASM-2883) is merged. ONLY THEN cut the SDK tag.
- **Case B** — SDK-only release: `workflow_dispatch` may be triggered freely; current `master` is already what we want to ship.

Inserted between the existing `## When NOT to use` and `## How to use` sections so the ordering rule lands prominently before the dispatch mechanics.

## Motivation — the 2026-06-15 incident

On 2026-06-15 02:21 UTC, `@agent-assembly/sdk@0.0.1-beta.2` was published to npm via `workflow_dispatch` while `agent-assembly`'s latest release was still `v0.0.1-beta.1` (pre-AAASM-3000 IPC fix). The bundle on npm at version `0.0.1-beta.2` therefore does NOT carry the AAASM-3000 fix that users would reasonably expect from that version label. When agent-assembly's `notify-downstream` later fired at 09:36 UTC with the actual new content, the SDK refused to re-publish (npm immutability). Same incident on PyPI at 02:22 UTC.

Per operator decision (AAASM-3007), the fix is operator discipline (this SOP), **not** a workflow-code restriction — `workflow_dispatch` is kept open for legitimate Case B releases.

## Tracking

- Jira: **AAASM-3007**
- This SOP block is added verbatim in three coordinated PRs (this `node-sdk` PR, the parallel `python-sdk` PR, and the inverse `Downstream SDK coordination` block on the `agent-assembly` release skill). Reviewers should diff the SOP wording side-by-side across the SDK PRs to confirm byte-for-byte consistency.

## Test plan

- [x] Markdown still renders — only added a new `##` section between two existing `##` sections; no frontmatter or code-fence changes.
- [x] Existing skill flow unaffected — `## Quick reference`, `## When to use`, `## When NOT to use`, `## How to use`, `## Do NOT manually run`, and `## Detailed references` all unchanged.
- [x] No duplicate section titles introduced.
- [x] One granular commit, atomic, bisectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)