### PR TITLE
[AAASM-3433] 🔧 (ci): run CodeQL on push to master (default-branch coverage)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+on:
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
+  push:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
+    branches:
+      - master
+  schedule:
+    - cron: "0 3 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          submodules: recursive
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@65216971a11ded447a6b76263d5a144519e5eee1 # codeql-bundle-v2.25.2
+        with:
+          languages: javascript-typescript
+          build-mode: none
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@65216971a11ded447a6b76263d5a144519e5eee1 # codeql-bundle-v2.25.2
+        with:
+          category: "/language:javascript-typescript"


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

CodeQL security analysis was never recorded on `node-sdk`'s default branch. `gh api repos/ai-agent-assembly/node-sdk/code-scanning/analyses` returns `404 "no analysis found"` — the code-scanning (security) dashboard is empty and there is no scheduled scan.

Investigation showed the repo's only CodeQL runs come from GitHub's *dynamic default setup* in **code-quality mode** — they upload `javascript.quality.sarif` ("Uploading code quality results"), which lands in the code-quality feed, not the security `code-scanning/analyses` feed. Hence 0 security analyses despite green CodeQL runs.

* ### Task summary:

    Add a committed `.github/workflows/codeql.yml` (mirroring go-sdk's) that runs the **security** CodeQL analysis for `javascript-typescript` and uploads SARIF to the code-scanning feed on **push to `master`** and on a **weekly schedule**, while keeping PR runs.

* ### Task tickets:

    * Task ID: AAASM-3433.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    Triggers `pull_request` + `push: branches:[master]` + `schedule: cron "0 3 * * 1"`; `permissions.security-events: write` for SARIF upload. Language `javascript-typescript`, `build-mode: none` (no autobuild needed for JS/TS), `submodules: recursive` for parity with go-sdk.

## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
* Scopes:
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
* Additional description:
    CI-config only. No source, dependency, or runtime change. Adds one new workflow file; touches no existing job.

## _Description_

* Add `.github/workflows/codeql.yml`: security CodeQL `Analyze (javascript-typescript)` on PR, push to `master`, and weekly `schedule`, validated with `actionlint` (clean).

**How to verify:** After merge, push to `master` triggers the `CodeQL` workflow; `gh api repos/ai-agent-assembly/node-sdk/code-scanning/analyses` should then return a recorded analysis on `refs/heads/master`.

Closes AAASM-3433

🤖 Generated with [Claude Code](https://claude.com/claude-code)
