### PR TITLE
[AAASM-3031] ♻️ (sdk): AA_* canonical env prefix, AAASM_* deprecated alias

### DIFF
--- a/src/core/gateway-resolver.ts
+++ b/src/core/gateway-resolver.ts
@@ -16,7 +16,10 @@ import { ConfigurationError, GatewayError } from "../errors/index.js";
  * Resolution precedence (highest first):
  *
  *   1. Explicit field on the AssemblyConfig
- *   2. Environment variable (AAASM_GATEWAY_URL / AAASM_API_KEY)
+ *   2. Environment variable — canonical ``AA_GATEWAY_URL`` / ``AA_API_KEY``,
+ *      with the legacy ``AAASM_GATEWAY_URL`` / ``AAASM_API_KEY`` names accepted
+ *      as deprecated aliases (a one-time warning is logged when a legacy name
+ *      supplies the value)
  *   3. Config file (~/.aasm/config.yaml, optional js-yaml soft dep)
  *   4. Local default: probe http://localhost:7391, auto-start if absent
  */
@@ -27,8 +30,51 @@ export const DEFAULT_PROBE_TIMEOUT_MS = 500;
 export const DEFAULT_AUTO_START_TIMEOUT_MS = 5000;
 export const DEFAULT_CONFIG_FILE_PATH = "~/.aasm/config.yaml";
 
-export const ENV_GATEWAY_URL = "AAASM_GATEWAY_URL";
-export const ENV_API_KEY = "AAASM_API_KEY";
+export const ENV_GATEWAY_URL = "AA_GATEWAY_URL";
+export const ENV_API_KEY = "AA_API_KEY";
+
+/**
+ * Deprecated environment-variable names, kept as backwards-compatible aliases.
+ *
+ * When one of these supplies a value (and the canonical ``AA_*`` name is unset)
+ * a one-time deprecation warning is emitted via ``readEnvWithDeprecation``.
+ */
+export const LEGACY_ENV_GATEWAY_URL = "AAASM_GATEWAY_URL";
+export const LEGACY_ENV_API_KEY = "AAASM_API_KEY";
+
+/**
+ * Tracks which legacy env-var names have already produced a deprecation
+ * warning so the message is logged at most once per name per process.
+ */
+const _warnedLegacyEnv = new Set<string>();
+
+/**
+ * Read an environment variable preferring the canonical ``AA_*`` name and
+ * falling back to a deprecated ``AAASM_*`` alias.
+ *
+ * Returns ``undefined`` when neither name is set. When the value comes from
+ * the legacy alias, a deprecation warning is logged exactly once per legacy
+ * name (guarded by ``_warnedLegacyEnv``) directing the user to the canonical
+ * name.
+ */
+function readEnvWithDeprecation(canonicalName: string, legacyName: string): string | undefined {
+  const canonical = process.env[canonicalName];
+  if (canonical) return canonical;
+
+  const legacy = process.env[legacyName];
+  if (legacy) {
+    if (!_warnedLegacyEnv.has(legacyName)) {
+      _warnedLegacyEnv.add(legacyName);
+      console.warn(
+        `[agent-assembly] ${legacyName} is deprecated and will be removed in a ` +
+          `future release. Use ${canonicalName} instead.`
+      );
+    }
+    return legacy;
+  }
+
+  return undefined;
+}
 
 export const AASM_AUTO_START_ARGV = ["start", "--mode", "local", "--foreground"] as const;
 
@@ -159,7 +205,12 @@ const _seams = {
   autoStartGateway: autoStartGateway,
 };
 
