### PR TITLE
[AAASM-3403] ♻️ (node-sdk): Replace no-op gateway client with native queryPolicy + register

### DIFF
--- a/src/core/init-assembly.ts
+++ b/src/core/init-assembly.ts
@@ -9,7 +9,11 @@ import {
   createNoopGatewayClient,
   type GatewayClient
 } from "../gateway/client.js";
-import { createNativeClient, type NativeClient } from "../native/client.js";
+import {
+  createNativeClient,
+  type NativeClient,
+  type RegisterOptions
+} from "../native/client.js";
 import { ConfigurationError } from "../errors/index.js";
 import type { AssemblyConfig } from "../types/assembly-config.js";
 import type { AssemblyContext } from "../types/assembly-context.js";
@@ -52,6 +56,27 @@ function buildRegistrationEvent(config: AssemblyConfig): Record<string, string> 
 }
 
 /**
+ * Build the {@link RegisterOptions} for the native `register` gRPC call
+ * (AAASM-3400) from the resolved config and the detected frameworks. `name`
+ * falls back to `agentId`; `framework` is the first detected framework (or
+ * `"none"` when running without an adapter); `gatewayEndpoint` is set only when
+ * a gateway URL was resolved so the native default endpoint resolution is
+ * preserved when it was not.
+ */
+function buildRegisterOptions(
+  config: AssemblyConfig,
+  frameworks: readonly string[]
+): RegisterOptions {
+  const agentId = config.agentId ?? "";
+  return {
+    agentId,
+    name: config.name ?? agentId,
+    framework: frameworks[0] ?? "none",
+    ...(config.gatewayUrl ? { gatewayEndpoint: config.gatewayUrl } : {})
+  };
+}
+
+/**
  * The only built-in {@link AssemblyMode} for which {@link createClient}
  * constructs a gateway client whose `check()` consults a real authoritative
  * verdict (the native `queryPolicy` against a reachable `aa-runtime`). Every
@@ -59,7 +84,10 @@ function buildRegistrationEvent(config: AssemblyConfig): Record<string, string> 
  */
 const CHECK_CAPABLE_MODE: AssemblyMode = "napi-inprocess";
 
