### PR TITLE
[AAASM-3047] ♻️ (aa-ffi-node): Expose query_policy through the napi shim

### DIFF
--- a/native/aa-ffi-node/Cargo.lock
+++ b/native/aa-ffi-node/Cargo.lock
@@ -6,10 +6,12 @@ version = 4
 name = "aa-ffi-node"
 version = "0.0.0"
 dependencies = [
+ "aa-proto",
  "aa-sdk-client",
  "napi",
  "napi-build",
  "napi-derive",
+ "prost",
  "serde_json",
  "tokio",
 ]
@@ -17,7 +19,7 @@ dependencies = [
 [[package]]
 name = "aa-proto"
 version = "0.0.1-beta.2"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=0aa9c945511d010457535c20704f7f42d59f2126#0aa9c945511d010457535c20704f7f42d59f2126"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=4f9eea19c2c7e9d6730319e427861a291010fc75#4f9eea19c2c7e9d6730319e427861a291010fc75"
 dependencies = [
  "prost",
  "tonic",
@@ -28,7 +30,7 @@ dependencies = [
 [[package]]
 name = "aa-sdk-client"
 version = "0.0.1-beta.2"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=0aa9c945511d010457535c20704f7f42d59f2126#0aa9c945511d010457535c20704f7f42d59f2126"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=4f9eea19c2c7e9d6730319e427861a291010fc75#4f9eea19c2c7e9d6730319e427861a291010fc75"
 dependencies = [
  "aa-proto",
  "aa-security",
@@ -40,7 +42,7 @@ dependencies = [
 [[package]]
 name = "aa-security"
 version = "0.0.1-beta.2"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=0aa9c945511d010457535c20704f7f42d59f2126#0aa9c945511d010457535c20704f7f42d59f2126"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=4f9eea19c2c7e9d6730319e427861a291010fc75#4f9eea19c2c7e9d6730319e427861a291010fc75"
 dependencies = [
  "aho-corasick",
 ]

--- a/native/aa-ffi-node/Cargo.toml
+++ b/native/aa-ffi-node/Cargo.toml
@@ -15,11 +15,24 @@ crate-type = ["cdylib"]
 # `rev`); advisory preflight arrives transitively via its default `preflight`
 # feature. AAASM-2559 will formalize a published/pinned distribution + a
 # standalone-build CI smoke check on the agent-assembly side.
-aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "0aa9c945511d010457535c20704f7f42d59f2126", package = "aa-sdk-client" }
+#
+# `aa-proto` is pinned at the SAME SHA so cargo resolves a single checkout of
+# the agent-assembly workspace; `query_policy` builds a `CheckActionRequest`
+# and reads its `CheckActionResponse` directly from these generated types.
+aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "4f9eea19c2c7e9d6730319e427861a291010fc75", package = "aa-sdk-client" }
+aa-proto = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "4f9eea19c2c7e9d6730319e427861a291010fc75", package = "aa-proto" }
 napi = { version = "3", default-features = false, features = ["napi8", "tokio_rt", "serde-json"] }
 napi-derive = "3"
+prost = "0.14"
 serde_json = "1"
 tokio = { version = "1", features = ["rt"] }
 
 [build-dependencies]
 napi-build = "2"
+
+[dev-dependencies]
+# A Rust integration test drives `query_policy` against a mock `aa-runtime`
+# Unix-domain-socket server that answers `PolicyQuery` over the shared wire
+# codec, so it needs the async net/io stack and prost to encode the response.
+prost = "0.14"
+tokio = { version = "1", features = ["rt", "macros", "net", "io-util", "time"] }

--- a/native/aa-ffi-node/index.d.ts
+++ b/native/aa-ffi-node/index.d.ts
@@ -28,6 +28,35 @@ export declare function connect(socketPath: string): Promise<ClientHandle>
 export declare function disconnect(handle: ClientHandle): Promise<void>
 
 /**
+ * A policy verdict returned to JS.
+ *
+ * `decision` is one of `"allow"`, `"deny"`, `"pending"`, `"redact"`; `reason`
+ * is the human-readable explanation from the policy engine (or the fail-open
+ * note when the runtime did not answer).
+ */
+export interface PolicyDecision {
+  decision: string
+  reason: string
+}
+
+/**
+ * Synchronously query the runtime for a policy decision on an action.
+ *
+ * The JS query object is translated into a `CheckActionRequest` (agent id,
+ * action type, and — for tool calls — tool name / source / args) and handed
+ * to [`AssemblyClient::query_policy`], which blocks the calling thread for up
+ * to 5s waiting on the runtime's `CheckActionResponse`.
+ *
+ * **Fail-open:** the SDK is advisory, not a security boundary. If the runtime
+ * is unreachable or too slow ([`SdkClientError::QueryFailed`]), this returns a
+ * non-deny `"allow"` so a missing or degraded runtime never blocks the agent —
+ * the proxy / eBPF layers remain authoritative. Any other client error
+ * (poisoned lock, closed channel, session already shut down) is a genuine
+ * local fault and surfaces as a typed error.
+ */
+export declare function queryPolicy(handle: ClientHandle, query: any): PolicyDecision
+
+/**
  * Ship a captured event to the runtime.
  *
  * The JS event object is translated to the shared client's

--- a/native/aa-ffi-node/src/lib.rs
+++ b/native/aa-ffi-node/src/lib.rs
@@ -243,3 +243,117 @@ fn decision_to_str(value: i32) -> &'static str {
 fn typed_error(code: &str, message: &str) -> Error {
   Error::from_reason(format!("{code}:{message}"))
 }
+
+#[cfg(test)]
+mod tests {
+  use std::path::PathBuf;
+  use std::time::Duration;
+
+  use aa_proto::assembly::common::v1::Decision;
+  use aa_proto::assembly::policy::v1::CheckActionResponse;
+  use aa_sdk_client::codec;
+  use aa_sdk_client::ipc::spawn_ipc_thread;
+  use prost::Message;
+  use serde_json::json;
+  use tokio::io::{AsyncReadExt, AsyncWriteExt};
+  use tokio::net::UnixListener;
+
+  use super::*;
+
+  /// A `queryPolicy` against a runtime that answers `PolicyQuery` with a Deny
+  /// `CheckActionResponse` returns `"deny"` to the JS caller. Mirrors the
+  /// shared client's `query_policy_returns_runtime_decision` test, but drives
+  /// the napi shim's `query_policy` end-to-end (translation + decision mapping).
+  #[tokio::test]
+  async fn query_policy_maps_runtime_deny() {
+    let socket_path = format!("/tmp/aa-ffi-node-query-{}.sock", std::process::id());
+    let _ = std::fs::remove_file(&socket_path);
+    let listener = UnixListener::bind(&socket_path).unwrap();
+
+    // Mock runtime: read the heartbeat + the PolicyQuery, then reply with a
+    // Deny CheckActionResponse. Bodies here are < 128 bytes, so the
+    // length-delimiter varint is a single byte.
+    let server = tokio::spawn(async move {
+      let (mut stream, _) = listener.accept().await.unwrap();
+      assert_eq!(stream.read_u8().await.unwrap(), codec::TAG_HEARTBEAT);
+      assert_eq!(stream.read_u8().await.unwrap(), codec::TAG_POLICY_QUERY);
+      let len = stream.read_u8().await.unwrap() as usize;
+      if len > 0 {
+        let mut body = vec![0u8; len];
+        stream.read_exact(&mut body).await.unwrap();
+      }
+
+      let resp = CheckActionResponse {
+        decision: Decision::Deny as i32,
+        reason: "blocked by policy".to_string(),
+        ..Default::default()
+      };
+      let mut buf = Vec::new();
+      resp.encode(&mut buf).unwrap();
+      assert!(buf.len() < 128, "test assumes a single-byte length varint");
+      stream.write_u8(codec::TAG_POLICY_RESPONSE).await.unwrap();
+      stream.write_u8(buf.len() as u8).await.unwrap();
+      stream.write_all(&buf).await.unwrap();
+      stream.flush().await.unwrap();
+      // Keep the connection open so the client can read the reply.
+      tokio::time::sleep(Duration::from_millis(200)).await;
+    });
+
+    let ipc = spawn_ipc_thread(PathBuf::from(&socket_path)).unwrap();
+    let handle = ClientHandle {
+      inner: Arc::new(AssemblyClient::new(ipc, Vec::new())),
+    };
+
+    // query_policy blocks the calling thread, so run it off the async runtime.
+    let result = tokio::task::spawn_blocking(move || {
+      query_policy(
+        &handle,
+        json!({
+          "agent_id": "agent-1",
+          "action_type": "tool_call",
+          "tool_name": "run_python",
+          "tool_source": "langchain",
+          "args": { "code": "print(1)" },
+        }),
+      )
+    })
+    .await
+    .unwrap();
+
+    server.abort();
+    let _ = std::fs::remove_file(&socket_path);
+
+    let decision = result.expect("query_policy should return a verdict");
+    assert_eq!(decision.decision, "deny");
+    assert_eq!(decision.reason, "blocked by policy");
+  }
+
+  /// With no runtime listening, `query_policy` blocks until the 5s timeout,
+  /// gets `SdkClientError::QueryFailed`, and **fails open**: it returns a
+  /// non-deny `"allow"` so an unreachable runtime never blocks the agent.
+  #[tokio::test]
+  async fn query_policy_fails_open_when_no_runtime() {
+    // A path nothing is listening on — spawn_ipc_thread starts the background
+    // thread regardless; the query then times out with QueryFailed.
+    let socket_path = format!("/tmp/aa-ffi-node-noserver-{}.sock", std::process::id());
+    let _ = std::fs::remove_file(&socket_path);
+
+    let ipc = spawn_ipc_thread(PathBuf::from(&socket_path)).unwrap();
+    let handle = ClientHandle {
+      inner: Arc::new(AssemblyClient::new(ipc, Vec::new())),
+    };
+
+    let result = tokio::task::spawn_blocking(move || {
+      query_policy(&handle, json!({ "agent_id": "agent-1", "tool_name": "run_python" }))
+    })
+    .await
+    .unwrap();
+
+    let decision = result.expect("fail-open must surface as Ok, never an error");
+    assert_eq!(
+      decision.decision, "allow",
+      "an unreachable runtime must fail open to allow"
+    );
+    assert_eq!(decision.reason, FAIL_OPEN_REASON);
+  }
+}

--- a/native/aa-ffi-node/src/lib.rs
+++ b/native/aa-ffi-node/src/lib.rs
@@ -12,8 +12,12 @@
 
 use std::sync::Arc;
 
+use aa_proto::assembly::common::v1::{ActionType, AgentId, Decision};
+use aa_proto::assembly::policy::v1::{
+  action_context, ActionContext, CheckActionRequest, ToolCallContext,
+};
 use aa_sdk_client::ipc::spawn_ipc_thread;
-use aa_sdk_client::{AssemblyClient, AssemblyConfig};
+use aa_sdk_client::{AssemblyClient, AssemblyConfig, SdkClientError};
 use napi::bindgen_prelude::{Error, Result};
 use napi_derive::napi;
 use serde_json::Value;
@@ -21,6 +25,15 @@ use serde_json::Value;
 const ERR_CONNECT: &str = "AA_ERR_CONNECT";
 const ERR_SEND_EVENT: &str = "AA_ERR_SEND_EVENT";
 const ERR_DISCONNECT: &str = "AA_ERR_DISCONNECT";
+const ERR_QUERY_POLICY: &str = "AA_ERR_QUERY_POLICY";
+
+/// Reason attached to a fail-open `allow` when the runtime does not answer.
+///
+/// The SDK is advisory, not a security boundary: an unreachable or slow
+/// `aa-runtime` must never block the agent (the proxy / eBPF layers remain
+/// authoritative), so a [`SdkClientError::QueryFailed`] is surfaced as an
+/// `allow` rather than a hard error.
+const FAIL_OPEN_REASON: &str = "aa-runtime unreachable or slow; failing open (advisory SDK)";
 
 /// Handle to an active Agent Assembly session, wrapping the shared
 /// [`AssemblyClient`]. The inner `Arc` keeps napi calls cheap and lets the
@@ -72,6 +85,52 @@ pub fn send_event(handle: &ClientHandle, event: Value) -> Result<()> {
     .map_err(|err| typed_error(ERR_SEND_EVENT, &err.to_string()))
 }
 
+/// A policy verdict returned to JS.
+///
+/// `decision` is one of `"allow"`, `"deny"`, `"pending"`, `"redact"`; `reason`
+/// is the human-readable explanation from the policy engine (or the fail-open
+/// note when the runtime did not answer).
+#[napi(object)]
+pub struct PolicyDecision {
+  pub decision: String,
+  pub reason: String,
+}
+
+/// Synchronously query the runtime for a policy decision on an action.
+///
+/// The JS query object is translated into a `CheckActionRequest` (agent id,
+/// action type, and — for tool calls — tool name / source / args) and handed
+/// to [`AssemblyClient::query_policy`], which blocks the calling thread for up
+/// to 5s waiting on the runtime's `CheckActionResponse`.
+///
+/// **Fail-open:** the SDK is advisory, not a security boundary. When the
+/// runtime does not return a decision — it is too slow or the connection
+/// closed ([`SdkClientError::QueryFailed`]), or it was never reachable so the
+/// IPC channel is closed / the session is shut down — this returns a non-deny
+/// `"allow"` so a missing or degraded runtime never blocks the agent (the
+/// proxy / eBPF layers remain authoritative). Only a genuine local fault
+/// (a poisoned lock) surfaces as a typed error.
+#[napi]
+pub fn query_policy(handle: &ClientHandle, query: Value) -> Result<PolicyDecision> {
+  let request = translate_query(query);
+
+  match handle.inner.query_policy(request) {
+    Ok(response) => Ok(PolicyDecision {
+      decision: decision_to_str(response.decision).to_string(),
+      reason: response.reason,
+    }),
+    // Fail-open: a slow, unreachable, or shut-down runtime must never block the
+    // agent. All three mean "no authoritative decision came back".
+    Err(SdkClientError::QueryFailed)
+    | Err(SdkClientError::ChannelClosed)
+    | Err(SdkClientError::Shutdown) => Ok(PolicyDecision {
+      decision: decision_to_str(Decision::Allow as i32).to_string(),
+      reason: FAIL_OPEN_REASON.to_string(),
+    }),
+    Err(err) => Err(typed_error(ERR_QUERY_POLICY, &err.to_string())),
+  }
+}
+
 /// Shut down the session and join the background IPC thread.
 ///
 /// Idempotent — delegates to [`AssemblyClient::shutdown`], which blocks on the
@@ -100,6 +159,85 @@ fn translate_event(event: Value) -> (String, String) {
     .to_string();
   let details = serde_json::to_string(&event).unwrap_or_default();
   (event_type, details)
+}
+
+/// Translate a JS policy-query object into a [`CheckActionRequest`].
+///
+/// Reads `agent_id`, `action_type`, and (for tool calls) `tool_name`,
+/// `tool_source`, and `args` from the object. `args` is serialized to JSON
+/// bytes for the policy engine to inspect; absent fields fall back to empty so
+/// the runtime — which re-derives context authoritatively — always receives a
+/// well-formed request. Wrapper-level field shaping (createClient) is Wave 3.
+fn translate_query(query: Value) -> CheckActionRequest {
+  let agent_id = query
+    .get("agent_id")
+    .and_then(Value::as_str)
+    .unwrap_or_default()
+    .to_string();
+  let action_type_str = query
+    .get("action_type")
+    .and_then(Value::as_str)
+    .unwrap_or("tool_call");
+
+  let tool_name = query
+    .get("tool_name")
+    .and_then(Value::as_str)
+    .unwrap_or_default()
+    .to_string();
+  let tool_source = query
+    .get("tool_source")
+    .and_then(Value::as_str)
+    .unwrap_or_default()
+    .to_string();
+  let args_json = query
+    .get("args")
+    .map(|args| serde_json::to_vec(args).unwrap_or_default())
+    .unwrap_or_default();
+
+  let context = ActionContext {
+    action: Some(action_context::Action::ToolCall(ToolCallContext {
+      tool_name,
+      tool_source,
+      args_json,
+      target_url: String::new(),
+    })),
+  };
+
+  CheckActionRequest {
+    agent_id: Some(AgentId {
+      org_id: String::new(),
+      team_id: String::new(),
+      agent_id,
+    }),
+    action_type: action_type_from_str(action_type_str),
+    context: Some(context),
+    ..Default::default()
+  }
+}
+
+/// Map a JS action-type string onto the proto [`ActionType`] discriminant.
+fn action_type_from_str(value: &str) -> i32 {
+  match value {
+    "llm_call" => ActionType::LlmCall as i32,
+    "tool_call" => ActionType::ToolCall as i32,
+    "file_op" | "file_operation" => ActionType::FileOperation as i32,
+    "network_call" => ActionType::NetworkCall as i32,
+    "process_exec" => ActionType::ProcessExec as i32,
+    "agent_spawn" => ActionType::AgentSpawn as i32,
+    "tool_result" => ActionType::ToolResult as i32,
+    _ => ActionType::ActionUnspecified as i32,
+  }
+}
+
+/// Map a proto [`Decision`] discriminant onto its JS string.
+fn decision_to_str(value: i32) -> &'static str {
+  match Decision::try_from(value).unwrap_or(Decision::Unspecified) {
+    Decision::Allow => "allow",
+    Decision::Deny => "deny",
+    Decision::Pending => "pending",
+    Decision::Redact => "redact",
+    Decision::Unspecified => "",
+  }
 }
 
 fn typed_error(code: &str, message: &str) -> Error {


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

* ### Task summary:

    Wave 2 of AAASM-3021 for **node-sdk**: expose a synchronous `queryPolicy` through the napi shim, delegating to the new `aa_sdk_client::AssemblyClient::query_policy` synchronous policy round-trip over the `aa-runtime` UDS.

* ### Task tickets:

    * Task ID: AAASM-3047.
    * Relative task IDs:
        * [x] AAASM-3021 (parent — synchronous policy-query waves across the SDKs).
        * [x] AAASM-3036 (sibling wave reference).
    * Relative PRs:
        * agent-assembly `4f9eea19c2c7e9d6730319e427861a291010fc75` (adds `AssemblyClient::query_policy`).

* ### Key point change (optional):

    `queryPolicy(handle, query): PolicyDecision` translates a JS query object (`agent_id`, `action_type`, `tool_name`, `tool_source`, `args`) into a proto `CheckActionRequest`, blocks (≤5s) on the runtime decision, and maps `Decision` → `"allow"` / `"deny"` / `"pending"` / `"redact"` (+ `reason`).

    **Fail-open:** when the runtime returns no decision (`QueryFailed` / `ChannelClosed` / `Shutdown`) the shim returns a non-deny `"allow"`, so an unreachable or slow runtime never blocks the agent — the proxy / eBPF layers remain authoritative. Only a poisoned lock surfaces as a typed error.

[//]: # (What's the scope in project it would affect with your modify?)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
* Scopes:
    * [x] 🪡 API client and transport
    * [x] 🫀 Data model and types
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
    * [x] 🚀 Building
        * [x] 🔗 Dependencies
* Additional description:
    Pins `aa-sdk-client` **and** `aa-proto` at `4f9eea19c2c7e9d6730319e427861a291010fc75` (single agent-assembly checkout). Native `.node` binaries are gitignored / built in CI; the checked-in `index.d.ts` is regenerated to include `queryPolicy` + `PolicyDecision`. Wrapper wiring (`createClient` / `withAssembly`) is **Wave 3** and intentionally untouched here.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* `⬆️` Bump `aa-sdk-client` / `aa-proto` git-SHA pin to `4f9eea19`; add `aa-proto` + `prost` as direct deps.
* `✨` Add `queryPolicy` napi function + `PolicyDecision` return type, with fail-open behavior and proto translation helpers.
* `✅` Add two Rust unit tests over a mock `aa-runtime` UDS server: Deny round-trip → `"deny"`; no-server → fail-open `"allow"`.

### How to verify

```bash
cd native/aa-ffi-node
# napi cdylib needs dynamic-lookup link args on macOS (same as the python shim);
# CI on Linux links napi normally.
RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" cargo test
cd ../..
pnpm native:build && pnpm native:check-types && pnpm lint && pnpm typecheck && pnpm test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
