### PR TITLE
[AAASM-3123] 🔒 (op-control): Secure transport + safe runtime auto-start

### DIFF
--- a/src/core/gateway-resolver.ts
+++ b/src/core/gateway-resolver.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve as resolvePath } from "node:path";
+import { isAbsolute, join, resolve as resolvePath } from "node:path";
 
 import { ConfigurationError, GatewayError } from "../errors/index.js";
 
@@ -21,7 +21,9 @@ import { ConfigurationError, GatewayError } from "../errors/index.js";
  *      as deprecated aliases (a one-time warning is logged when a legacy name
  *      supplies the value)
  *   3. Config file (~/.aasm/config.yaml, optional js-yaml soft dep)
- *   4. Local default: probe http://localhost:7391, auto-start if absent
+ *   4. Local default: probe http://localhost:7391; when absent, auto-start the
+ *      local `aasm` gateway ONLY if `AA_AUTO_START` is opted in and the binary
+ *      resolves to an allow-listed install dir — otherwise raise an error.
  */
 
 export const DEFAULT_GATEWAY_URL = "http://localhost:7391";
@@ -32,6 +34,64 @@ export const DEFAULT_CONFIG_FILE_PATH = "~/.aasm/config.yaml";
 
 export const ENV_GATEWAY_URL = "AA_GATEWAY_URL";
 export const ENV_API_KEY = "AA_API_KEY";
+
+/**
+ * Opt-in gate for auto-starting a local gateway. Auto-start spawns the `aasm`
+ * binary resolved from `$PATH`, so it is gated behind an explicit opt-in rather
+ * than running silently: a `$PATH` entry an attacker can write to would
+ * otherwise be executed by any process that calls `initAssembly()`. Set to
+ * `1`/`true`/`yes` to permit auto-start.
+ */
+export const ENV_AUTO_START = "AA_AUTO_START";
+
+/** Truthy values that enable {@link ENV_AUTO_START}. */
+function autoStartEnabled(): boolean {
+  const raw = process.env[ENV_AUTO_START]?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+}
+
+/**
+ * Directories an auto-started `aasm` binary is permitted to live in. The
+ * resolved path must be absolute and sit inside one of these install roots,
+ * which blocks a `$PATH`-injected `./aasm` (cwd) or a binary planted in an
+ * arbitrary writable directory from being spawned. Mirrors the documented
+ * install locations (Homebrew, system, user-local, cargo).
+ */
+function allowedInstallDirs(): string[] {
+  const home = homedir();
+  return [
+    "/usr/local/bin",
+    "/usr/bin",
+    "/opt/homebrew/bin",
+    join(home, ".local", "bin"),
+    join(home, ".cargo", "bin"),
+    "/usr/local/cargo/bin",
+  ];
+}
+
+/**
+ * Throw {@link ConfigurationError} unless `aasmPath` is an absolute path inside
+ * an allow-listed install directory (see {@link allowedInstallDirs}). This is
+ * the integrity gate for the auto-start subprocess — without it the SDK would
+ * execute whatever `aasm` happened to be first on `$PATH`.
+ */
+export function assertAllowedAasmPath(aasmPath: string): void {
+  if (!isAbsolute(aasmPath)) {
+    throw new ConfigurationError(
+      `Refusing to auto-start a non-absolute 'aasm' path: ${aasmPath}. ` +
+        `Set ${ENV_GATEWAY_URL} to an already-running gateway instead.`
+    );
+  }
+  const resolved = resolvePath(aasmPath);
+  const ok = allowedInstallDirs().some((dir) => resolved.startsWith(dir + "/"));
+  if (!ok) {
+    throw new ConfigurationError(
+      `Refusing to auto-start 'aasm' from an untrusted location: ${resolved}. ` +
+        `Install it under one of: ${allowedInstallDirs().join(", ")}, ` +
+        `or set ${ENV_GATEWAY_URL} to an already-running gateway.`
+    );
+  }
+}
 
 /**
  * Deprecated environment-variable names, kept as backwards-compatible aliases.
@@ -235,6 +295,12 @@ export async function autoStartGateway(
     );
   }
 
+  // Integrity gate: only spawn an absolute path from an allow-listed install
+  // dir, and surface the resolved path so the operator can see exactly which
+  // binary the SDK is about to execute.
+  assertAllowedAasmPath(aasmPath);
+  console.info(`[agent-assembly] auto-starting gateway from ${aasmPath}`);
+
   _seams.spawnAasm(aasmPath);
 
   if (!(await waitForHealthz(baseUrl, timeoutMs))) {
@@ -268,6 +334,17 @@ export async function resolveGatewayUrl(explicit?: string): Promise<string> {
 
   if (await _seams.probeHealthz(DEFAULT_GATEWAY_URL)) {
     return DEFAULT_GATEWAY_URL;
+  }
+
+  // Auto-start is opt-in: spawning the local `aasm` binary is a privileged
+  // side effect, so a missing gateway is a hard error unless the operator has
+  // explicitly enabled AA_AUTO_START.
+  if (!autoStartEnabled()) {
+    throw new ConfigurationError(
+      `No gateway found at ${DEFAULT_GATEWAY_URL}. Start one with 'aasm start ` +
+        `--mode local', set ${ENV_GATEWAY_URL} to a running gateway, or set ` +
+        `${ENV_AUTO_START}=1 to allow the SDK to auto-start a local gateway.`
+    );
   }
 
   await _seams.autoStartGateway(DEFAULT_GATEWAY_URL);

--- a/src/op-control.ts
+++ b/src/op-control.ts
@@ -58,14 +58,77 @@ export interface OpControlSubscriberOptions {
   orgId: string;
   teamId: string;
   agentId: string;
-  /** Optional credentials override; defaults to insecure (matches PR-D's
-   * dev-mode gateway). Use `grpc.credentials.createSsl(...)` in prod.
+  /** Explicit credentials override. When supplied it is used verbatim and the
+   * loopback / `allowInsecure` defaulting below is bypassed — the caller has
+   * taken full responsibility for the transport (e.g. `createSsl(...)` with a
+   * custom CA, or `createInsecure()` for an in-cluster sidecar).
    */
   credentials?: ChannelCredentials;