-export function createClient(config: AssemblyConfig): GatewayClient {
+export function createClient(
+  config: AssemblyConfig,
+  nativeClientOverride?: NativeClient
+): GatewayClient {
   const mode = config.mode ?? "auto";
   if (config.gatewayClient) {
     return config.gatewayClient;
@@ -91,11 +119,17 @@ export function createClient(config: AssemblyConfig): GatewayClient {
   // gateway client swallows local faults, so this never blocks without a
   // runtime — preserving the pre-feature fail-open behavior.
   if (mode === "napi-inprocess") {
-    const nativeClient = createNativeClient({
-      gateway: config.gatewayUrl ?? "",
-      apiKey: config.apiKey ?? "",
-      mode: "napi-inprocess"
-    });
+    // Reuse the caller-supplied native client when present so the registered
+    // session (the one `register()` stored the gateway token on) is the same
+    // session `queryPolicy` runs against. Standalone callers (and the routing
+    // tests) get a freshly-built client instead.
+    const nativeClient =
+      nativeClientOverride ??
+      createNativeClient({
+        gateway: config.gatewayUrl ?? "",
+        apiKey: config.apiKey ?? "",
+        mode: "napi-inprocess"
+      });
     return createNativeGatewayClient(mode, nativeClient, config.agentId, httpBaseUrl);
   }
 
@@ -358,14 +392,12 @@ export async function initAssembly(config: AssemblyConfig = {}): Promise<Assembl
     ...(resolvedParentAgentId ? { parentAgentId: resolvedParentAgentId } : {})
   };
 
-  const client = createClient(resolvedConfig);
   const frameworks = detectFrameworks();
-  const adapters = await registerAdapters(frameworks);
 
-  await startNetworkLayerIfNeeded(client, resolvedConfig);
-
-  // Send topology registration event through the native transport on every boot
-  // except sdk-only mode (which has no sidecar to register with).
+  // Build the native transport up front (every mode except sdk-only, which has
+  // no sidecar) so the same session backs both the gateway client's `check()`
+  // and the agent registration — the gateway token `register()` stores on the
+  // session is then attached to every subsequent `queryPolicy` request.
   let nativeClient: NativeClient | undefined;
   if (resolvedConfig.mode !== "sdk-only") {
     nativeClient = createNativeClient({
@@ -373,6 +405,28 @@ export async function initAssembly(config: AssemblyConfig = {}): Promise<Assembl
       apiKey: resolvedApiKey,
       mode: resolvedConfig.mode === "napi-inprocess" ? "napi-inprocess" : "grpc-sidecar"
     });
+  }
+
+  const client = createClient(resolvedConfig, nativeClient);
+  const adapters = await registerAdapters(frameworks);
+
+  await startNetworkLayerIfNeeded(client, resolvedConfig);
+
+  if (nativeClient !== undefined) {
+    // AAASM-3403: register the agent over the native SDK→gateway gRPC call so
+    // the gateway issues a credential token (stored on this session) that
+    // unblocks subsequent policy queries. Advisory: a failed registration must
+    // not abort init — the agent proceeds unregistered and the proxy / eBPF
+    // layers remain authoritative.
+    try {
+      await nativeClient.register(buildRegisterOptions(resolvedConfig, frameworks));
+    } catch (error) {
+      console.warn(
+        `[agent-assembly] agent registration failed; proceeding unregistered: ${String(error)}`
+      );
+    }
+    // Topology lineage metadata still flows as an audit event (parent / team /
+    // delegation), which `register` does not carry.
     nativeClient.sendEvent(buildRegistrationEvent(resolvedConfig));
   }
 

--- a/src/native/client.ts
+++ b/src/native/client.ts
@@ -19,10 +19,23 @@ interface NativePolicyDecision {
   reason: string;
 }
 
+/**
+ * Options for the native `register` primitive (AAASM-3400). `agentId` is the
+ * identity the gateway registers; `name` / `framework` are descriptive
+ * metadata; `gatewayEndpoint` overrides the gateway gRPC endpoint.
+ */
+export interface RegisterOptions {
+  agentId: string;
+  name: string;
+  framework: string;
+  gatewayEndpoint?: string;
+}
+
 interface NativeBinding {
   connect: (socketPath: string) => Promise<object>;
   sendEvent: (handle: object, event: unknown) => void;
   queryPolicy: (handle: object, query: unknown) => Promise<NativePolicyDecision>;
+  register?: (handle: object, options: RegisterOptions) => Promise<string>;
   disconnect: (handle: object) => Promise<void>;
 }
 
@@ -35,6 +48,7 @@ interface GlobalWithNativeBinding {
 const ERROR_CONNECT = "AA_ERR_CONNECT";
 const ERROR_SEND_EVENT = "AA_ERR_SEND_EVENT";
 const ERROR_QUERY_POLICY = "AA_ERR_QUERY_POLICY";
+const ERROR_REGISTER = "AA_ERR_REGISTER";
 const ERROR_DISCONNECT = "AA_ERR_DISCONNECT";
 
 export class NativeConnectError extends Error {
@@ -49,6 +63,10 @@ export class NativeQueryPolicyError extends Error {
   readonly code = ERROR_QUERY_POLICY;
 }
 
+export class NativeRegisterError extends Error {
+  readonly code = ERROR_REGISTER;
+}
+
 export class NativeDisconnectError extends Error {
   readonly code = ERROR_DISCONNECT;
 }
@@ -58,6 +76,18 @@ export interface NativeClient {
   close: () => Promise<void>;
   sendEvent: (event: unknown) => void;
   queryPolicy: (action: unknown) => Promise<PolicyResult>;
+  /**
+   * Register this agent with the governance gateway over the native
+   * SDK→gateway gRPC call (AAASM-3400). The token the gateway issues is stored
+   * on the underlying session and attached to every subsequent
+   * {@link queryPolicy} request, so the gateway does not deny a registered
+   * agent. Returns the assigned policy id.
+   *
+   * **Advisory:** like the rest of the SDK this is not a security boundary. A
+   * failed registration surfaces as a typed error; callers may proceed
+   * unregistered (the proxy / eBPF layers remain authoritative).
+   */
+  register: (options: RegisterOptions) => Promise<string>;
 }
 
 /**
@@ -96,6 +126,9 @@ function mapNativeError(error: unknown): Error {
   }
   if (code === ERROR_QUERY_POLICY) {
     return new NativeQueryPolicyError(detail);
+  }
+  if (code === ERROR_REGISTER) {
+    return new NativeRegisterError(detail);
   }
   if (code === ERROR_DISCONNECT) {
     return new NativeDisconnectError(detail);
@@ -146,7 +179,11 @@ export function createNativeClient(options: InitAssemblyOptions): NativeClient {
       mode,
       close: async () => undefined,
       sendEvent: () => undefined,
-      queryPolicy: async () => ({ denied: false, pending: false })
+      queryPolicy: async () => ({ denied: false, pending: false }),
+      // No native session to register against off the in-process path; the
+      // gRPC sidecar registers the agent in its own process. Resolve neutrally
+      // so init never blocks on a transport that does not own a handle.
+      register: async () => ""
     };
   }
 
@@ -226,6 +263,21 @@ export function createNativeClient(options: InitAssemblyOptions): NativeClient {
       const handle = await getHandle();
       const verdict = await binding.queryPolicy(handle, action);
       return mapDecisionToPolicyResult(verdict);
+    },
+    register: async (options: RegisterOptions) => {
+      // Register on the same session the queryPolicy path uses, so the token
+      // the gateway issues is stored on this handle and attached to every
+      // subsequent query. This is the only direct SDK→gateway gRPC call
+      // (ADR 0004); CheckAction still flows through aa-runtime.
+      if (binding.register === undefined) {
+        // A binding without `register` predates AAASM-3400; the agent simply
+        // runs unregistered rather than failing init.
+        return "";
+      }
+      const handle = await getHandle();
+      return binding.register(handle, options).catch((error: unknown) => {
+        throw mapNativeError(error);
+      });
     }
   };
 }

--- a/src/types/assembly-config.ts
+++ b/src/types/assembly-config.ts
@@ -26,6 +26,12 @@ export interface AssemblyConfig {
    */
   apiKey?: string;
   agentId?: string;
+  /**
+   * Human-readable agent name recorded by the gateway at registration
+   * (AAASM-3400). Descriptive metadata only; when omitted it falls back to
+   * ``agentId``.
+   */
+  name?: string;
   mode?: AssemblyMode;
   gatewayClient?: GatewayClient;
   langchain?: LangChainAdapterConfig;

--- a/tests/hooks-patch.test.ts
+++ b/tests/hooks-patch.test.ts
@@ -9,7 +9,8 @@ function createClient(mode: NativeClient["mode"]): NativeClient {
     mode,
     close: async () => undefined,
     sendEvent: () => undefined,
-    queryPolicy: async () => ({ denied: false, pending: false })
+    queryPolicy: async () => ({ denied: false, pending: false }),
+    register: async () => ""
   };
 }
 

--- a/tests/native-gateway-enforcement.test.ts
+++ b/tests/native-gateway-enforcement.test.ts
@@ -19,7 +19,8 @@ function fakeNativeClient(queryPolicy: NativeClient["queryPolicy"]): NativeClien
     mode: "napi-inprocess",
     close: vi.fn(async () => undefined),
     sendEvent: vi.fn(() => undefined),
-    queryPolicy
+    queryPolicy,
+    register: vi.fn(async () => "")
   };
 }
 

--- a/tests/native-register.test.ts
+++ b/tests/native-register.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * AAASM-3403 — wire the native `register` primitive (AAASM-3400) into the SDK.
+ *
+ * Two contracts are covered:
+ *
+ *  1. The `NativeClient` wrapper's `register()` delegates to the binding's
+ *     `register(handle, options)` on the **same** session handle the
+ *     `queryPolicy` path uses, so the gateway token attaches to subsequent
+ *     queries.
+ *  2. `initAssembly` calls `register()` on boot (napi-inprocess) with the
+ *     RegisterOptions derived from the config, and a failed registration is
+ *     swallowed so init proceeds unregistered (advisory SDK, fail-open).
+ */
+
+interface MockBinding {
+  connect: ReturnType<typeof vi.fn>;
+  sendEvent: ReturnType<typeof vi.fn>;
+  queryPolicy: ReturnType<typeof vi.fn>;
+  register: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+}
+
+function makeBinding(overrides: Partial<MockBinding> = {}): MockBinding {
+  return {
+    connect: vi.fn(async () => ({ id: "handle" })),
+    sendEvent: vi.fn(() => undefined),
+    queryPolicy: vi.fn(async () => ({ decision: "allow", reason: "" })),
+    register: vi.fn(async () => "policy-7"),
+    disconnect: vi.fn(async () => undefined),
+    ...overrides
+  };
+}
+
+async function loadWithBinding(binding: MockBinding) {
+  vi.resetModules();
+  vi.doMock("node:module", () => ({
+    createRequire: () => () => binding
+  }));
+  return import("../src/index.js");
+}
+
+async function loadNativeClientWithBinding(binding: MockBinding) {
+  vi.resetModules();
+  vi.doMock("node:module", () => ({
+    createRequire: () => () => binding
+  }));
+  return import("../src/native/client.js");
+}
+
+describe("native register wrapper (AAASM-3403)", () => {
+  it("delegates to the binding on the same handle queryPolicy uses", async () => {
+    const binding = makeBinding();
+    const mod = await loadNativeClientWithBinding(binding);
+
+    const client = mod.createNativeClient({
+      gateway: "/tmp/aa.sock",
+      apiKey: "k",
+      mode: "napi-inprocess"
+    });
+
+    const policyId = await client.register({
+      agentId: "agent-1",
+      name: "Agent One",
+      framework: "langchain-js"
+    });
+    await client.queryPolicy({ agent_id: "agent-1", action_type: "tool_call" });
+
+    expect(policyId).toBe("policy-7");
+    expect(binding.connect).toHaveBeenCalledTimes(1); // one shared session
+    expect(binding.register).toHaveBeenCalledWith(
+      { id: "handle" },
+      { agentId: "agent-1", name: "Agent One", framework: "langchain-js" }
+    );
+    expect(binding.queryPolicy.mock.calls[0]?.[0]).toEqual({ id: "handle" });
+    await client.close();
+  });
+
+  it("resolves neutrally when the binding has no register (pre-AAASM-3400)", async () => {
+    const binding = makeBinding();
+    // Simulate an older binding that predates the register primitive.
+    const noRegister = { ...binding, register: undefined } as unknown as MockBinding;
+    const mod = await loadNativeClientWithBinding(noRegister);
+
+    const client = mod.createNativeClient({
+      gateway: "/tmp/aa.sock",
+      apiKey: "k",
+      mode: "napi-inprocess"
+    });
+
+    await expect(
+      client.register({ agentId: "a", name: "a", framework: "none" })
+    ).resolves.toBe("");
+    expect(binding.connect).not.toHaveBeenCalled();
+    await client.close();
+  });
+
+  it("surfaces a binding register failure as a typed error", async () => {
+    const binding = makeBinding({
+      register: vi.fn(async () => {
+        throw new Error("AA_ERR_REGISTER:gateway unreachable");
+      })
+    });
+    const mod = await loadNativeClientWithBinding(binding);
+
+    const client = mod.createNativeClient({
+      gateway: "/tmp/aa.sock",
+      apiKey: "k",
+      mode: "napi-inprocess"
+    });
+
+    await expect(
+      client.register({ agentId: "a", name: "a", framework: "none" })
+    ).rejects.toBeInstanceOf(mod.NativeRegisterError);
+    await client.close();
+  });
+});
+
+describe("initAssembly registers the agent (AAASM-3403)", () => {
+  it("calls native register with options from the config on napi-inprocess boot", async () => {
+    const binding = makeBinding();
+    const { initAssembly } = await loadWithBinding(binding);
+
+    const ctx = await initAssembly({
+      gatewayUrl: "/tmp/aa.sock",
+      apiKey: "test-key",
+      agentId: "agent-9",
+      name: "Ninth Agent",
+      mode: "napi-inprocess"
+    });
+    await ctx.shutdown();
+
+    expect(binding.register).toHaveBeenCalledOnce();
+    expect(binding.register).toHaveBeenCalledWith(
+      { id: "handle" },
+      {
+        agentId: "agent-9",
+        name: "Ninth Agent",
+        framework: "none",
+        gatewayEndpoint: "/tmp/aa.sock"
+      }
+    );
+  });
+
+  it("defaults name to agentId when name is omitted", async () => {
+    const binding = makeBinding();
+    const { initAssembly } = await loadWithBinding(binding);
+
+    const ctx = await initAssembly({
+      gatewayUrl: "/tmp/aa.sock",
+      apiKey: "test-key",
+      agentId: "solo",
+      mode: "napi-inprocess"
+    });
+    await ctx.shutdown();
+
+    expect(binding.register.mock.calls[0]?.[1]).toMatchObject({
+      agentId: "solo",
+      name: "solo"
+    });
+  });
+
+  it("proceeds unregistered when registration fails (fail-open)", async () => {
+    const binding = makeBinding({
+      register: vi.fn(async () => {
+        throw new Error("AA_ERR_REGISTER:gateway down");
+      })
+    });
+    const { initAssembly } = await loadWithBinding(binding);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    // init must not reject just because the gateway rejected registration.
+    const ctx = await initAssembly({
+      gatewayUrl: "/tmp/aa.sock",
+      apiKey: "test-key",
+      agentId: "agent-x",
+      mode: "napi-inprocess"
+    });
+    await ctx.shutdown();
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("proceeding unregistered"));
+    // Lineage audit event still ships.
+    expect(binding.sendEvent).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("does not register in sdk-only mode (no session to register against)", async () => {
+    const binding = makeBinding();
+    const { initAssembly } = await loadWithBinding(binding);
+
+    const ctx = await initAssembly({
+      gatewayUrl: "https://gateway.example.com",
+      apiKey: "test-key",
+      mode: "sdk-only"
+    });
+    await ctx.shutdown();
+
+    expect(binding.connect).not.toHaveBeenCalled();
+    expect(binding.register).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## _Target_

The public TS SDK routed pre-execution checks through `createNoopGatewayClient`, whose `check()` always returns `{denied:false}` — so a denied action was not blocked at the SDK layer even against a reachable core. The AAASM-3050 work already wired `queryPolicy` deny-blocking for `napi-inprocess`, but the native `register()` primitive (AAASM-3400) was never called from `initAssembly`, so the gateway never issued the credential token that subsequent policy queries need.

* ### Task summary:

    Wire the native `register()` gRPC call (AAASM-3400) into `initAssembly` and back the gateway client with the same registered native session, so the gateway-issued token attaches to every `queryPolicy` and a `deny` decision actually blocks. Closes the unwired-enforcement gap for the Node SDK.

* ### Task tickets:

    * Task ID: AAASM-3403.
    * Relative task IDs:
        * [x] AAASM-3400 (native `register`/`queryPolicy` binding) — depended on.
        * [x] AAASM-3050 (native gateway client deny-blocking) — built on.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    * `NativeClient` now exposes `register(options)`, delegating to the binding's `register(handle, options)` on the **same** session handle `queryPolicy` runs against — so the credential token the gateway issues is attached to subsequent policy queries (ADR 0004: register is the only direct SDK→gateway gRPC call; CheckAction still flows through `aa-runtime`).
    * `initAssembly` builds one native client up front (non-sdk-only), passes it to `createClient` so `check()` and registration share a session, then calls `register()` on boot with `RegisterOptions` derived from config (`agentId` / `name` / `framework` / `gatewayEndpoint`).
    * Registration is **advisory / fail-open**: a failed `register()` is swallowed (warns, proceeds unregistered); the proxy / eBPF layers remain authoritative. Enforce/observe/disabled semantics are preserved — only `enforce` hard-blocks (unchanged from AAASM-3105).

## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
    * [x] 🔧 Fixing bug
* Scopes:
    * [x] 🧩 SDK public API
    * [x] 🪡 API client and transport
    * [x] 🫀 Data model and types
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
    * [x] 📚 Documentation
* Additional description:
    `AssemblyConfig` gains an optional `name` field (additive, defaults to `agentId`). No public signature is broken: `createClient` gains an optional second argument.

## _Description_

* `src/native/client.ts`: add `register()` to `NativeClient` + `RegisterOptions` type + `NativeRegisterError`; napi path delegates to `binding.register` on the shared handle, grpc-sidecar path is a no-op, pre-3400 bindings resolve neutrally.
* `src/core/init-assembly.ts`: share one native session between the gateway client and registration; call `register()` on boot with config-derived options; fail open on registration error; keep topology lineage `sendEvent`.
* `src/types/assembly-config.ts`: optional `name` field.
* `tests/native-register.test.ts`: regression coverage — wrapper delegates on the shared handle, init registers with the right options, fail-open on registration error, sdk-only never registers.

## How to verify

* `pnpm install && pnpm lint && pnpm typecheck && pnpm test && pnpm build` — all green locally (307 tests pass, 2 skipped).
* New: `pnpm exec vitest run tests/native-register.test.ts`.

Closes AAASM-3403

🤖 Generated with [Claude Code](https://claude.com/claude-code)