-export const __testing = { _seams };
+export const __testing = {
+  _seams,
+  resetLegacyEnvWarnings: (): void => {
+    _warnedLegacyEnv.clear();
+  },
+};
 
 /**
  * Spawn ``aasm start --mode local --foreground`` and wait until ``/healthz``
@@ -205,7 +256,7 @@ export async function autoStartGateway(
 export async function resolveGatewayUrl(explicit?: string): Promise<string> {
   if (explicit) return explicit;
 
-  const fromEnv = process.env[ENV_GATEWAY_URL];
+  const fromEnv = readEnvWithDeprecation(ENV_GATEWAY_URL, LEGACY_ENV_GATEWAY_URL);
   if (fromEnv) return fromEnv;
 
   const config = await _seams.loadConfigFile();
@@ -233,7 +284,7 @@ export async function resolveGatewayUrl(explicit?: string): Promise<string> {
 export async function resolveApiKey(explicit?: string): Promise<string> {
   if (explicit) return explicit;
 
-  const fromEnv = process.env[ENV_API_KEY];
+  const fromEnv = readEnvWithDeprecation(ENV_API_KEY, LEGACY_ENV_API_KEY);
   if (fromEnv) return fromEnv;
 
   const config = await _seams.loadConfigFile();

--- a/tests/gateway-resolver.test.ts
+++ b/tests/gateway-resolver.test.ts
@@ -10,6 +10,8 @@ import {
   DEFAULT_GATEWAY_URL,
   ENV_API_KEY,
   ENV_GATEWAY_URL,
+  LEGACY_ENV_API_KEY,
+  LEGACY_ENV_GATEWAY_URL,
   loadConfigFile,
   probeHealthz,
   resolveApiKey,
@@ -176,11 +178,21 @@ describe("autoStartGateway", () => {
 describe("resolveGatewayUrl", () => {
   const originalSeams = { ...__testing._seams };
   const originalEnv = process.env[ENV_GATEWAY_URL];
+  const originalLegacyEnv = process.env[LEGACY_ENV_GATEWAY_URL];
+
+  beforeEach(() => {
+    delete process.env[ENV_GATEWAY_URL];
+    delete process.env[LEGACY_ENV_GATEWAY_URL];
+    __testing.resetLegacyEnvWarnings();
+  });
 
   afterEach(() => {
     Object.assign(__testing._seams, originalSeams);
     if (originalEnv === undefined) delete process.env[ENV_GATEWAY_URL];
     else process.env[ENV_GATEWAY_URL] = originalEnv;
+    if (originalLegacyEnv === undefined) delete process.env[LEGACY_ENV_GATEWAY_URL];
+    else process.env[LEGACY_ENV_GATEWAY_URL] = originalLegacyEnv;
+    __testing.resetLegacyEnvWarnings();
     vi.restoreAllMocks();
   });
 
@@ -189,7 +201,7 @@ describe("resolveGatewayUrl", () => {
     await expect(resolveGatewayUrl("http://explicit:7391")).resolves.toBe("http://explicit:7391");
   });
 
-  it("uses AAASM_GATEWAY_URL over config + default", async () => {
+  it("uses AA_GATEWAY_URL over config + default", async () => {
     process.env[ENV_GATEWAY_URL] = "http://from-env:7391";
     __testing._seams.loadConfigFile = async () => ({
       agent: { gateway_url: "http://from-config:7391" }
@@ -197,8 +209,31 @@ describe("resolveGatewayUrl", () => {
     await expect(resolveGatewayUrl()).resolves.toBe("http://from-env:7391");
   });
 
-  it("falls back to config file when env is unset", async () => {
-    delete process.env[ENV_GATEWAY_URL];
+  it("falls back to the deprecated AAASM_GATEWAY_URL and warns once", async () => {
+    process.env[LEGACY_ENV_GATEWAY_URL] = "http://from-legacy:7391";
+    __testing._seams.loadConfigFile = async () => ({
+      agent: { gateway_url: "http://from-config:7391" }
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(resolveGatewayUrl()).resolves.toBe("http://from-legacy:7391");
+    await expect(resolveGatewayUrl()).resolves.toBe("http://from-legacy:7391");
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]![0]).toContain(LEGACY_ENV_GATEWAY_URL);
+    expect(warnSpy.mock.calls[0]![0]).toContain(ENV_GATEWAY_URL);
+  });
+
+  it("prefers AA_GATEWAY_URL over the legacy alias and does not warn", async () => {
+    process.env[ENV_GATEWAY_URL] = "http://from-canonical:7391";
+    process.env[LEGACY_ENV_GATEWAY_URL] = "http://from-legacy:7391";
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(resolveGatewayUrl()).resolves.toBe("http://from-canonical:7391");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to config file when neither env name is set", async () => {
     __testing._seams.loadConfigFile = async () => ({
       agent: { gateway_url: "http://from-config:7391" }
     });
@@ -231,11 +266,21 @@ describe("resolveGatewayUrl", () => {
 describe("resolveApiKey", () => {
   const originalSeams = { ...__testing._seams };
   const originalEnv = process.env[ENV_API_KEY];
+  const originalLegacyEnv = process.env[LEGACY_ENV_API_KEY];
+
+  beforeEach(() => {
+    delete process.env[ENV_API_KEY];
+    delete process.env[LEGACY_ENV_API_KEY];
+    __testing.resetLegacyEnvWarnings();
+  });
 
   afterEach(() => {
     Object.assign(__testing._seams, originalSeams);
     if (originalEnv === undefined) delete process.env[ENV_API_KEY];
     else process.env[ENV_API_KEY] = originalEnv;
+    if (originalLegacyEnv === undefined) delete process.env[LEGACY_ENV_API_KEY];
+    else process.env[LEGACY_ENV_API_KEY] = originalLegacyEnv;
+    __testing.resetLegacyEnvWarnings();
     vi.restoreAllMocks();
   });
 
@@ -244,7 +289,7 @@ describe("resolveApiKey", () => {
     await expect(resolveApiKey("k-explicit")).resolves.toBe("k-explicit");
   });
 
-  it("uses AAASM_API_KEY over config-file value", async () => {
+  it("uses AA_API_KEY over config-file value", async () => {
     process.env[ENV_API_KEY] = "k-env";
     __testing._seams.loadConfigFile = async () => ({
       agent: { api_key: "k-config" }
@@ -252,8 +297,31 @@ describe("resolveApiKey", () => {
     await expect(resolveApiKey()).resolves.toBe("k-env");
   });
 
-  it("falls back to config file when env is unset", async () => {
-    delete process.env[ENV_API_KEY];
+  it("falls back to the deprecated AAASM_API_KEY and warns once", async () => {
+    process.env[LEGACY_ENV_API_KEY] = "k-legacy";
+    __testing._seams.loadConfigFile = async () => ({
+      agent: { api_key: "k-config" }
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(resolveApiKey()).resolves.toBe("k-legacy");
+    await expect(resolveApiKey()).resolves.toBe("k-legacy");
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]![0]).toContain(LEGACY_ENV_API_KEY);
+    expect(warnSpy.mock.calls[0]![0]).toContain(ENV_API_KEY);
+  });
+
+  it("prefers AA_API_KEY over the legacy alias and does not warn", async () => {
+    process.env[ENV_API_KEY] = "k-canonical";
+    process.env[LEGACY_ENV_API_KEY] = "k-legacy";
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(resolveApiKey()).resolves.toBe("k-canonical");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to config file when neither env name is set", async () => {
     __testing._seams.loadConfigFile = async () => ({
       agent: { api_key: "k-config" }
     });
@@ -261,7 +329,6 @@ describe("resolveApiKey", () => {
   });
 
   it("returns empty string as the documented local-mode default", async () => {
-    delete process.env[ENV_API_KEY];
     __testing._seams.loadConfigFile = async () => ({});
     await expect(resolveApiKey()).resolves.toBe("");
   });


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

* ### Task summary:

    Make `AA_*` the canonical environment-variable prefix in `src/core/gateway-resolver.ts`, keeping the legacy `AAASM_*` names as backwards-compatible deprecated aliases. `resolveGatewayUrl` / `resolveApiKey` now read `AA_GATEWAY_URL` / `AA_API_KEY` first and fall back to `AAASM_GATEWAY_URL` / `AAASM_API_KEY`, emitting a one-time deprecation warning (`console.warn`, guarded by a module-level "already warned" set) when a value is supplied by a legacy name.

* ### Task tickets:

    * Task ID: AAASM-3031.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    * As-is: env reads were `process.env["AAASM_GATEWAY_URL"]` / `process.env["AAASM_API_KEY"]`.
    * To-be: a shared `readEnvWithDeprecation(canonical, legacy)` helper prefers `AA_*`, falls back to `AAASM_*`, and warns once per legacy name per process.
    * `ENV_GATEWAY_URL` / `ENV_API_KEY` now equal the `AA_*` names; new `LEGACY_ENV_GATEWAY_URL` / `LEGACY_ENV_API_KEY` exports hold the deprecated aliases. The newer dual-URL path in `init-assembly.ts` is intentionally untouched.

## _Effecting Scope_

* Action Types:
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
    * [x] ♻️ Refactoring something
* Scopes:
    * [x] 🧩 SDK public API
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
* Additional description:
    No breaking change — `AAASM_*` still resolves; only a deprecation warning is added.

## _Description_

* Read `AA_GATEWAY_URL` / `AA_API_KEY` first; fall back to `AAASM_GATEWAY_URL` / `AAASM_API_KEY`.
* Log a one-time `console.warn` deprecation notice when a legacy name supplies the value.
* Update the resolution-precedence doc comment to document `AA_*` primary + `AAASM_*` deprecated.
* Add resolver tests: AA_* wins when set, legacy AAASM_* resolves + warns once, AA_* precedence over alias (no warn), config fallback when neither is set.

## _How to verify_

* `pnpm typecheck` — clean.
* `pnpm lint` — clean.
* `pnpm test` — 230 passed | 2 skipped (4 new resolver tests).
