### PR TITLE
[AAASM-3459] 🔖 (release): node-sdk 0.0.1-beta.4 (prep)

### DIFF
--- a/docs/02-quick-start/index.md
+++ b/docs/02-quick-start/index.md
@@ -19,11 +19,11 @@ npm install @agent-assembly/sdk
 The package ships dual ESM/CJS entries and selects a prebuilt native binding for your
 platform during `postinstall`, so there is no extra build step for typical consumers.
 
-:::note Pre-1.0 / alpha
-The current release line is `0.0.1-alpha.x`, published under the npm `alpha`
+:::note Pre-1.0 / beta
+The current release line is `0.0.1-beta.x`, published under the npm `beta`
 dist-tag. The public surface (`initAssembly`, `withAssembly`) is stabilizing but may
-change between alpha releases. Pin an exact version for reproducible installs:
-`npm install @agent-assembly/sdk@0.0.1-alpha.3`.
+change between pre-releases. Pin an exact version for reproducible installs:
+`npm install @agent-assembly/sdk@0.0.1-beta.4`.
 :::
 
 ## 2. Make sure a gateway is reachable

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/sdk",
-  "version": "0.0.1-alpha.4",
+  "version": "0.0.1-beta.4",
   "description": "TypeScript SDK for Agent Assembly",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

* ### Task summary:

    Version-prep for the next node-sdk beta on its published line. The published
    npm `@agent-assembly/sdk` **beta** dist-tag is `0.0.1-beta.3`, so the next
    beta is **0.0.1-beta.4**.

    **Source of truth — version is dispatch-set, not `package.json`:** the
    published npm version is supplied at release time via `release-node.yml`
    (the `npm_version` `workflow_dispatch` input, or the `release_tag` payload on
    the coordinated `repository_dispatch` path). The workflow overwrites
    `package.json`'s `version` at publish; master's `version` field is local-dev
    metadata only. This PR therefore (1) de-stales that local field from the
    leftover `0.0.1-alpha.4` to `0.0.1-beta.4`, and (2) syncs the stale
    quick-start release-line note to the beta line. It does **not** drive the
    publish.

* ### Task tickets:

    * Task ID: AAASM-3459.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * Gated on the core `agent-assembly` `v0.0.1-beta.3` release + the
          `bot/aa-ffi-pin-<tag>` FFI-pin bump PR (per release-runbook SOP).

* ### Key point change (optional):

    * `package.json` `version`: `0.0.1-alpha.4` → `0.0.1-beta.4` (de-stale).
    * `docs/02-quick-start/index.md`: alpha note → beta note (`0.0.1-beta.x`,
      `beta` dist-tag, beta pin example), matching the README.

## _Effecting Scope_

* Action Types:
    * [x] 🚀 Release
* Scopes:
    * [x] 🚀 Building
        * [x] 📦 Project configurations
    * [x] 📚 Documentation
* Additional description:

    No code / public-API change. **Publish is gated** and not triggered by this
    PR: the 5-package npm publish + native `aasm` binary are sourced from the
    core `agent-assembly v0.0.1-beta.3` GitHub Release (binary source +
    `aa-sdk-client` FFI-pin). Per `release-runbook` / `sdk-only-release`, the
    coordinated publish fires only after the core tag is cut and the
    `bot/aa-ffi-pin-<tag>` bump PR is merged here. This PR does **not** dispatch
    `release-node.yml`.

## _Description_

* Bump local-dev `package.json` version to `0.0.1-beta.4`.
* Sync the quick-start install note from the alpha line to the beta line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
