### PR TITLE
[AAASM-3400] ✨ (aa-ffi-node): Add native register() + queryPolicy() over aa-sdk-client gateway Register

### DIFF
--- a/native/aa-ffi-node/Cargo.lock
+++ b/native/aa-ffi-node/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 [[package]]
 name = "aa-proto"
 version = "0.0.1-beta.2"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=4f9eea19c2c7e9d6730319e427861a291010fc75#4f9eea19c2c7e9d6730319e427861a291010fc75"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=9cde1d83e4114114bd49c9546d4fa5d86d6cbd32#9cde1d83e4114114bd49c9546d4fa5d86d6cbd32"
 dependencies = [
  "prost",
  "tonic",
@@ -30,19 +30,24 @@ dependencies = [
 [[package]]
 name = "aa-sdk-client"
 version = "0.0.1-beta.2"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=4f9eea19c2c7e9d6730319e427861a291010fc75#4f9eea19c2c7e9d6730319e427861a291010fc75"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=9cde1d83e4114114bd49c9546d4fa5d86d6cbd32#9cde1d83e4114114bd49c9546d4fa5d86d6cbd32"
 dependencies = [
  "aa-proto",
  "aa-security",
+ "bs58",
+ "ed25519-dalek",
+ "hex",
  "prost",
+ "sha2 0.11.0",
  "tokio",
+ "tonic",
  "tracing",
 ]
 
 [[package]]
 name = "aa-security"
 version = "0.0.1-beta.2"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=4f9eea19c2c7e9d6730319e427861a291010fc75#4f9eea19c2c7e9d6730319e427861a291010fc75"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=9cde1d83e4114114bd49c9546d4fa5d86d6cbd32#9cde1d83e4114114bd49c9546d4fa5d86d6cbd32"
 dependencies = [
  "aho-corasick",
 ]
@@ -129,10 +134,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "bytes"
@@ -147,6 +185,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "convert_case"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,10 +206,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctor"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "either"
@@ -188,6 +357,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fixedbitset"
@@ -296,6 +471,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +545,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "http"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +594,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -666,6 +877,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +994,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +1036,15 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -869,6 +1108,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +1159,22 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -914,11 +1200,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1107,6 +1408,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,6 +1436,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -1305,6 +1618,12 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/native/aa-ffi-node/Cargo.toml
+++ b/native/aa-ffi-node/Cargo.toml
@@ -19,8 +19,14 @@ crate-type = ["cdylib"]
 # `aa-proto` is pinned at the SAME SHA so cargo resolves a single checkout of
 # the agent-assembly workspace; `query_policy` builds a `CheckActionRequest`
 # and reads its `CheckActionResponse` directly from these generated types.
-aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "4f9eea19c2c7e9d6730319e427861a291010fc75", package = "aa-sdk-client" }
-aa-proto = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "4f9eea19c2c7e9d6730319e427861a291010fc75", package = "aa-proto" }
+#
+# Pinned at agent-assembly master 9cde1d83 (AAASM-3396), which adds
+# `AssemblyClient::register()` (the one direct SDK→gateway gRPC call, per ADR
+# 0004) and makes `query_policy()` attach the registration `credential_token`
+# so the gateway does not deny a registered agent. That commit also adds the
+# `gateway_endpoint` field to `AssemblyConfig`, consumed by `register`.
+aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "9cde1d83e4114114bd49c9546d4fa5d86d6cbd32", package = "aa-sdk-client" }
+aa-proto = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "9cde1d83e4114114bd49c9546d4fa5d86d6cbd32", package = "aa-proto" }
 napi = { version = "3", default-features = false, features = ["napi8", "tokio_rt", "serde-json"] }
 napi-derive = "3"
 prost = "0.14"

