### PR TITLE
[AAASM-3105] 🔒 (init): Fail closed when no real gateway client in enforce mode

### DIFF
--- a/src/core/init-assembly.ts
+++ b/src/core/init-assembly.ts
@@ -10,8 +10,10 @@ import {
   type GatewayClient
 } from "../gateway/client.js";
 import { createNativeClient, type NativeClient } from "../native/client.js";
+import { ConfigurationError } from "../errors/index.js";
 import type { AssemblyConfig } from "../types/assembly-config.js";
 import type { AssemblyContext } from "../types/assembly-context.js";
+import type { AssemblyMode } from "../types/assembly-mode.js";
 import { ENFORCEMENT_MODES } from "../types/enforcement-mode.js";
 import type {
   LangChainCallbackHandlerLike,
@@ -49,10 +51,34 @@ function buildRegistrationEvent(config: AssemblyConfig): Record<string, string> 
   return event;
 }
 
+/**
+ * The only built-in {@link AssemblyMode} for which {@link createClient}
+ * constructs a gateway client whose `check()` consults a real authoritative
+ * verdict (the native `queryPolicy` against a reachable `aa-runtime`). Every
+ * other mode falls back to the allow-all no-op client.
+ */
+const CHECK_CAPABLE_MODE: AssemblyMode = "napi-inprocess";
+
 export function createClient(config: AssemblyConfig): GatewayClient {
   const mode = config.mode ?? "auto";
   if (config.gatewayClient) {
     return config.gatewayClient;
+  }
+
+  // AAASM-3105 (fail closed): the no-op gateway client's `check()` is allow-all,
+  // so registering under live `"enforce"` while routing through it would let a
+  // policy-denied action proceed unchecked — a silent fail-open. When the caller
+  // explicitly asks for `"enforce"` but supplies no check-capable mode (and no
+  // own `gatewayClient`), refuse loudly instead of pretending to enforce. An
+  // omitted `enforcementMode` keeps the pre-feature behavior (server-side
+  // default), and `"observe"` / `"disabled"` intentionally let actions through.
+  if (config.enforcementMode === "enforce" && mode !== CHECK_CAPABLE_MODE) {
+    throw new ConfigurationError(
+      `enforcementMode "enforce" requires a check-capable client, but mode "${mode}" ` +
+        `routes through the allow-all no-op gateway client, which cannot block a ` +
+        `denied action. Use mode "${CHECK_CAPABLE_MODE}", supply your own ` +
+        `gatewayClient, or set enforcementMode to "observe"/"disabled".`
+    );
   }
 
   // HTTP routes use controlPlaneUrl when set, otherwise fall back to the

--- a/tests/enforcement-mode.test.ts
+++ b/tests/enforcement-mode.test.ts
@@ -7,7 +7,9 @@ import { describe, expect, it, vi } from "vitest";
 import { initAssembly, type EnforcementMode } from "../src/index.js";
 
 describe("initAssembly enforcementMode parameter", () => {
-  it.each(["enforce", "observe", "disabled"] as const)(
+  // `enforce` is exercised separately: in a non-check-capable mode it now fails
+  // closed (AAASM-3105), so it cannot be asserted on the allow-all `auto` path.
+  it.each(["observe", "disabled"] as const)(
     "accepts %s and echoes it on the returned context",
     async (mode) => {
       const ctx = await initAssembly({

--- a/tests/fail-closed-enforce.test.ts
+++ b/tests/fail-closed-enforce.test.ts
@@ -1,0 +1,80 @@
+/**
+ * AAASM-3105 — fail-closed when `enforce` is requested without a check-capable
+ * client.
+ *
+ * The no-op gateway client's `check()` is allow-all, so routing an agent
+ * registered under live `"enforce"` through it would silently let a
+ * policy-denied action proceed (a fail-open). `createClient` must instead
+ * refuse loudly. `"observe"` / `"disabled"` (and an omitted mode) intentionally
+ * let actions through and must keep returning the allow-all no-op client.
+ */
+import { describe, expect, it } from "vitest";
+import { createClient } from "../src/core/init-assembly.js";
+import { ConfigurationError } from "../src/errors/index.js";
+import type { EnforcementMode } from "../src/index.js";
+import type { AssemblyMode } from "../src/types/assembly-mode.js";
+
+const NON_CHECK_CAPABLE_MODES: readonly AssemblyMode[] = ["auto", "grpc-sidecar", "sdk-only"];
+
+describe("createClient fail-closed under enforce (AAASM-3105)", () => {
+  it.each(NON_CHECK_CAPABLE_MODES)(
+    "throws ConfigurationError for enforce + %s (no check-capable client)",
+    (mode) => {
+      expect(() =>
+        createClient({
+          gatewayUrl: "https://gateway.example.com",
+          apiKey: "k",
+          agentId: "agent-1",
+          mode,
+          enforcementMode: "enforce"
+        })
+      ).toThrow(ConfigurationError);
+    }
+  );
+
+  it("throws for enforce when mode is omitted (defaults to the allow-all auto path)", () => {
+    expect(() =>
+      createClient({
+        gatewayUrl: "https://gateway.example.com",
+        apiKey: "k",
+        enforcementMode: "enforce"
+      })
+    ).toThrow(ConfigurationError);
+  });
+
+  it.each(["observe", "disabled"] as const)(
+    "does not throw for %s in auto mode and keeps the allow-all no-op client",
+    async (enforcementMode: EnforcementMode) => {
+      const client = createClient({
+        gatewayUrl: "https://gateway.example.com",
+        apiKey: "k",
+        enforcementMode
+      });
+      await expect(
+        client.check({ action: "tool_call", toolName: "rm", runId: "run-1" })
+      ).resolves.toEqual({ denied: false, pending: false });
+    }
+  );
+
+  it("does not throw when enforcementMode is omitted (pre-feature behavior)", () => {
+    expect(() =>
+      createClient({ gatewayUrl: "https://gateway.example.com", apiKey: "k" })
+    ).not.toThrow();
+  });
+
+  it("honors a caller-supplied gatewayClient under enforce (no fail-closed)", () => {
+    const ownClient = createClient({
+      gatewayUrl: "https://gateway.example.com",
+      apiKey: "k",
+      enforcementMode: "observe"
+    });
+    expect(() =>
+      createClient({
+        gatewayUrl: "https://gateway.example.com",
+        apiKey: "k",
+        enforcementMode: "enforce",
+        gatewayClient: ownClient
+      })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## _Target_

Close a High-severity fail-open: an agent registered under live `enforce` was silently allowed to run policy-denied actions because the default `auto` (and `grpc-sidecar` / `sdk-only`) modes route `check()` through the allow-all no-op gateway client. The SDK is advisory, but it must not *claim* to enforce while structurally unable to block. The fix makes the SDK fail **closed** in that exact configuration.

* ### Task summary:

    In `createClient`, when `enforcementMode === "enforce"` and the resolved mode is not check-capable (only `napi-inprocess` constructs a client whose `check()` consults a real authoritative verdict) and the caller supplied no own `gatewayClient`, throw `ConfigurationError` instead of returning the allow-all no-op client. `observe` / `disabled` and an omitted `enforcementMode` (pre-feature shape) keep their prior behavior.

* ### Task tickets:

    * Task ID: AAASM-3105.
    * Relative task IDs:
        * [x] AAASM-3105.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    * **As-is:** `enforce` + `auto`/`grpc-sidecar`/`sdk-only` → no-op client, `check()` always `{ denied: false }` → denied action proceeds unchecked (silent fail-open).
    * **To-be:** that combination throws `ConfigurationError` at `initAssembly` time (fail-closed). Operators must use `napi-inprocess`, pass their own `gatewayClient`, or choose `observe`/`disabled`.

## _Effecting Scope_

* Action Types:
    * [x] 🔧 Fixing bug
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
* Scopes:
    * [x] 🧩 SDK public API
    * [x] ⛑️ Error handling
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
* Additional description:
    Behavioral change for callers who passed `enforcementMode: "enforce"` without a check-capable mode — they now get a loud `ConfigurationError` rather than a false sense of enforcement. This is the intended security correction.

## _Description_

* `src/core/init-assembly.ts` — `createClient` now fails closed under `enforce` without a check-capable client; added `AssemblyMode`/`ConfigurationError` imports and a `CHECK_CAPABLE_MODE` constant.
* `tests/enforcement-mode.test.ts` — removed `enforce` from the allow-all echo case (it asserted the fail-open).
* `tests/fail-closed-enforce.test.ts` — new regression suite: asserts the throw for enforce + each non-check-capable mode (and omitted mode), and that `observe`/`disabled`, omitted mode, and a caller-supplied `gatewayClient` keep working.

How to verify: `pnpm typecheck`, `pnpm lint`, and `npx vitest run tests/fail-closed-enforce.test.ts tests/enforcement-mode.test.ts tests/create-client-mode-routing.test.ts` (all green).

Closes AAASM-3105