+  /**
+   * Permit a plaintext (`createInsecure`) channel to a **non-loopback**
+   * gateway. Off by default: control-plane signals (pause / terminate) and the
+   * agent identity triple travel this stream, so an unencrypted channel to a
+   * remote host is opt-in only. Loopback targets stay plaintext without this
+   * flag (local dev-mode gateway). Ignored when `credentials` is set.
+   */
+  allowInsecure?: boolean;
   /** Test seam — when supplied, skips opening a real gRPC channel and uses
    * this client directly. Used by the vitest tests.
    */
   clientFactory?: () => OpControlClient;
+}
+
+/**
+ * Hosts treated as loopback for the secure-by-default transport decision.
+ * A loopback gateway is the local dev-mode CP, where plaintext gRPC is the
+ * documented default; anything else is presumed remote and must be encrypted.
+ */
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+/**
+ * Extract the bare host from a gRPC target (`host:port`, a bare host, or a
+ * URL-style `scheme://host:port`). Returns the lowercased host with any
+ * surrounding IPv6 brackets preserved so it can be matched against
+ * {@link LOOPBACK_HOSTS}.
+ */
+export function gatewayHostOf(gatewayUrl: string): string {
+  let target = gatewayUrl.trim();
+  const schemeIdx = target.indexOf("://");
+  if (schemeIdx !== -1) target = target.slice(schemeIdx + 3);
+  // Drop a path/query suffix if a URL form was passed.
+  const slashIdx = target.indexOf("/");
+  if (slashIdx !== -1) target = target.slice(0, slashIdx);
+  if (target.startsWith("[")) {
+    // Bracketed IPv6: keep the bracketed form, strip only the trailing :port.
+    const close = target.indexOf("]");
+    return close === -1 ? target.toLowerCase() : target.slice(0, close + 1).toLowerCase();
+  }
+  const colonIdx = target.indexOf(":");
+  if (colonIdx !== -1) target = target.slice(0, colonIdx);
+  return target.toLowerCase();
+}
+
+function isLoopbackTarget(gatewayUrl: string): boolean {
+  return LOOPBACK_HOSTS.has(gatewayHostOf(gatewayUrl));
+}
+
+/**
+ * Pick channel credentials for the op-control stream, secure by default.
+ *
+ * Precedence: an explicit `credentials` override wins; otherwise a loopback
+ * target gets plaintext (local dev gateway), a remote target gets TLS, and a
+ * remote target is only allowed plaintext when the caller sets `allowInsecure`.
+ *
+ * @throws never — returns the chosen {@link ChannelCredentials}.
+ */
+export function resolveOpControlCredentials(
+  gatewayUrl: string,
+  opts: Pick<OpControlSubscriberOptions, "credentials" | "allowInsecure">,
+): ChannelCredentials {
+  if (opts.credentials) return opts.credentials;
+  if (isLoopbackTarget(gatewayUrl)) return grpcCredentials.createInsecure();
+  if (opts.allowInsecure) return grpcCredentials.createInsecure();
+  return grpcCredentials.createSsl();
 }
 
 export class OpControlSubscriber {
@@ -94,7 +157,7 @@ export class OpControlSubscriber {
       ? opts.clientFactory()
       : (new PolicyServiceClient(
           gatewayUrl,
-          opts.credentials ?? grpcCredentials.createInsecure(),
+          resolveOpControlCredentials(gatewayUrl, opts),
         ) as unknown as OpControlClient & PolicyServiceClientType);
     const subscriber = new OpControlSubscriber(client, agent);
     subscriber.start();

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -13,12 +13,20 @@ import { existsSync, openSync } from "node:fs";
 import { createRequire } from "node:module";
 import { createConnection } from "node:net";
 import { arch, homedir, platform } from "node:os";
-import { delimiter as PATH_DELIM, dirname, join } from "node:path";
+import { delimiter as PATH_DELIM, dirname, isAbsolute, join, resolve as resolvePath } from "node:path";
 import { cwd, env } from "node:process";
 
 export const BINARY_NAME = "aasm";
 export const DEFAULT_PORT = 7878;
 export const DEFAULT_RUNTIME_HOST = "127.0.0.1";
+
+/**
+ * Opt-in gate for spawning the `aasm` sidecar. Auto-start runs a binary
+ * discovered from `$PATH` / the filesystem, so it is a privileged side effect
+ * that must be explicitly enabled rather than triggered silently by every
+ * `initAssembly()` call. Set to `1`/`true`/`yes` to permit auto-start.
+ */
+export const ENV_AUTO_START = "AA_AUTO_START";
 
 export const USER_LOCAL_BIN: string = join(homedir(), ".local", "bin");
 export const DOCKER_BASE_BIN = "/usr/local/bin";
@@ -99,6 +107,55 @@ export function isRunning(
   });
 }
 
