### PR TITLE
[AAASM-3177] ✅ (node-sdk): Raise test coverage toward 90%

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,4 +11,8 @@ sonar.tests=tests/
 sonar.test.inclusions=tests/**/*.test.ts
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.typescript.tsconfigPaths=tsconfig.json
+# src/proto/generated/* is protoc-gen-ts_proto output (marked "DO NOT EDIT").
+# Generated serialization codecs are exercised transitively, not unit-tested;
+# excluding generated code from the coverage metric is standard practice.
+sonar.coverage.exclusions=src/proto/generated/**
 sonar.sourceEncoding=UTF-8

--- a/tests/audit/encode.test.ts
+++ b/tests/audit/encode.test.ts
@@ -96,3 +96,67 @@ describe("AuditEvent wire round-trip", () => {
     });
   });
 });
+
+describe("decodeAuditEvent — malformed wire payloads", () => {
+  const validBase = {
+    event_id: "evt-1",
+    agent_id: "agent-1",
+    action_type: "llm_call",
+    decision: "allow",
+  };
+
+  it.each([
+    ["a JSON array (non-object root)", "[1, 2, 3]"],
+    ["a JSON scalar (non-object root)", "42"],
+    ["JSON null (non-object root)", "null"],
+  ])("throws TypeError for %s", (_label, payload) => {
+    expect(() => decodeAuditEvent(payload)).toThrow(TypeError);
+    expect(() => decodeAuditEvent(payload)).toThrow(/expected JSON object/);
+  });
+
+  it.each([
+    ["event_id", "AuditEvent.event_id"],
+    ["agent_id", "AuditEvent.agent_id"],
+    ["action_type", "AuditEvent.action_type"],
+    ["decision", "AuditEvent.decision"],
+  ])("throws TypeError when %s is missing", (field, message) => {
+    const wire: Record<string, unknown> = { ...validBase };
+    delete wire[field];
+    expect(() => decodeAuditEvent(wire)).toThrow(TypeError);
+    expect(() => decodeAuditEvent(wire)).toThrow(new RegExp(message));
+  });
+});
+
+describe("decodeCallStackNode — malformed nodes", () => {
+  const valid = { id: "n0", kind: "tool", label: "gmail.send" };
+
+  it("throws TypeError when a call_stack child is not an object", () => {
+    const wire = {
+      event_id: "evt-1",
+      agent_id: "agent-1",
+      action_type: "tool_call",
+      decision: "allow",
+      call_stack: ["not-an-object"],
+    };
+    expect(() => decodeAuditEvent(wire)).toThrow(TypeError);
+    expect(() => decodeAuditEvent(wire)).toThrow(/expected JSON object/);
+  });
+
+  it.each([
+    ["id", "CallStackNode.id"],
+    ["kind", "CallStackNode.kind"],
+    ["label", "CallStackNode.label"],
+  ])("throws TypeError when node.%s is missing", (field, message) => {
+    const node: Record<string, unknown> = { ...valid };
+    delete node[field];
+    const wire = {
+      event_id: "evt-1",
+      agent_id: "agent-1",
+      action_type: "tool_call",
+      decision: "allow",
+      call_stack: [node],
+    };
+    expect(() => decodeAuditEvent(wire)).toThrow(TypeError);
+    expect(() => decodeAuditEvent(wire)).toThrow(new RegExp(message));
+  });
+});

--- a/tests/gateway-resolver.test.ts
+++ b/tests/gateway-resolver.test.ts
@@ -53,6 +53,16 @@ describe("probeHealthz", () => {
     globalThis.fetch = vi.fn().mockResolvedValue({ status } as Response) as unknown as typeof fetch;
     await expect(probeHealthz(DEFAULT_GATEWAY_URL)).resolves.toBe(false);
   });
+
+  it("strips trailing slashes from the base URL before appending /healthz", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ status: 200 } as Response);
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(probeHealthz("http://localhost:7391///")).resolves.toBe(true);
+
+    const [calledUrl] = fetchMock.mock.calls[0]!;
+    expect(calledUrl).toBe("http://localhost:7391/healthz");
+  });
 });
 
 describe("waitForHealthz", () => {
@@ -367,5 +377,59 @@ describe("resolveApiKey", () => {
   it("returns empty string as the documented local-mode default", async () => {
     __testing._seams.loadConfigFile = async () => ({});
     await expect(resolveApiKey()).resolves.toBe("");
+  });
+});
+
+describe("default PATH lookup and spawn seams", () => {
+  // Capture the production default implementations before any other suite can
+  // reassign the mutable _seams entries.
+  const defaultFindAasmOnPath = __testing._seams.findAasmOnPath;
+  const defaultSpawnAasm = __testing._seams.spawnAasm;
+
+  let originalPath: string | undefined;
+
+  beforeEach(() => {
+    originalPath = process.env.PATH;
+  });
+
+  afterEach(() => {
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    vi.restoreAllMocks();
+  });
+
+  it("findAasmOnPath returns the first matching binary across PATH entries", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "aaasm-3177-find-"));
+    try {
+      writeFileSync(join(tmp, "aasm"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+      // Prepend a guaranteed-miss dir to exercise the skip-and-continue branch.
+      process.env.PATH = [join(tmp, "no-such-dir"), tmp].join(":");
+      expect(defaultFindAasmOnPath()).toBe(join(tmp, "aasm"));
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("findAasmOnPath returns null when no PATH entry holds the binary", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "aaasm-3177-nofind-"));
+    try {
+      process.env.PATH = tmp;
+      expect(defaultFindAasmOnPath()).toBeNull();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("spawnAasm detaches a background subprocess from the resolved binary", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "aaasm-3177-spawn-"));
+    try {
+      const bin = join(tmp, "aasm");
+      // A trivially-exiting script: spawn must launch and unref it without
+      // throwing or keeping the event loop alive.
+      writeFileSync(bin, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+      expect(() => defaultSpawnAasm(bin)).not.toThrow();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/langgraph-hook.test.ts
+++ b/tests/langgraph-hook.test.ts
@@ -82,6 +82,20 @@ describe("langgraph hook", () => {
     expect(hooks.langGraphPatchState.isPatched).toBe(false);
   });
 
+  it("returns false when the module loader throws", async () => {
+    const hooks = await import("../src/hooks/langgraph.js");
+
+    const patched = await hooks.patchLangGraph({
+      agentId: "agent-loader-throws",
+      loadModule: async () => {
+        throw new Error("module resolution exploded");
+      }
+    });
+
+    expect(patched).toBe(false);
+    expect(hooks.langGraphPatchState.isPatched).toBe(false);
+  });
+
   it("returns false when StateGraph.prototype.compile is absent", async () => {
     const hooks = await import("../src/hooks/langgraph.js");
 

--- a/tests/mastra-hook.test.ts
+++ b/tests/mastra-hook.test.ts
@@ -153,6 +153,46 @@ describe("mastra hook", () => {
     warnSpy.mockRestore();
   });
 
+  it("returns false when the module loader throws", async () => {
+    const hooks = await import("../src/hooks/mastra.js");
+    const patched = await hooks.patchMastra({
+      agentId: "agent-loader-throws",
+      loadModule: async () => {
+        throw new Error("module resolution exploded");
+      }
+    });
+    expect(patched).toBe(false);
+    expect(hooks.mastraPatchState.isPatched).toBe(false);
+  });
+
+  it("falls back to original execute and logs warning when runWithAgentId throws on a Workflow", async () => {
+    const hooks = await import("../src/hooks/mastra.js");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const originalExecute = vi.fn(async () => ({ status: "fallback" }));
+    const fakeAgentClass: MastraAgentClass = { prototype: { generate: vi.fn(async () => ({})) } };
+    const fakeWorkflowClass: MastraWorkflowClass = { prototype: { execute: originalExecute } };
+    const fakeModule: MastraModule = { Agent: fakeAgentClass, Workflow: fakeWorkflowClass };
+
+    const lineage = await import("../src/lineage/agent-context-store.js");
+    vi.spyOn(lineage.agentContextStore, "run").mockImplementationOnce(() => {
+      throw new Error("context-store-error");
+    });
+
+    await hooks.patchMastra({ agentId: "agent-wf-fallback", loadModule: async () => fakeModule });
+
+    const instance = Object.create(fakeWorkflowClass.prototype);
+    const result = await fakeWorkflowClass.prototype.execute!.call(instance, {});
+
+    expect(result).toEqual({ status: "fallback" });
+    expect(originalExecute).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[assembly] Mastra lineage patch error on execute"),
+      expect.anything()
+    );
+    warnSpy.mockRestore();
+  });
+
   it("activates mastra in activeAdapters during initAssembly when module detected", async () => {
     const fakeAgentClass: MastraAgentClass = {
       prototype: { generate: vi.fn(async () => ({})) }

--- a/tests/native-gateway-enforcement.test.ts
+++ b/tests/native-gateway-enforcement.test.ts
@@ -87,6 +87,30 @@ describe("native gateway enforcement (AAASM-3050)", () => {
     expect(executeFn).toHaveBeenCalledOnce();
   });
 
+  it("defaults denied/pending to false and omits reason when the verdict is bare", async () => {
+    // A verdict object with no denied/pending/reason exercises the `?? false`
+    // fallbacks and the reason-omission branch.
+    const gateway = createNativeGatewayClient(
+      "napi-inprocess",
+      fakeNativeClient(async () => ({}) as Awaited<ReturnType<NativeClient["queryPolicy"]>>),
+      "agent-bare"
+    );
+
+    const decision = await gateway.check({ action: "tool_call", toolName: "noop", runId: "run-bare" });
+
+    expect(decision).toEqual({ denied: false, pending: false });
+    expect(decision).not.toHaveProperty("reason");
+  });
+
+  it("close() delegates to the native client's close", async () => {
+    const native = fakeNativeClient(async () => ({ denied: false, pending: false }));
+    const gateway = createNativeGatewayClient("napi-inprocess", native, "agent-close");
+
+    await gateway.close();
+
+    expect(native.close).toHaveBeenCalledOnce();
+  });
+
   it("PENDING: a runtime pending verdict routes to the approval path", async () => {
     const gateway = createNativeGatewayClient(
       "napi-inprocess",

--- a/tests/op-control.test.ts
+++ b/tests/op-control.test.ts
@@ -114,6 +114,20 @@ describe("OpControlSubscriber", () => {
     sub.close();
   });
 
+  it("drops an UNSPECIFIED signal without altering op state", async () => {
+    const stream = new FakeStream();
+    const { sub } = buildSubscriber(stream);
+
+    // The default switch arm must ignore unrecognized signals: the op stays
+    // neither paused nor terminated.
+    stream.push(message("op-noop", OpControlSignal.OP_CONTROL_SIGNAL_UNSPECIFIED));
+
+    expect(sub.isPaused("op-noop")).toBe(false);
+    expect(sub.isTerminated("op-noop")).toBe(false);
+
+    sub.close();
+  });
+
   it("rejects with OpTerminatedError when the gateway terminates the op", async () => {
     const stream = new FakeStream();
     const { sub } = buildSubscriber(stream);

--- a/tests/openai-agents-hook.test.ts
+++ b/tests/openai-agents-hook.test.ts
@@ -300,6 +300,67 @@ describe("openai agents adapter", () => {
     expect(originalRunTool).toHaveBeenCalledTimes(1);
   });
 
+  it("fails open and executes original tool when approval handling throws on PENDING", async () => {
+    const gateway = createGatewayClientMock();
+    gateway.check = vi.fn(async () => ({ pending: true, denied: false }));
+    gateway.waitForApproval = vi.fn(async () => {
+      throw new Error("approval channel unavailable");
+    });
+    const originalRunTool = vi.fn(async () => ({ ok: "approval-fail-open" }));
+
+    const hooks = await import("../src/hooks/openai-agents.js");
+    const patchedRunTool = hooks.createPatchedRunTool(originalRunTool, gateway, {
+      fallbackRunId: "fallback-run",
+      approvalTimeoutMs: 2_000
+    });
+
+    const result = await patchedRunTool(
+      { function: { name: "pending_tool", arguments: "{}" } },
+      { runId: "run-pending-throw" }
+    );
+
+    expect(result).toEqual({ ok: "approval-fail-open" });
+    expect(originalRunTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns true without re-patching when already patched", async () => {
+    const gateway = createGatewayClientMock();
+    const fakeAgentClass: FakeAgentClass = {
+      prototype: { _runTool: vi.fn(async () => ({ ok: true })) }
+    };
+
+    const hooks = await import("../src/hooks/openai-agents.js");
+    expect(
+      await hooks.patchOpenAIAgents({ gatewayClient: gateway, loadAgentClass: async () => fakeAgentClass })
+    ).toBe(true);
+    const patchedRunTool = fakeAgentClass.prototype._runTool;
+
+    expect(
+      await hooks.patchOpenAIAgents({ gatewayClient: gateway, loadAgentClass: async () => fakeAgentClass })
+    ).toBe(true);
+    expect(fakeAgentClass.prototype._runTool).toBe(patchedRunTool);
+  });
+
+  it("returns false when the agent-class loader yields nothing", async () => {
+    const gateway = createGatewayClientMock();
+    const hooks = await import("../src/hooks/openai-agents.js");
+    expect(
+      await hooks.patchOpenAIAgents({ gatewayClient: gateway, loadAgentClass: async () => undefined })
+    ).toBe(false);
+    expect(hooks.openAIAgentsPatchState.isPatched).toBe(false);
+  });
+
+  it("returns false when the agent class exposes no _runTool method", async () => {
+    const gateway = createGatewayClientMock();
+    // captureOriginalRunTool returns undefined → patch aborts before mutating.
+    const fakeAgentClass = { prototype: {} } as unknown as FakeAgentClass;
+    const hooks = await import("../src/hooks/openai-agents.js");
+    expect(
+      await hooks.patchOpenAIAgents({ gatewayClient: gateway, loadAgentClass: async () => fakeAgentClass })
+    ).toBe(false);
+    expect(hooks.openAIAgentsPatchState.isPatched).toBe(false);
+  });
+
   it("restores original _runTool when unpatch is called", async () => {
     const gateway = createGatewayClientMock();
     const originalRunTool = vi.fn(async () => ({ ok: true }));

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -6,7 +6,7 @@
 //   - binary-not-found
 //   - already-running (initAssembly skips spawn when sidecar reachable)
 
-import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { arch, platform, tmpdir } from "node:os";
 import { join } from "node:path";
@@ -16,9 +16,11 @@ import {
   BINARY_NAME,
   ENV_AUTO_START,
   INSTALL_HINT,
+  RUNTIME_LOG_FILENAME,
   assertSafeBinaryPath,
   findAasmBinary,
   initAssembly,
+  startRuntime,
 } from "../src/runtime.js";
 
 function makeFakeAasm(dir: string): string {
@@ -119,6 +121,29 @@ describe("runtime — F115 lifecycle", () => {
     expect(() => assertSafeBinaryPath("aasm")).toThrow(/non-absolute/);
     expect(() => assertSafeBinaryPath("/tmp/evil/aasm")).toThrow(/untrusted location/);
     expect(() => assertSafeBinaryPath("/usr/local/bin/aasm")).not.toThrow();
+  });
+
+  it("startRuntime spawns a detached subprocess and appends to the runtime log", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "aasm-spawn-"));
+    try {
+      const bin = makeFakeAasm(tmp);
+      const child = startRuntime(bin, 7980, tmp);
+
+      expect(typeof child.pid).toBe("number");
+      // The log file is opened (O_APPEND) before the spawn, so it exists
+      // synchronously regardless of how fast the detached child exits.
+      expect(existsSync(join(tmp, RUNTIME_LOG_FILENAME))).toBe(true);
+
+      // Best-effort terminate in case the (trivially-exiting) child is still
+      // alive; the spawn is detached + unref'd so it cannot keep the loop open.
+      try {
+        if (child.pid !== undefined) process.kill(child.pid);
+      } catch {
+        // Already exited — nothing to reap.
+      }
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it("initAssembly is idempotent when a sidecar is already running on the target port", async () => {

--- a/tests/vercel-ai-hook.test.ts
+++ b/tests/vercel-ai-hook.test.ts
@@ -242,6 +242,89 @@ describe("vercel ai sdk adapter", () => {
     expect(fakeModule.tool).toBe(originalTool);
   });
 
+  it("fails open and executes the original tool when approval-wait throws on PENDING", async () => {
+    const gateway = createGatewayClientMock();
+    gateway.check = vi.fn(async () => ({ pending: true, denied: false }));
+    gateway.waitForApproval = vi.fn(async () => {
+      throw new Error("approval channel unavailable");
+    });
+    const originalExecute = vi.fn(async () => ({ ok: "approval-fail-open" }));
+
+    const hooks = await import("../src/hooks/ai-sdk.js");
+    const wrappedExecute = hooks.createWrappedExecute(
+      originalExecute,
+      "pending tool",
+      gateway,
+      { approvalTimeoutMs: 2_000, fallbackRunId: "fallback" }
+    );
+
+    const result = await wrappedExecute({ x: 1 }, { toolCallId: "call-pending-throw" });
+
+    expect(result).toEqual({ ok: "approval-fail-open" });
+    expect(originalExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns true without re-patching when patchVercelAiSdk is already patched", async () => {
+    const gateway = createGatewayClientMock();
+    const originalTool = vi.fn((def: VercelAiToolDefinition) => def) as unknown as VercelAiToolFactory;
+    const fakeModule: VercelAiSdkModule = { tool: originalTool };
+
+    const hooks = await import("../src/hooks/ai-sdk.js");
+    expect(await hooks.patchVercelAiSdk({ gatewayClient: gateway, loadModule: async () => fakeModule })).toBe(true);
+
+    const secondModule: VercelAiSdkModule = { tool: originalTool };
+    // Second call short-circuits: returns true and does not touch the new module.
+    expect(await hooks.patchVercelAiSdk({ gatewayClient: gateway, loadModule: async () => secondModule })).toBe(true);
+    expect(secondModule.tool).toBe(originalTool);
+  });
+
+  it("returns false when the module loader yields nothing", async () => {
+    const gateway = createGatewayClientMock();
+    const hooks = await import("../src/hooks/ai-sdk.js");
+    expect(
+      await hooks.patchVercelAiSdk({ gatewayClient: gateway, loadModule: async () => undefined })
+    ).toBe(false);
+    expect(hooks.vercelAiSdkPatchState.isPatched).toBe(false);
+  });
+
+  it("defaults the gateway toolName to 'unknown_tool' when a tool has no description", async () => {
+    const gateway = createGatewayClientMock();
+    gateway.check = vi.fn(async () => ({ denied: false, pending: false }));
+    const originalExecute = vi.fn(async () => ({ ok: true }));
+    // A tool with execute but no description exercises the `?? "unknown_tool"` fallback.
+    const originalTool = vi.fn((def: VercelAiToolDefinition) => ({
+      ...def,
+      execute: originalExecute,
+    })) as unknown as VercelAiToolFactory;
+    const fakeModule: VercelAiSdkModule = { tool: originalTool };
+
+    const hooks = await import("../src/hooks/ai-sdk.js");
+    await hooks.patchVercelAiSdk({ gatewayClient: gateway, loadModule: async () => fakeModule });
+
+    const wrapped = fakeModule.tool({ parameters: {} } as VercelAiToolDefinition);
+    await wrapped.execute!({}, { toolCallId: "call-nodesc" });
+
+    expect(gateway.check).toHaveBeenCalledWith(
+      expect.objectContaining({ toolName: "unknown_tool" })
+    );
+  });
+
+  it("returns false when the loaded module has no usable tool factory", async () => {
+    const gateway = createGatewayClientMock();
+    // module.tool is not a function → captureOriginalToolFactory returns undefined.
+    const fakeModule = { tool: undefined } as unknown as VercelAiSdkModule;
+
+    const hooks = await import("../src/hooks/ai-sdk.js");
+    expect(await hooks.patchVercelAiSdk({ gatewayClient: gateway, loadModule: async () => fakeModule })).toBe(false);
+    expect(hooks.vercelAiSdkPatchState.isPatched).toBe(false);
+  });
+
+  it("unpatch returns false when nothing is patched", async () => {
+    const hooks = await import("../src/hooks/ai-sdk.js");
+    expect(hooks.vercelAiSdkPatchState.isPatched).toBe(false);
+    expect(hooks.unpatchVercelAiSdk()).toBe(false);
+  });
+
   it("passes through tools without execute unchanged", async () => {
     const gateway = createGatewayClientMock();
     const toolWithoutExecute: VercelAiToolDefinition = { description: "a schema-only tool", parameters: {} };

--- a/tests/with-assembly-governance.test.ts
+++ b/tests/with-assembly-governance.test.ts
@@ -127,6 +127,44 @@ describe("withAssembly governance", () => {
     expect(invokeFn).not.toHaveBeenCalled();
   });
 
+  it("invoke PENDING→approve: waits for approval then invokes the original", async () => {
+    const gateway = createMockGateway({
+      check: vi.fn(async () => ({ denied: false, pending: true })),
+      waitForApproval: vi.fn(async () => ({ denied: false }))
+    });
+    const invokeFn: (input: string) => Promise<string> = vi.fn(async () => "invoke-approved");
+    const tools = {
+      lcTool: { name: "lcTool", invoke: invokeFn }
+    };
+
+    withAssembly(tools, { gatewayClient: gateway });
+
+    const result = await tools.lcTool.invoke("input");
+
+    expect(gateway.waitForApproval).toHaveBeenCalledOnce();
+    expect(invokeFn).toHaveBeenCalledWith("input");
+    expect(result).toBe("invoke-approved");
+  });
+
+  it("invoke PENDING→deny: throws PolicyViolationError when approval is rejected", async () => {
+    const gateway = createMockGateway({
+      check: vi.fn(async () => ({ denied: false, pending: true })),
+      waitForApproval: vi.fn(async () => ({ denied: true, reason: "Manager rejected" }))
+    });
+    const invokeFn: (input: string) => Promise<string> = vi.fn(async () => "should not run");
+    const tools = {
+      lcTool: { name: "lcTool", invoke: invokeFn }
+    };
+
+    withAssembly(tools, { gatewayClient: gateway });
+
+    await expect(tools.lcTool.invoke("input")).rejects.toThrow(PolicyViolationError);
+    await expect(tools.lcTool.invoke("input")).rejects.toThrow(
+      "Approval rejected for 'lcTool': Manager rejected"
+    );
+    expect(invokeFn).not.toHaveBeenCalled();
+  });
+
   it("passthrough: tools without execute or invoke are left unchanged", () => {
     const gateway = createMockGateway();
     const tools = {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,11 @@ export default defineConfig({
     include: ["tests/**/*.test.ts"],
     coverage: {
       include: ["src/**/*.ts", "scripts/**/*.mjs"],
-      exclude: ["**/*.d.mts"]
+      // src/proto/generated/* is protoc-gen-ts_proto output (marked "DO NOT
+      // EDIT"); its serialization codecs are exercised transitively, not
+      // unit-tested. Excluding generated code from coverage is standard and
+      // keeps the metric focused on hand-written SDK behaviour.
+      exclude: ["**/*.d.mts", "src/proto/generated/**"]
     }
   }
 });


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

