### PR TITLE
[AAASM-3439] 🔒 (sec): avoid shell interpolation in packaging test (CodeQL)

### DIFF
--- a/tests/packaging/npm-pack-content.test.ts
+++ b/tests/packaging/npm-pack-content.test.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -15,9 +15,21 @@ describe("packaging npm pack contents", () => {
 
       const packDir = fs.mkdtempSync(path.resolve(process.cwd(), ".pack-"));
 
+      // Pass the temp-dir path as a discrete argument (no shell interpolation):
+      // packDir is derived from an absolute cwd path that may contain spaces or
+      // shell metacharacters, which would corrupt a shell-built command string.
       const packEntries = JSON.parse(
-        execSync(
-          `npm pack --json --ignore-scripts --cache ./.npm-cache --pack-destination ${packDir}`,
+        execFileSync(
+          "npm",
+          [
+            "pack",
+            "--json",
+            "--ignore-scripts",
+            "--cache",
+            "./.npm-cache",
+            "--pack-destination",
+            packDir
+          ],
           {
             encoding: "utf8",
             stdio: "pipe"
@@ -29,7 +41,9 @@ describe("packaging npm pack contents", () => {
       expect(tarballName).toBeTruthy();
 
       const tarballPath = path.resolve(packDir, tarballName!);
-      const packedFiles = execSync(`tar -tf ${tarballPath}`, {
+      // Same rationale: tarballPath is an absolute path; pass it as an argument
+      // rather than interpolating it into a shell command string.
+      const packedFiles = execFileSync("tar", ["-tf", tarballPath], {
         encoding: "utf8",
         stdio: "pipe"
       })


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Resolve CodeQL code-scanning alert #1 (`js/shell-command-injection-from-environment`, MEDIUM) in `tests/packaging/npm-pack-content.test.ts`. The packaging test built the `tar` and `npm pack` shell commands by interpolating an absolute temp-dir path (derived from `process.cwd()`) into a shell-string `execSync` call. An absolute path containing spaces or shell metacharacters would corrupt the command.

* ### Task tickets:

    * Task ID: AAASM-3439.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    Switch the two path-interpolating `execSync(\`...\`)` calls to `execFileSync(cmd, [args])` with discrete argument arrays — no shell, so the absolute paths are never re-parsed by a shell. The `pnpm run build` call (no interpolation) is left unchanged. Test behaviour and assertions are identical.

## _Effecting Scope_

* Action Types:
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
* Scopes:
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
* Additional description:
    Test-only change; no production code, public API, or build config affected.

## _Description_

* `tests/packaging/npm-pack-content.test.ts`: import `execFileSync`; replace `execSync(\`npm pack ... ${packDir}\`)` and `execSync(\`tar -tf ${tarballPath}\`)` with `execFileSync` + args arrays. Added why-comments explaining the shell-injection rationale.

## _How to verify_

* `pnpm test -- tests/packaging/npm-pack-content.test.ts` — passes (target test green).
* `pnpm lint` and `pnpm typecheck` — clean.

Closes AAASM-3439

🤖 Generated with [Claude Code](https://claude.com/claude-code)