+/** Truthy values that enable {@link ENV_AUTO_START}. */
+function autoStartEnabled(): boolean {
+  const raw = env[ENV_AUTO_START]?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+}
+
+/**
+ * Install roots an auto-started `aasm` binary is permitted to live in, in
+ * addition to the npm-bundled `node_modules/@agent-assembly/runtime-*` path
+ * (which is trusted because it ships with the SDK install). This blocks a
+ * `$PATH`-injected `./aasm` or a binary planted in an arbitrary writable
+ * directory from being spawned.
+ */
+function allowedInstallDirs(): string[] {
+  const home = homedir();
+  return [
+    "/usr/local/bin",
+    "/usr/bin",
+    "/opt/homebrew/bin",
+    USER_LOCAL_BIN,
+    join(home, ".cargo", "bin"),
+    "/usr/local/cargo/bin",
+    DOCKER_BASE_BIN,
+  ];
+}
+
+/**
+ * Throw `Error` unless `binaryPath` is safe to spawn: it must be absolute and
+ * either resolve inside an allow-listed install dir (see
+ * {@link allowedInstallDirs}) or be the npm-bundled runtime binary. This is the
+ * integrity gate for the auto-start subprocess — without it the SDK would
+ * execute whatever `aasm` happened to be first on `$PATH`.
+ */
+export function assertSafeBinaryPath(binaryPath: string): void {
+  if (!isAbsolute(binaryPath)) {
+    throw new Error(`Refusing to auto-start a non-absolute 'aasm' path: ${binaryPath}`);
+  }
+  const resolved = resolvePath(binaryPath);
+  const bundled = bundledRuntimeBinaryPath();
+  if (bundled !== null && resolvePath(bundled) === resolved) return;
+  const ok = allowedInstallDirs().some((dir) => resolved.startsWith(resolvePath(dir) + "/"));
+  if (!ok) {
+    throw new Error(
+      `Refusing to auto-start 'aasm' from an untrusted location: ${resolved}. ` +
+        `Install it under one of: ${allowedInstallDirs().join(", ")}.`
+    );
+  }
+}
+
 /**
  * Spawn `aasm serve --port <port>` as a detached background subprocess.
  *
@@ -135,16 +192,31 @@ export function startRuntime(
  * is performed by the existing gateway-aware `@agent-assembly/sdk` `initAssembly`
  * once the sidecar is reachable.
  *
- * Throws `Error` with {@link INSTALL_HINT} when no binary is found.
+ * Auto-start is **opt-in**: when the sidecar is not already running, this
+ * throws unless `AA_AUTO_START` is enabled. When it does spawn, the resolved
+ * binary path is logged and integrity-checked via {@link assertSafeBinaryPath}.
+ *
+ * Throws `Error` with {@link INSTALL_HINT} when no binary is found, and a
+ * descriptive `Error` when auto-start is not opted in or the resolved binary
+ * fails the integrity check.
  */
 export async function initAssembly(
   _agentId?: string,
   port: number = DEFAULT_PORT,
 ): Promise<void> {
   if (await isRunning(port)) return;
+  if (!autoStartEnabled()) {
+    throw new Error(
+      `No aasm sidecar running on port ${port} and auto-start is disabled. ` +
+        `Start it with 'aasm serve --port ${port}', or set ${ENV_AUTO_START}=1 ` +
+        "to allow the SDK to auto-start it."
+    );
+  }
   const binary = findAasmBinary();
   if (binary === null) {
     throw new Error(INSTALL_HINT);
   }
+  assertSafeBinaryPath(binary);
+  console.info(`[agent-assembly] auto-starting aasm sidecar from ${binary}`);
   startRuntime(binary, port);
 }

