### PR TITLE
[AAASM-2029] ✨ (sdk): Add controlPlaneUrl + AA_CONTROL_PLANE_URL

### DIFF
--- a/src/core/init-assembly.ts
+++ b/src/core/init-assembly.ts
@@ -26,6 +26,11 @@ import { resolveApiKey, resolveGatewayUrl } from "./gateway-resolver.js";
 
 const requireFromCwd = createRequire(`${process.cwd()}/`);
 
+/** Env-var fallback for ``gatewayUrl`` read at ``initAssembly`` entry. */
+export const ENV_GATEWAY_URL = "AA_GATEWAY_URL";
+/** Env-var fallback for ``controlPlaneUrl`` read at ``initAssembly`` entry. */
+export const ENV_CONTROL_PLANE_URL = "AA_CONTROL_PLANE_URL";
+
 function buildRegistrationEvent(config: AssemblyConfig): Record<string, string> {
   const event: Record<string, string> = { event_type: "register" };
   if (config.parentAgentId !== undefined) event.parent_agent_id = config.parentAgentId;
@@ -46,7 +51,10 @@ export function createClient(config: AssemblyConfig): GatewayClient {
     return config.gatewayClient;
   }
 
-  return createNoopGatewayClient(mode);
+  // HTTP routes use controlPlaneUrl when set, otherwise fall back to the
+  // resolved gatewayUrl so pre-feature callers keep their existing base URL.
+  const httpBaseUrl = config.controlPlaneUrl ?? config.gatewayUrl;
+  return createNoopGatewayClient(mode, httpBaseUrl);
 }
 
 function isPackageInstalled(packageName: string): boolean {
@@ -225,12 +233,17 @@ export async function initAssembly(config: AssemblyConfig = {}): Promise<Assembl
   // Auto-populate parentAgentId from the async context store when not explicitly provided.
   // This allows child agents spawned inside framework hooks to inherit lineage automatically.
   const resolvedParentAgentId = config.parentAgentId ?? currentAgentId();
-  const resolvedGatewayUrl = await resolveGatewayUrl(config.gatewayUrl);
+  // Env-var fallbacks read at entry: explicit config field > env-var > the
+  // downstream resolver chain (which may itself error if required and absent).
+  const gatewayUrlInput = config.gatewayUrl ?? process.env[ENV_GATEWAY_URL];
+  const controlPlaneUrlInput = config.controlPlaneUrl ?? process.env[ENV_CONTROL_PLANE_URL];
+  const resolvedGatewayUrl = await resolveGatewayUrl(gatewayUrlInput);
   const resolvedApiKey = await resolveApiKey(config.apiKey);
   const resolvedConfig: AssemblyConfig = {
     ...config,
     gatewayUrl: resolvedGatewayUrl,
     apiKey: resolvedApiKey,
+    ...(controlPlaneUrlInput !== undefined ? { controlPlaneUrl: controlPlaneUrlInput } : {}),
     ...(resolvedParentAgentId ? { parentAgentId: resolvedParentAgentId } : {})
   };
 

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -10,6 +10,12 @@ import type { AssemblyMode } from "../types/assembly-mode.js";
 
 export interface GatewayClient {
   readonly mode: AssemblyMode;
+  /**
+   * Base URL for the client's HTTP routes. Resolved by ``initAssembly`` to
+   * ``controlPlaneUrl`` when set, otherwise to ``gatewayUrl``. Undefined when
+   * the client is constructed without a URL (e.g. a bare no-op test client).
+   */
+  readonly httpBaseUrl?: string;
   start: () => Promise<void>;
   close: () => Promise<void>;
   check: (request: GatewayCheckRequest) => Promise<GatewayDecision>;
@@ -23,9 +29,13 @@ export interface GatewayClient {
   scanPrompts: (scan: GatewayPromptScan) => Promise<void>;
 }
 
-export function createNoopGatewayClient(mode: AssemblyMode): GatewayClient {
+export function createNoopGatewayClient(
+  mode: AssemblyMode,
+  httpBaseUrl?: string
+): GatewayClient {
   return {
     mode,
+    ...(httpBaseUrl !== undefined ? { httpBaseUrl } : {}),
     start: async () => undefined,
     close: async () => undefined,
     check: async () => ({ denied: false, pending: false }),

--- a/src/types/assembly-config.ts
+++ b/src/types/assembly-config.ts
@@ -12,6 +12,14 @@ export interface AssemblyConfig {
    */
   gatewayUrl?: string;
   /**
+   * Control-plane HTTP base URL. When set, the gateway client routes its HTTP
+   * traffic here instead of ``gatewayUrl``; when omitted it falls back to the
+   * resolved ``gatewayUrl`` (backwards-compatible). ``initAssembly`` also reads
+   * the ``AA_CONTROL_PLANE_URL`` environment variable as a fallback when this
+   * field is not set. The gRPC transport continues to use ``gatewayUrl``.
+   */
+  controlPlaneUrl?: string;
+  /**
    * API key. When omitted, ``initAssembly`` resolves it via
    * AAASM_API_KEY, the config file, or defaults to an empty string
    * (local mode is unauth-accepting).

--- a/tests/control-plane-url.test.ts
+++ b/tests/control-plane-url.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as gatewayClientModule from "../src/gateway/client.js";
+import { createNoopGatewayClient } from "../src/gateway/client.js";
+import { createClient } from "../src/core/init-assembly.js";
+import {
+  ENV_CONTROL_PLANE_URL,
+  ENV_GATEWAY_URL,
+  initAssembly
+} from "../src/core/init-assembly.js";
+import { __testing } from "../src/core/gateway-resolver.js";
+
+describe("createNoopGatewayClient httpBaseUrl", () => {
+  it("exposes the supplied httpBaseUrl", () => {
+    const client = createNoopGatewayClient("sdk-only", "https://cp.example.com");
+    expect(client.httpBaseUrl).toBe("https://cp.example.com");
+  });
+
+  it("leaves httpBaseUrl undefined when no URL is supplied", () => {
+    const client = createNoopGatewayClient("sdk-only");
+    expect(client.httpBaseUrl).toBeUndefined();
+  });
+});
+
+describe("createClient HTTP base URL resolution", () => {
+  it("defaults the HTTP base URL to gatewayUrl when controlPlaneUrl is unset", () => {
+    const client = createClient({ gatewayUrl: "https://gateway.example.com" });
+    expect(client.httpBaseUrl).toBe("https://gateway.example.com");
+  });
+
+  it("uses controlPlaneUrl for the HTTP base URL when set", () => {
+    const client = createClient({
+      gatewayUrl: "https://gateway.example.com",
+      controlPlaneUrl: "https://control-plane.example.com"
+    });
+    expect(client.httpBaseUrl).toBe("https://control-plane.example.com");
+  });
+
+  it("returns an explicit gatewayClient unchanged", () => {
+    const injected = createNoopGatewayClient("sdk-only", "https://injected.example.com");
+    const client = createClient({
+      gatewayUrl: "https://gateway.example.com",
+      controlPlaneUrl: "https://control-plane.example.com",
+      gatewayClient: injected
+    });
+    expect(client).toBe(injected);
+  });
+});
+
+describe("initAssembly env-var fallbacks", () => {
+  const originalSeams = { ...__testing._seams };
+  const originalGatewayEnv = process.env[ENV_GATEWAY_URL];
+  const originalControlPlaneEnv = process.env[ENV_CONTROL_PLANE_URL];
+
+  beforeEach(() => {
+    delete process.env[ENV_GATEWAY_URL];
+    delete process.env[ENV_CONTROL_PLANE_URL];
+    // Keep the resolver from probing / auto-starting a local gateway.
+    __testing._seams.loadConfigFile = async () => ({});
+    __testing._seams.probeHealthz = async () => true;
+    __testing._seams.autoStartGateway = vi.fn();
+  });
+
+  afterEach(() => {
+    Object.assign(__testing._seams, originalSeams);
+    if (originalGatewayEnv === undefined) delete process.env[ENV_GATEWAY_URL];
+    else process.env[ENV_GATEWAY_URL] = originalGatewayEnv;
+    if (originalControlPlaneEnv === undefined) delete process.env[ENV_CONTROL_PLANE_URL];
+    else process.env[ENV_CONTROL_PLANE_URL] = originalControlPlaneEnv;
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to AA_GATEWAY_URL for the HTTP base URL when no field is set", async () => {
+    process.env[ENV_GATEWAY_URL] = "https://env-gateway.example.com";
+    const spy = vi.spyOn(gatewayClientModule, "createNoopGatewayClient");
+
+    const ctx = await initAssembly();
+    try {
+      expect(spy).toHaveBeenCalledWith("auto", "https://env-gateway.example.com");
+    } finally {
+      await ctx.shutdown();
+    }
+  });
+
+  it("falls back to AA_CONTROL_PLANE_URL for the HTTP base URL when no field is set", async () => {
+    process.env[ENV_GATEWAY_URL] = "https://env-gateway.example.com";
+    process.env[ENV_CONTROL_PLANE_URL] = "https://env-control-plane.example.com";
+    const spy = vi.spyOn(gatewayClientModule, "createNoopGatewayClient");
+
+    const ctx = await initAssembly();
+    try {
+      expect(spy).toHaveBeenCalledWith("auto", "https://env-control-plane.example.com");
+    } finally {
+      await ctx.shutdown();
+    }
+  });
+
+  it("explicit controlPlaneUrl field overrides AA_CONTROL_PLANE_URL", async () => {
+    process.env[ENV_CONTROL_PLANE_URL] = "https://env-control-plane.example.com";
+    const spy = vi.spyOn(gatewayClientModule, "createNoopGatewayClient");
+
+    const ctx = await initAssembly({
+      gatewayUrl: "https://gateway.example.com",
+      controlPlaneUrl: "https://explicit-control-plane.example.com",
+      apiKey: "test-key"
+    });
+    try {
+      expect(spy).toHaveBeenCalledWith("auto", "https://explicit-control-plane.example.com");
+    } finally {
+      await ctx.shutdown();
+    }
+  });
+});


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

* ### Task summary:

    Add an optional `controlPlaneUrl` field to `AssemblyConfig` and thread it through `initAssembly` into the gateway client. When set, the gateway client's HTTP routes use `controlPlaneUrl`; when unset they default to the resolved `gatewayUrl` (backwards-compatible). New env-var fallbacks are read at `initAssembly` entry — `AA_GATEWAY_URL` for `gatewayUrl`, `AA_CONTROL_PLANE_URL` for `controlPlaneUrl` — with resolution order: explicit config field > env-var > downstream resolver.

* ### Task tickets:

    * Task ID: AAASM-2029.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    * `AssemblyConfig.controlPlaneUrl?: string` added; gRPC transport (`op-control.ts`) continues to use `gatewayUrl` — only HTTP routing is affected.
    * `GatewayClient` gains a readonly `httpBaseUrl?`; `createNoopGatewayClient(mode, httpBaseUrl?)` (new optional 2nd arg, backwards-compatible).
    * `createClient` computes `httpBaseUrl = controlPlaneUrl ?? gatewayUrl`.
    * `initAssembly` resolves env fallbacks at entry before delegating to the existing resolver chain.

## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
* Scopes:
    * [x] 🧩 SDK public API
    * [x] 🪡 API client and transport
    * [x] 🫀 Data model and types
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
* Additional description:
    N/A.

## _Description_

* `src/types/assembly-config.ts` — add optional `controlPlaneUrl` field.
* `src/gateway/client.ts` — add readonly `httpBaseUrl` to `GatewayClient`; `createNoopGatewayClient` accepts an optional `httpBaseUrl`.
* `src/core/init-assembly.ts` — export `ENV_GATEWAY_URL` / `ENV_CONTROL_PLANE_URL`; read env fallbacks at `initAssembly` entry; `createClient` threads `controlPlaneUrl ?? gatewayUrl` into the client as `httpBaseUrl`.
* `tests/control-plane-url.test.ts` — 8 vitest cases: `httpBaseUrl` exposure, default-to-`gatewayUrl`, explicit `controlPlaneUrl`, and `AA_GATEWAY_URL` / `AA_CONTROL_PLANE_URL` fallbacks + field-over-env precedence.

### How to verify

`pnpm install && pnpm typecheck && pnpm lint && pnpm test` — all green (226 passed, 2 skipped).

Closes AAASM-2029.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
