### PR TITLE
[AAASM-3086] 🧹 (node-sdk): Clear 4 BLOCKER/CRITICAL code smells

### DIFF
--- a/src/core/init-assembly.ts
+++ b/src/core/init-assembly.ts
@@ -237,7 +237,13 @@ async function patchDetectedOpenAIAgents(
   return patchOpenAIAgents({ gatewayClient: client });
 }
 
-export async function initAssembly(config: AssemblyConfig = {}): Promise<AssemblyContext> {
+/**
+ * Validate caller-supplied `initAssembly` config, throwing `RangeError` on the
+ * two fields that can arrive malformed from non-TS callers (plain JS, JSON
+ * config, dynamic input). Extracted to keep `initAssembly` below the cognitive
+ * complexity threshold; behaviour-preserving.
+ */
+function validateConfig(config: AssemblyConfig): void {
   if (config.delegationReason !== undefined && config.delegationReason.length > 256) {
     throw new RangeError("delegationReason must be <= 256 characters");
   }
@@ -249,6 +255,66 @@ export async function initAssembly(config: AssemblyConfig = {}): Promise<Assembl
       `enforcementMode must be one of: ${ENFORCEMENT_MODES.join(", ")} (got: ${String(config.enforcementMode)})`
     );
   }
+}
+
+/** Outcome of running every framework patch/detect path during `initAssembly`. */
+interface FrameworkPatchResult {
+  langChainHandler: AssemblyCallbackHandler | undefined;
+  wrappedLangChainTools: string[];
+  vercelAiSdkPatched: boolean;
+  openAIAgentsPatched: boolean;
+  langGraphPatched: boolean;
+  mastraPatched: boolean;
+}
+
+/**
+ * Run every framework detect-and-patch path for the resolved config. Extracted
+ * from `initAssembly` to keep its cognitive complexity below threshold;
+ * behaviour-preserving (same calls, same order).
+ */
+async function applyFrameworkPatches(
+  config: AssemblyConfig,
+  client: GatewayClient,
+  frameworks: readonly string[]
+): Promise<FrameworkPatchResult> {
+  const langChainHandler = await registerLangChainHandler(config, client, frameworks);
+  const wrappedLangChainTools = await wrapLangChainTools(config, client, frameworks);
+  const vercelAiSdkPatched = await patchDetectedVercelAiSdk(client, frameworks, config.agentId);
+  const openAIAgentsPatched = await patchDetectedOpenAIAgents(client, frameworks);
+  const langGraphPatched = await patchDetectedLangGraph(frameworks, config.agentId);
+  const mastraPatched = await patchDetectedMastra(frameworks, config.agentId);
+
+  return {
+    langChainHandler,
+    wrappedLangChainTools,
+    vercelAiSdkPatched,
+    openAIAgentsPatched,
+    langGraphPatched,
+    mastraPatched
+  };
+}
+
+/**
+ * Build the deduped list of active adapter ids from the registered adapters plus
+ * whichever framework patches actually took effect. Extracted from
+ * `initAssembly` to keep its cognitive complexity below threshold.
+ */
+function buildActiveAdapters(adapters: readonly Adapter[], patches: FrameworkPatchResult): string[] {
+  return [
+    ...new Set([
+      ...adapters.map((adapter) => adapter.id),
+      ...(patches.langChainHandler ? ["langchain-js"] : []),
+      ...(patches.wrappedLangChainTools.length > 0 ? ["langchain-js"] : []),
+      ...(patches.vercelAiSdkPatched ? ["vercel-ai-sdk"] : []),
+      ...(patches.openAIAgentsPatched ? ["openai-agents"] : []),
+      ...(patches.langGraphPatched ? ["langgraph-js"] : []),
+      ...(patches.mastraPatched ? ["mastra"] : [])
+    ])
+  ];
+}
+
+export async function initAssembly(config: AssemblyConfig = {}): Promise<AssemblyContext> {
+  validateConfig(config);
   // Auto-populate parentAgentId from the async context store when not explicitly provided.
   // This allows child agents spawned inside framework hooks to inherit lineage automatically.
   const resolvedParentAgentId = config.parentAgentId ?? currentAgentId();
@@ -284,29 +350,10 @@ export async function initAssembly(config: AssemblyConfig = {}): Promise<Assembl
     nativeClient.sendEvent(buildRegistrationEvent(resolvedConfig));
   }
 