--- a/tests/gateway-resolver.test.ts
+++ b/tests/gateway-resolver.test.ts
@@ -6,9 +6,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   __testing,
+  assertAllowedAasmPath,
   autoStartGateway,
   DEFAULT_GATEWAY_URL,
   ENV_API_KEY,
+  ENV_AUTO_START,
   ENV_GATEWAY_URL,
   LEGACY_ENV_API_KEY,
   LEGACY_ENV_GATEWAY_URL,
@@ -179,10 +181,12 @@ describe("resolveGatewayUrl", () => {
   const originalSeams = { ...__testing._seams };
   const originalEnv = process.env[ENV_GATEWAY_URL];
   const originalLegacyEnv = process.env[LEGACY_ENV_GATEWAY_URL];
+  const originalAutoStartEnv = process.env[ENV_AUTO_START];
 
   beforeEach(() => {
     delete process.env[ENV_GATEWAY_URL];
     delete process.env[LEGACY_ENV_GATEWAY_URL];
+    delete process.env[ENV_AUTO_START];
     __testing.resetLegacyEnvWarnings();
   });
 
@@ -192,6 +196,8 @@ describe("resolveGatewayUrl", () => {
     else process.env[ENV_GATEWAY_URL] = originalEnv;
     if (originalLegacyEnv === undefined) delete process.env[LEGACY_ENV_GATEWAY_URL];
     else process.env[LEGACY_ENV_GATEWAY_URL] = originalLegacyEnv;
+    if (originalAutoStartEnv === undefined) delete process.env[ENV_AUTO_START];
+    else process.env[ENV_AUTO_START] = originalAutoStartEnv;
     __testing.resetLegacyEnvWarnings();
     vi.restoreAllMocks();
   });
@@ -251,7 +257,8 @@ describe("resolveGatewayUrl", () => {
     expect(autoStartSpy).not.toHaveBeenCalled();
   });
 
-  it("invokes autoStartGateway when probe fails", async () => {
+  it("invokes autoStartGateway when probe fails and AA_AUTO_START is opted in", async () => {
+    process.env[ENV_AUTO_START] = "1";
     delete process.env[ENV_GATEWAY_URL];
     __testing._seams.loadConfigFile = async () => ({});
     __testing._seams.probeHealthz = async () => false;
@@ -260,6 +267,35 @@ describe("resolveGatewayUrl", () => {
 
     await expect(resolveGatewayUrl()).resolves.toBe(DEFAULT_GATEWAY_URL);
     expect(autoStartSpy).toHaveBeenCalledWith(DEFAULT_GATEWAY_URL);
+  });
+
+  it("throws ConfigurationError instead of auto-starting when AA_AUTO_START is unset", async () => {
+    delete process.env[ENV_GATEWAY_URL];
+    delete process.env[ENV_AUTO_START];
+    __testing._seams.loadConfigFile = async () => ({});
+    __testing._seams.probeHealthz = async () => false;
+    const autoStartSpy = vi.fn().mockResolvedValue(undefined);
+    __testing._seams.autoStartGateway = autoStartSpy;
+
+    await expect(resolveGatewayUrl()).rejects.toBeInstanceOf(ConfigurationError);
+    await expect(resolveGatewayUrl()).rejects.toThrow(new RegExp(ENV_AUTO_START));
+    expect(autoStartSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("assertAllowedAasmPath", () => {
+  it("accepts an absolute path inside an allow-listed install dir", () => {
+    expect(() => assertAllowedAasmPath("/usr/local/bin/aasm")).not.toThrow();
+  });
+
+  it("rejects a relative / PATH-injected path", () => {
+    expect(() => assertAllowedAasmPath("aasm")).toThrow(ConfigurationError);
+    expect(() => assertAllowedAasmPath("./aasm")).toThrow(/non-absolute/);
+  });
+
+  it("rejects an absolute path outside the install allow-list", () => {
+    expect(() => assertAllowedAasmPath("/tmp/evil/aasm")).toThrow(ConfigurationError);
+    expect(() => assertAllowedAasmPath("/tmp/evil/aasm")).toThrow(/untrusted location/);
   });
 });
 

--- a/tests/init-assembly-zero-config.test.ts
+++ b/tests/init-assembly-zero-config.test.ts
@@ -1,16 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { __testing, DEFAULT_GATEWAY_URL, ENV_API_KEY, ENV_GATEWAY_URL } from "../src/core/gateway-resolver.js";
+import {
+  __testing,
+  DEFAULT_GATEWAY_URL,
+  ENV_API_KEY,
+  ENV_AUTO_START,
+  ENV_GATEWAY_URL,
+} from "../src/core/gateway-resolver.js";
 import { initAssembly } from "../src/index.js";
 
 describe("initAssembly zero-config", () => {
   const originalSeams = { ...__testing._seams };
   const originalGatewayEnv = process.env[ENV_GATEWAY_URL];
   const originalApiKeyEnv = process.env[ENV_API_KEY];
+  const originalAutoStartEnv = process.env[ENV_AUTO_START];
 
   beforeEach(() => {
     delete process.env[ENV_GATEWAY_URL];
     delete process.env[ENV_API_KEY];
+    delete process.env[ENV_AUTO_START];
   });
 
   afterEach(async () => {
@@ -19,6 +27,8 @@ describe("initAssembly zero-config", () => {
     else process.env[ENV_GATEWAY_URL] = originalGatewayEnv;
     if (originalApiKeyEnv === undefined) delete process.env[ENV_API_KEY];
     else process.env[ENV_API_KEY] = originalApiKeyEnv;
+    if (originalAutoStartEnv === undefined) delete process.env[ENV_AUTO_START];
+    else process.env[ENV_AUTO_START] = originalAutoStartEnv;
     vi.restoreAllMocks();
   });
 
@@ -38,7 +48,8 @@ describe("initAssembly zero-config", () => {
     expect(__testing._seams.autoStartGateway).not.toHaveBeenCalled();
   });
 
-  it("triggers auto-start when no gateway is listening", async () => {
+  it("triggers auto-start when no gateway is listening and AA_AUTO_START is opted in", async () => {
+    process.env[ENV_AUTO_START] = "1";
     __testing._seams.loadConfigFile = async () => ({});
     __testing._seams.probeHealthz = async () => false;
     const autoStartSpy = vi.fn().mockResolvedValue(undefined);
@@ -50,6 +61,16 @@ describe("initAssembly zero-config", () => {
     } finally {
       await ctx.shutdown();
     }
+  });
+
+  it("does NOT auto-start when no gateway is listening and AA_AUTO_START is unset", async () => {
+    __testing._seams.loadConfigFile = async () => ({});
+    __testing._seams.probeHealthz = async () => false;
+    const autoStartSpy = vi.fn().mockResolvedValue(undefined);
+    __testing._seams.autoStartGateway = autoStartSpy;
+
+    await expect(initAssembly()).rejects.toThrow(/auto-start a local gateway/);
+    expect(autoStartSpy).not.toHaveBeenCalled();
   });
 
   it("explicit gatewayUrl + apiKey bypass the resolver entirely", async () => {

--- a/tests/op-control.test.ts
+++ b/tests/op-control.test.ts
@@ -8,10 +8,16 @@
  */
 
 import { EventEmitter } from "node:events";
+import { credentials as grpcCredentials } from "@grpc/grpc-js";
 import { describe, expect, it } from "vitest";
 
 import { OpTerminatedError } from "../src/errors/op-terminated-error.js";
-import { OpControlSubscriber, type OpControlClient } from "../src/op-control.js";
+import {
+  OpControlSubscriber,
+  gatewayHostOf,
+  resolveOpControlCredentials,
+  type OpControlClient,
+} from "../src/op-control.js";
 import { type OpControlMessage, OpControlSignal } from "../src/proto/generated/policy.js";
 
 /**
@@ -197,5 +203,45 @@ describe("OpControlSubscriber", () => {
     expect(elapsed).toBeLessThan(500);
 
     sub.close();
+  });
+});
+
+describe("gatewayHostOf", () => {
+  it.each([
+    ["localhost:7391", "localhost"],
+    ["127.0.0.1:7391", "127.0.0.1"],
+    ["gateway.prod.example:443", "gateway.prod.example"],
+    ["https://gateway.prod.example:443/path", "gateway.prod.example"],
+    ["[::1]:7391", "[::1]"],
+    ["GATEWAY.PROD.EXAMPLE", "gateway.prod.example"],
+  ])("extracts the host from %s", (target, host) => {
+    expect(gatewayHostOf(target)).toBe(host);
+  });
+});
+
+describe("resolveOpControlCredentials (secure by default)", () => {
+  // grpc-js ChannelCredentials exposes _isSecure(); insecure → false, TLS → true.
+  const isSecure = (c: ReturnType<typeof grpcCredentials.createInsecure>): boolean =>
+    (c as unknown as { _isSecure(): boolean })._isSecure();
+
+  it("uses plaintext for a loopback target without any opt-in", () => {
+    expect(isSecure(resolveOpControlCredentials("localhost:7391", {}))).toBe(false);
+    expect(isSecure(resolveOpControlCredentials("127.0.0.1:7391", {}))).toBe(false);
+    expect(isSecure(resolveOpControlCredentials("[::1]:7391", {}))).toBe(false);
+  });
+
+  it("defaults a remote target to TLS", () => {
+    expect(isSecure(resolveOpControlCredentials("gateway.prod.example:443", {}))).toBe(true);
+  });
+
+  it("only allows plaintext to a remote target when allowInsecure is set", () => {
+    expect(
+      isSecure(resolveOpControlCredentials("gateway.prod.example:443", { allowInsecure: true })),
+    ).toBe(false);
+  });
+
+  it("honours an explicit credentials override verbatim", () => {
+    const explicit = grpcCredentials.createSsl();
+    expect(resolveOpControlCredentials("localhost:7391", { credentials: explicit })).toBe(explicit);
   });
 });

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -12,7 +12,14 @@ import { arch, platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { BINARY_NAME, INSTALL_HINT, findAasmBinary, initAssembly } from "../src/runtime.js";
+import {
+  BINARY_NAME,
+  ENV_AUTO_START,
+  INSTALL_HINT,
+  assertSafeBinaryPath,
+  findAasmBinary,
+  initAssembly,
+} from "../src/runtime.js";
 
 function makeFakeAasm(dir: string): string {
   const path = join(dir, BINARY_NAME);
@@ -69,17 +76,19 @@ describe("runtime — F115 lifecycle", () => {
     }
   });
 
-  it("initAssembly throws Error with INSTALL_HINT when binary not found", async () => {
+  it("initAssembly throws Error with INSTALL_HINT when binary not found and auto-start opted in", async () => {
     const tmp = mkdtempSync(join(tmpdir(), "aasm-missing-"));
     const originalCwd = process.cwd();
     const originalPath = process.env.PATH;
     const originalHome = process.env.HOME;
+    const originalAutoStart = process.env[ENV_AUTO_START];
     try {
       // Empty cwd (no node_modules), empty PATH/HOME → every search path misses.
       writeFileSync(join(tmp, "package.json"), JSON.stringify({ name: "test-missing" }));
       process.chdir(tmp);
       process.env.PATH = join(tmp, "no-such-path");
       process.env.HOME = join(tmp, "no-such-home");
+      process.env[ENV_AUTO_START] = "1";
 
       await expect(initAssembly()).rejects.toThrowError(INSTALL_HINT);
       await expect(initAssembly()).rejects.toThrowError(/agent-assembly runtime not found/);
@@ -87,8 +96,29 @@ describe("runtime — F115 lifecycle", () => {
       process.chdir(originalCwd);
       process.env.PATH = originalPath;
       process.env.HOME = originalHome;
+      if (originalAutoStart === undefined) delete process.env[ENV_AUTO_START];
+      else process.env[ENV_AUTO_START] = originalAutoStart;
       rmSync(tmp, { recursive: true, force: true });
     }
+  });
+
+  it("initAssembly refuses to auto-start when AA_AUTO_START is unset", async () => {
+    const originalAutoStart = process.env[ENV_AUTO_START];
+    try {
+      delete process.env[ENV_AUTO_START];
+      // No sidecar listens on this ephemeral-but-unbound port; the gate must
+      // fire before any binary lookup or spawn.
+      await expect(initAssembly(undefined, 7879)).rejects.toThrow(/auto-start is disabled/);
+    } finally {
+      if (originalAutoStart === undefined) delete process.env[ENV_AUTO_START];
+      else process.env[ENV_AUTO_START] = originalAutoStart;
+    }
+  });
+
+  it("assertSafeBinaryPath rejects relative and untrusted-location binaries", () => {
+    expect(() => assertSafeBinaryPath("aasm")).toThrow(/non-absolute/);
+    expect(() => assertSafeBinaryPath("/tmp/evil/aasm")).toThrow(/untrusted location/);
+    expect(() => assertSafeBinaryPath("/usr/local/bin/aasm")).not.toThrow();
   });
 
   it("initAssembly is idempotent when a sidecar is already running on the target port", async () => {


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Fix two Wave-2 (Medium) security findings in the SDK's operator-control path:
    insecure-by-default gRPC transport, and unguarded runtime auto-start.

* ### Task tickets:

    * Task ID: AAASM-3123, AAASM-3124.
    * Relative task IDs:
        * [x] AAASM-3123 — op-control gRPC defaulted to `createInsecure()`.
        * [x] AAASM-3124 — runtime/gateway auto-start spawned `aasm` from `$PATH` with no integrity check.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    * **AAASM-3123** (`src/op-control.ts`): credentials are now chosen by target. Loopback
      (`localhost`/`127.0.0.1`/`::1`) stays plaintext for the local dev gateway; a non-loopback
      target defaults to **TLS** (`createSsl()`). Plaintext to a remote host is opt-in via a new
      `allowInsecure: true` option; an explicit `credentials` override is still honoured verbatim.
    * **AAASM-3124** (`src/core/gateway-resolver.ts`, `src/runtime.ts`): auto-start is now
      **opt-in** behind `AA_AUTO_START` (was silent). When it does spawn, the resolved binary
      path is **logged** and **integrity-checked** — it must be an absolute path inside an
      allow-listed install dir (Homebrew / system / `~/.local/bin` / cargo / Docker base), or the
      npm-bundled runtime binary. A `$PATH`-injected `./aasm` or a binary in an arbitrary writable
      dir is refused. With auto-start off, a missing gateway is a clear `ConfigurationError`.

## _Effecting Scope_

* Action Types:
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
        * [x] 🟠 Has breaking change
* Scopes:
    * [x] 🪡 API client and transport
    * [x] 🧩 SDK public API
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing

    **Breaking change note:** auto-start no longer runs silently — consumers relying on the
    zero-config local auto-start must now set `AA_AUTO_START=1` (or start `aasm` themselves).
    Remote op-control consumers using the old plaintext default must set `allowInsecure: true`
    or provide TLS credentials.

## _Description_

* Default op-control gRPC to TLS for non-loopback gateways; add `allowInsecure` opt-in.
* Gate gateway/sidecar auto-start behind `AA_AUTO_START`; log + allow-list the resolved binary.
* Add regression tests for transport selection, the opt-in gate, and the path allow-list.

Closes AAASM-3123
Closes AAASM-3124

🤖 Generated with [Claude Code](https://claude.com/claude-code)
