### PR TITLE
🤖 (aa-ffi-node): Bump aa-sdk-client pin to v0.0.1-beta.3

### DIFF
--- a/native/aa-ffi-node/Cargo.lock
+++ b/native/aa-ffi-node/Cargo.lock
@@ -6,7 +6,7 @@ version = 4
 name = "aa-ffi-node"
 version = "0.0.0"
 dependencies = [
- "aa-proto 0.0.1-beta.3 (git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=fdff8e402e83f01bda3fbbf1f3f7f831b391b62b)",
+ "aa-proto",
  "aa-sdk-client",
  "napi",
  "napi-build",
@@ -28,22 +28,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "aa-proto"
-version = "0.0.1-beta.3"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=fdff8e402e83f01bda3fbbf1f3f7f831b391b62b#ebc4d7dc9da81cdf4f265d681c138500ca6e98e7"
-dependencies = [
- "prost",
- "tonic",
- "tonic-prost",
- "tonic-prost-build",
-]
-
-[[package]]
 name = "aa-sdk-client"
 version = "0.0.1-beta.3"
 source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=ebc4d7dc9da81cdf4f265d681c138500ca6e98e7#ebc4d7dc9da81cdf4f265d681c138500ca6e98e7"
 dependencies = [
- "aa-proto 0.0.1-beta.3 (git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=ebc4d7dc9da81cdf4f265d681c138500ca6e98e7)",
+ "aa-proto",
  "aa-security",
  "bs58",
  "ed25519-dalek",

--- a/native/aa-ffi-node/Cargo.lock
+++ b/native/aa-ffi-node/Cargo.lock
@@ -6,7 +6,7 @@ version = 4
 name = "aa-ffi-node"
 version = "0.0.0"
 dependencies = [
- "aa-proto",
+ "aa-proto 0.0.1-beta.3 (git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=fdff8e402e83f01bda3fbbf1f3f7f831b391b62b)",
  "aa-sdk-client",
  "napi",
  "napi-build",
@@ -18,8 +18,19 @@ dependencies = [
 
 [[package]]
 name = "aa-proto"
-version = "0.0.1-beta.2"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=fdff8e402e83f01bda3fbbf1f3f7f831b391b62b#fdff8e402e83f01bda3fbbf1f3f7f831b391b62b"
+version = "0.0.1-beta.3"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=ebc4d7dc9da81cdf4f265d681c138500ca6e98e7#ebc4d7dc9da81cdf4f265d681c138500ca6e98e7"
+dependencies = [
+ "prost",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
+]
+
+[[package]]
+name = "aa-proto"
+version = "0.0.1-beta.3"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=fdff8e402e83f01bda3fbbf1f3f7f831b391b62b#ebc4d7dc9da81cdf4f265d681c138500ca6e98e7"
 dependencies = [
  "prost",
  "tonic",
@@ -29,10 +40,10 @@ dependencies = [
 
 [[package]]
 name = "aa-sdk-client"
-version = "0.0.1-beta.2"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=fdff8e402e83f01bda3fbbf1f3f7f831b391b62b#fdff8e402e83f01bda3fbbf1f3f7f831b391b62b"
+version = "0.0.1-beta.3"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=ebc4d7dc9da81cdf4f265d681c138500ca6e98e7#ebc4d7dc9da81cdf4f265d681c138500ca6e98e7"
 dependencies = [
- "aa-proto",
+ "aa-proto 0.0.1-beta.3 (git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=ebc4d7dc9da81cdf4f265d681c138500ca6e98e7)",
  "aa-security",
  "bs58",
  "ed25519-dalek",
@@ -46,8 +57,8 @@ dependencies = [
 
 [[package]]
 name = "aa-security"
-version = "0.0.1-beta.2"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=fdff8e402e83f01bda3fbbf1f3f7f831b391b62b#fdff8e402e83f01bda3fbbf1f3f7f831b391b62b"
+version = "0.0.1-beta.3"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=ebc4d7dc9da81cdf4f265d681c138500ca6e98e7#ebc4d7dc9da81cdf4f265d681c138500ca6e98e7"
 dependencies = [
  "aho-corasick",
 ]

--- a/native/aa-ffi-node/Cargo.toml
+++ b/native/aa-ffi-node/Cargo.toml
@@ -27,7 +27,7 @@ crate-type = ["cdylib"]
 # `AssemblyClient::register()` (the one direct SDK→gateway gRPC call, per ADR
 # 0004) plus the `gateway_endpoint` field.
 aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "ebc4d7dc9da81cdf4f265d681c138500ca6e98e7", package = "aa-sdk-client" }
-aa-proto = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "fdff8e402e83f01bda3fbbf1f3f7f831b391b62b", package = "aa-proto" }
+aa-proto = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "ebc4d7dc9da81cdf4f265d681c138500ca6e98e7", package = "aa-proto" }
 napi = { version = "3", default-features = false, features = ["napi8", "tokio_rt", "serde-json"] }
 napi-derive = "3"
 prost = "0.14"

--- a/native/aa-ffi-node/Cargo.toml
+++ b/native/aa-ffi-node/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib"]
 # topology lineage). The base 9cde1d83 (AAASM-3396) added
 # `AssemblyClient::register()` (the one direct SDK→gateway gRPC call, per ADR
 # 0004) plus the `gateway_endpoint` field.
-aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "fdff8e402e83f01bda3fbbf1f3f7f831b391b62b", package = "aa-sdk-client" }
+aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "ebc4d7dc9da81cdf4f265d681c138500ca6e98e7", package = "aa-sdk-client" }
 aa-proto = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "fdff8e402e83f01bda3fbbf1f3f7f831b391b62b", package = "aa-proto" }
 napi = { version = "3", default-features = false, features = ["napi8", "tokio_rt", "serde-json"] }
 napi-derive = "3"


### PR DESCRIPTION
Auto-bump `aa-sdk-client` git-SHA pin in `native/aa-ffi-node/Cargo.toml`
to track agent-assembly release `v0.0.1-beta.3` (commit
`ebc4d7dc9da81cdf4f265d681c138500ca6e98e7`).

Why: without this PR, the SDK source pin drifts behind the published
agent-assembly binaries (AAASM-2880 observed an 8-day drift behind
alpha-9). Merging this PR on `node-sdk` realigns the native shim
with the matching upstream tag.

Upstream tag: https://github.com/ai-agent-assembly/agent-assembly/releases/tag/v0.0.1-beta.3
Source workflow: https://github.com/ai-agent-assembly/agent-assembly/actions/runs/27861438009