-  const langChainHandler = await registerLangChainHandler(resolvedConfig, client, frameworks);
-  const wrappedLangChainTools = await wrapLangChainTools(resolvedConfig, client, frameworks);
-  const vercelAiSdkPatched = await patchDetectedVercelAiSdk(
-    client,
-    frameworks,
-    resolvedConfig.agentId
-  );
-  const openAIAgentsPatched = await patchDetectedOpenAIAgents(client, frameworks);
-  const langGraphPatched = await patchDetectedLangGraph(frameworks, resolvedConfig.agentId);
-  const mastraPatched = await patchDetectedMastra(frameworks, resolvedConfig.agentId);
+  const patches = await applyFrameworkPatches(resolvedConfig, client, frameworks);
 
   return {
-    activeAdapters: [
-      ...new Set([
-        ...adapters.map((adapter) => adapter.id),
-        ...(langChainHandler ? ["langchain-js"] : []),
-        ...(wrappedLangChainTools.length > 0 ? ["langchain-js"] : []),
-        ...(vercelAiSdkPatched ? ["vercel-ai-sdk"] : []),
-        ...(openAIAgentsPatched ? ["openai-agents"] : []),
-        ...(langGraphPatched ? ["langgraph-js"] : []),
-        ...(mastraPatched ? ["mastra"] : [])
-      ])
-    ],
+    activeAdapters: buildActiveAdapters(adapters, patches),
     ...(resolvedConfig.parentAgentId !== undefined && {
       parentAgentId: resolvedConfig.parentAgentId
     }),

--- a/src/hooks/langchain.ts
+++ b/src/hooks/langchain.ts
@@ -1,8 +1,17 @@
 import type { NativeClient } from "../native/client.js";
 
+/**
+ * Intentional no-op stub: native-transport LangChain patching is not
+ * implemented. LangChain enforcement is performed in the SDK's callback layer
+ * (post-execution redaction) and wrapper layer (pre-execution deny) wired by
+ * `initAssembly`, not through this native hook — so there is nothing to patch
+ * here yet. Returns `false` (nothing patched) for every mode.
+ *
+ * The `client` parameter is retained to keep the adapter-registry hook
+ * signature (and the public `patchLangChain` export) uniform with the other
+ * `patch*` hooks; it is deliberately unused until native patching lands.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- stub param kept for signature stability; see TSDoc above
 export async function patchLangChain(client: NativeClient): Promise<boolean> {
-  if (client.mode === "grpc-sidecar" || client.mode === "napi-inprocess") {
-    return false;
-  }
   return false;
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -130,17 +130,17 @@ export function startRuntime(
  *  2. Resolve the binary via {@link findAasmBinary}.
  *  3. Spawn the sidecar via {@link startRuntime}.
  *
- * `agentId` is accepted to keep the ticket-specified signature stable;
- * actual register-and-connect is performed by the existing gateway-aware
- * `@agent-assembly/sdk` `initAssembly` once the sidecar is reachable.
+ * `_agentId` is accepted to keep the ticket-specified signature stable but is
+ * intentionally not consumed at this lifecycle layer; actual register-and-connect
+ * is performed by the existing gateway-aware `@agent-assembly/sdk` `initAssembly`
+ * once the sidecar is reachable.
  *
  * Throws `Error` with {@link INSTALL_HINT} when no binary is found.
  */
 export async function initAssembly(
-  agentId?: string,
+  _agentId?: string,
   port: number = DEFAULT_PORT,
 ): Promise<void> {
-  void agentId; // not consumed at the lifecycle layer; see jsdoc
   if (await isRunning(port)) return;
   const binary = findAasmBinary();
   if (binary === null) {

--- a/tests/op-control.test.ts
+++ b/tests/op-control.test.ts
@@ -77,6 +77,11 @@ describe("OpControlSubscriber", () => {
     const stream = new FakeStream();
     const { sub } = buildSubscriber(stream);
     await sub.waitForOp("never-seen", { timeoutMs: 50 });
+    // No PAUSE/TERMINATE arrived, so the op was never blocked and waitForOp
+    // returned on the immediate path — the subscriber must report it neither
+    // paused nor terminated.
+    expect(sub.isPaused("never-seen")).toBe(false);
+    expect(sub.isTerminated("never-seen")).toBe(false);
     sub.close();
   });
 


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

* ### Task summary:

    Clear the 4 BLOCKER/CRITICAL `CODE_SMELL` findings on `node-sdk` master, as
    reported by SonarCloud. One commit per finding, behaviour-preserving.

* ### Task tickets:

    * Task ID: [AAASM-3086](https://lightning-dust-mite.atlassian.net/browse/AAASM-3086)
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    **Findings resolved: 4 / 4 — deferred: 0.**

    | Severity | Rule | File:Line | Fix |
    | --- | --- | --- | --- |
    | BLOCKER | `typescript:S2699` | `tests/op-control.test.ts:76` | Added meaningful assertions (`isPaused`/`isTerminated` both `false`) matching the case's "returns immediately when no signals yet" intent. |
    | BLOCKER | `typescript:S3516` | `src/hooks/langchain.ts:3` | Both arms of the mode check returned `false` (dead branch, constant return). Native LangChain patching is genuinely unimplemented (enforcement lives in the callback + wrapper layers), so collapsed to an explicit documented no-op stub. |
    | CRITICAL | `typescript:S3776` | `src/core/init-assembly.ts:210` | Extracted `validateConfig`, `applyFrameworkPatches`, and `buildActiveAdapters` helpers to bring `initAssembly` under the cognitive-complexity threshold. Same calls, same order, same dedup logic. |
    | CRITICAL | `typescript:S3735` | `src/runtime.ts:143` | Removed the `void agentId` operator statement; renamed the intentionally-unused param to `_agentId`. Positional callers unaffected. |

## _Effecting Scope_

* Action Types:
    * [x] ♻️ Refactoring something
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
* Scopes:
    * [x] 🤖 Framework hooks
    * [x] 🧪 Unit testing
    * [x] 🧩 SDK public API
* Additional description:
    No behavioural change beyond the intended fixes. `patchLangChain`'s public
    signature is preserved (param retained via a documented lint suppression).

## _Description_

* `✅ (op-control)` — assert not-paused/terminated in the no-signal `waitForOp` test.
* `♻️ (hooks)` — collapse `patchLangChain` dead branch into a documented stub.
* `♻️ (init-assembly)` — extract helpers to cut `initAssembly` complexity.
* `♻️ (runtime)` — drop the `void` operator on the unused `initAssembly` `agentId` param.

## _Test Plan_

Run from the repo root:

```bash
pnpm install --frozen-lockfile
pnpm typecheck   # clean
pnpm lint        # clean
pnpm test        # 239 passed | 2 skipped (vitest)
```

All four commands pass locally. The `op-control` test now fails if `waitForOp`
ever takes the paused/terminated path for an op with no signals, so the new
assertions guard the documented immediate-return behaviour.

## _Deferred items_

None — all 4 findings resolved.

Closes AAASM-3086


[AAASM-3086]: https://lightning-dust-mite.atlassian.net/browse/AAASM-3086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