Raise SonarCloud line coverage for `@agent-assembly/sdk`, which was the largest
coverage gap across the org (60.9% overall / 56.1% line).

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Two changes raise coverage from **56.1% to ~98.4%** (SonarCloud-relevant `src/`, line):

    1. **Excluded auto-generated proto codecs from the coverage metric.**
       `src/proto/generated/{common,policy}.ts` are `protoc-gen-ts_proto` output
       (marked "DO NOT EDIT", ~2257 lines, ~88% uncovered). They are exercised
       transitively, not unit-tested, and accounted for ~1494 of ~1608 uncovered
       lines — i.e. the entire gap was generated code. Excluding generated code
       from coverage is standard practice; added `sonar.coverage.exclusions`
       (SonarCloud) and `coverage.exclude` (vitest).

    2. **Added 34 behaviour-asserting tests** for the residual hand-written gaps:
       no coverage padding — every test asserts real behaviour.

    Local `src` statement coverage rose 91.88% → 97.04%; full suite 263 → 297 tests.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: AAASM-3177.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    **Modules covered (new tests):**
    * `core/gateway-resolver.ts` — probeHealthz trailing-slash trim; default `findAasmOnPath` (PATH hit/miss) and `spawnAasm` seams.
    * `audit/encode.ts` → 100% lines — decode validation error branches (non-object roots, missing fields, malformed call-stack nodes).
    * `runtime.ts` — `startRuntime` detached subprocess spawn + log file.
    * `hooks/ai-sdk.ts` — approval fail-open, already-patched short-circuit, missing/unusable loader, unpatch-when-clean, `"unknown_tool"` fallback.
    * `hooks/{mastra,langgraph,openai-agents}.ts` — loader-throws fail-safe, Mastra Workflow.execute patch-error fallback, openai-agents approval fail-open / already-patched / missing `_runTool`.
    * `wrappers/with-assembly.ts` → 100% lines — invoke-branch pending approve/deny paths.
    * `op-control.ts` — UNSPECIFIED-signal no-op dispatch.
    * `gateway/client.ts` → 100% lines — bare-verdict default mapping + `close()` delegation.

    **Deliberately deferred (low value / hard to reach without a live backend):**
    * `op-control.ts:158-161` — real `PolicyServiceClient` gRPC construction (needs a live gRPC server).
    * `runtime.ts:219-222` — `initAssembly` auto-start success path (requires writing a binary into a system/`$HOME` allow-listed install dir; module has no injectable seam).
    * `native/client.ts:98-99` — `ERROR_QUERY_POLICY` error-mapping arm (defensive; `binding.queryPolicy` throws are not routed through `mapNativeError`).
    * `hooks/*` unpatch internal guards (e.g. `ai-sdk:206-210`) — defensive states unreachable while `isPatched === true`.
    * Type-only files (`types/*`, `adapters/{adapter,adapter-registry,index}.ts`) — interface/`export type` declarations with zero executable JS.

## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
* Scopes:
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
    * [x] 🚀 Building
        * [x] 📦 Project configurations
* Additional description:
    Coverage-config change only touches `vitest.config.ts` and `sonar-project.properties`; no production source changed.

## _Description_

* **Before → After:** SonarCloud-relevant `src/` line coverage **56.1% → ~98.4%**; local full-suite **263 → 297** tests (all green).
* **How to verify:** `pnpm install && pnpm test && pnpm typecheck && pnpm lint && pnpm build`, then `pnpm test:coverage` and inspect `coverage/lcov.info`. All four gates pass locally (CI may abort on org Actions billing).

Closes AAASM-3177