--- a/native/aa-ffi-node/index.d.ts
+++ b/native/aa-ffi-node/index.d.ts
@@ -61,6 +61,40 @@ export interface PolicyDecision {
 export declare function queryPolicy(handle: ClientHandle, query: any): Promise<PolicyDecision>
 
 /**
+ * Register this agent with the governance gateway and store the issued
+ * credential token on the session.
+ *
+ * This is the **only** direct SDK→gateway gRPC call (per ADR 0004);
+ * `CheckAction` still flows through `aa-runtime`. The token the gateway issues
+ * is stored inside the shared [`AssemblyClient`] and then attached to every
+ * subsequent [`query_policy`] request so the gateway's
+ * `validate_credential_token` does not deny a registered agent.
+ *
+ * Delegates to [`AssemblyClient::register`], an async tonic call, so this napi
+ * function is itself `async` and awaits it without blocking the Node event
+ * loop. Returns the assigned policy id reported by the gateway. A failed
+ * registration — gateway unreachable, identity rejected — surfaces as a typed
+ * error so the caller can decide whether to proceed unregistered.
+ */
+export declare function register(handle: ClientHandle, options: RegisterOptions): Promise<string>
+
+/**
+ * Parameters for [`register`].
+ *
+ * `agentId` is the agent identity the gateway registers (derived into a
+ * `did:key` + Ed25519 public key by the shared client). `name` and `framework`
+ * are descriptive metadata the gateway records. `gatewayEndpoint` overrides the
+ * gateway gRPC endpoint (default resolved from `AA_GATEWAY_ENDPOINT` or
+ * `http://127.0.0.1:50051`).
+ */
+export interface RegisterOptions {
+  agentId: string
+  name: string
+  framework: string
+  gatewayEndpoint?: string
+}
+
+/**
  * Ship a captured event to the runtime.
  *
  * The JS event object is translated to the shared client's

--- a/native/aa-ffi-node/src/lib.rs
+++ b/native/aa-ffi-node/src/lib.rs
@@ -23,6 +23,7 @@ use napi_derive::napi;
 use serde_json::Value;
 
 const ERR_CONNECT: &str = "AA_ERR_CONNECT";
+const ERR_REGISTER: &str = "AA_ERR_REGISTER";
 const ERR_SEND_EVENT: &str = "AA_ERR_SEND_EVENT";
 const ERR_DISCONNECT: &str = "AA_ERR_DISCONNECT";
 const ERR_QUERY_POLICY: &str = "AA_ERR_QUERY_POLICY";
@@ -68,6 +69,50 @@ pub async fn connect(socket_path: String) -> Result<ClientHandle> {
   Ok(ClientHandle {
     inner: Arc::new(client),
   })
+}
+
+/// Parameters for [`register`].
+///
+/// `agentId` is the agent identity the gateway registers (derived into a
+/// `did:key` + Ed25519 public key by the shared client). `name` and `framework`
+/// are descriptive metadata the gateway records. `gatewayEndpoint` overrides the
+/// gateway gRPC endpoint (default resolved from `AA_GATEWAY_ENDPOINT` or
+/// `http://127.0.0.1:50051`).
+#[napi(object)]
+pub struct RegisterOptions {
+  pub agent_id: String,
+  pub name: String,
+  pub framework: String,
+  pub gateway_endpoint: Option<String>,
+}
+
+/// Register this agent with the governance gateway and store the issued
+/// credential token on the session.
+///
+/// This is the **only** direct SDK→gateway gRPC call (per ADR 0004);
+/// `CheckAction` still flows through `aa-runtime`. The token the gateway issues
+/// is stored inside the shared [`AssemblyClient`] and then attached to every
+/// subsequent [`query_policy`] request so the gateway's
+/// `validate_credential_token` does not deny a registered agent.
+///
+/// Delegates to [`AssemblyClient::register`], an async tonic call, so this napi
+/// function is itself `async` and awaits it without blocking the Node event
+/// loop. Returns the assigned policy id reported by the gateway. A failed
+/// registration — gateway unreachable, identity rejected — surfaces as a typed
+/// error so the caller can decide whether to proceed unregistered.
+#[napi]
+pub async fn register(handle: &ClientHandle, options: RegisterOptions) -> Result<String> {
+  let config = AssemblyConfig {
+    agent_id: options.agent_id,
+    socket_path: None,
+    gateway_endpoint: options.gateway_endpoint,
+  };
+
+  handle
+    .inner
+    .register(&config, options.name, options.framework)
+    .await
+    .map_err(|err| typed_error(ERR_REGISTER, &err.to_string()))
 }
 
 /// Ship a captured event to the runtime.

--- a/native/aa-ffi-node/src/lib.rs
+++ b/native/aa-ffi-node/src/lib.rs
@@ -57,6 +57,7 @@ pub async fn connect(socket_path: String) -> Result<ClientHandle> {
   let config = AssemblyConfig {
     agent_id: String::new(),
     socket_path: Some(socket_path),
+    gateway_endpoint: None,
   };
   let resolved = config.resolve_socket_path();
 


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Add `register()` + `queryPolicy()` coverage to the native napi binding (`aa-ffi-node`), backed by the now-merged `aa-sdk-client` gateway Register + `credential_token` work on agent-assembly master `9cde1d83` (AAASM-3396). `queryPolicy` already existed in the binding; this ticket bumps the shared-crate pin to the SHA that carries the gateway-register support and adds the native `register()` method.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: AAASM-3400 (T6).
    * Relative task IDs:
        * [x] AAASM-3396 — `aa-sdk-client` Gateway Register + `credential_token` (merged, agent-assembly `9cde1d83`).
        * [ ] AAASM-3403 (T9) — surface `register` / `queryPolicy` on the public TS API / wrappers (follow-up; **not** in this PR).
    * Relative PRs:
        * agent-assembly#1151 (AAASM-3396).

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    * Bump the `aa-sdk-client` **and** `aa-proto` git-SHA pin in `native/aa-ffi-node/Cargo.toml` (+ `Cargo.lock`) from `4f9eea19` to `9cde1d83` (single rev — ADR 0003 lockstep invariant preserved). The new SHA adds `AssemblyClient::register()`, a token-attaching `query_policy()`, and a new `gateway_endpoint` field on `AssemblyConfig`.
    * Set the new `gateway_endpoint: None` in the existing `connect()` config literal so the crate compiles against the bumped dep.
    * Add `#[napi] async fn register(handle, options)` delegating to `AssemblyClient::register()` (the only direct SDK→gateway gRPC call, per ADR 0004). It builds an `AssemblyConfig` from the JS `RegisterOptions` (`agentId` / `name` / `framework` / optional `gatewayEndpoint`), awaits the async tonic call, and returns the gateway-assigned policy id. The issued `credential_token` is stored on the shared client and attached to subsequent `queryPolicy()` calls.
    * Regenerate the checked-in `index.d.ts` so `register` and the `RegisterOptions` interface are surfaced (the binding previously exposed `connect` / `sendEvent` / `queryPolicy` / `disconnect`).

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] 🧩 SDK public API
    * [x] 🪡 API client and transport
    * [ ] 🤖 Framework hooks
    * [x] 🫀 Data model and types
    * [ ] ⛑️ Error handling
    * [x] 🧪 Testing
        * [ ] 🧪 Unit testing
        * [x] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [x] 🚀 Building
        * [ ] 🤖 CI/CD
        * [x] 🔗 Dependencies
        * [ ] 📦 Project configurations
    * [ ] 📚 Documentation
* Additional description:
    Only the native binding changes. The public TypeScript API and framework wrappers are intentionally untouched — wiring those is AAASM-3403 (T9).

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* `⬆️ (aa-ffi-node)` Bump `aa-sdk-client` / `aa-proto` pin to `9cde1d83`; add `gateway_endpoint: None` to the `connect()` config literal to keep the crate compiling.
* `✨ (aa-ffi-node)` Add native `register()` over the shared `AssemblyClient::register()`; surface `register` + `RegisterOptions` in the regenerated `index.d.ts`.

### Verification

* `cargo check` / `cargo clippy --all-targets -- -D warnings` on `native/aa-ffi-node` — clean.
* `pnpm install` + `pnpm native:build` — native addon builds; `index.d.ts` regenerated with `register` / `RegisterOptions`.
* `pnpm lint`, `pnpm typecheck`, `pnpm native:check-types` — clean.
* JS smoke check: `register` / `queryPolicy` are exported callable functions; `register` performs the gateway gRPC call and rejects with the typed `AA_ERR_REGISTER` error when no gateway is listening.
* Note: `cargo test` for the crate cannot link standalone on macOS (the `_napi_*` symbols are resolved by Node at load time, not at link time — a known limitation for these napi/pyo3 shims); the existing `query_policy` unit tests run on Linux CI.

Closes AAASM-3400
