### PR TITLE
[AAASM-3500] ✨ (node-sdk): Wire OpControlSubscriber into withAssembly tool path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,16 @@
 export { initAssembly } from "./core/init-assembly.js";
 export { withAssembly } from "./wrappers/index.js";
-export type { WithAssemblyOptions } from "./wrappers/index.js";
+export type { OpControl, WithAssemblyOptions } from "./wrappers/index.js";
+// Live op-control consumer (AAASM-3491). Subscribes to the gateway's
+// OpControlStream and exposes per-op cooperative-pause / fast-fail-terminate;
+// pass the subscriber as `withAssembly(..., { opControl })` so an operator
+// terminate/pause reaches a running tool through the SDK tool path.
+export { OpControlSubscriber } from "./op-control.js";
+export type {
+  OpControlClient,
+  OpControlSubscriberOptions
+} from "./op-control.js";
+export { OpTerminatedError } from "./errors/op-terminated-error.js";
 export type {
   AssemblyConfig,
   AssemblyContext,

--- a/src/wrappers/index.ts
+++ b/src/wrappers/index.ts
@@ -1,2 +1,2 @@
 export { withAssembly } from "./with-assembly.js";
-export type { WithAssemblyOptions } from "./with-assembly.js";
+export type { OpControl, WithAssemblyOptions } from "./with-assembly.js";

--- a/src/wrappers/with-assembly.ts
+++ b/src/wrappers/with-assembly.ts
@@ -1,15 +1,100 @@
 import { randomUUID } from "node:crypto";
+import { OpTerminatedError } from "../errors/op-terminated-error.js";
 import { PolicyViolationError } from "../errors/policy-violation-error.js";
 import type { GatewayClient } from "../gateway/client.js";
 import type { ToolMap } from "../types/tool-map.js";
+
+/**
+ * Narrow seam onto the live op-control consumer (AAASM-3491).
+ *
+ * The wrapper only needs to *wait until an op is runnable* — a pause blocks
+ * here cooperatively, a terminate rejects with {@link OpTerminatedError}.
+ * Depending on this strip rather than the concrete `OpControlSubscriber` keeps
+ * the wrapper decoupled from the gRPC transport and lets tests drive it without
+ * a live stream; the real `OpControlSubscriber` satisfies it structurally. This
+ * mirrors the Python companion's `build_governance_interceptor(op_control=...)`
+ * seam.
+ */
+export interface OpControl {
+  waitForOp(opId: string, opts?: { timeoutMs?: number }): Promise<void>;
+}
 
 export interface WithAssemblyOptions {
   gatewayClient: GatewayClient;
   agentId?: string;
   approvalTimeoutMs?: number;
+  /**
+   * Live op-control consumer. When supplied, the gateway kill switch
+   * (AAASM-3491) is honored *in this tool path*: before the pre-exec gateway
+   * check, a terminated op fast-fails the call and a paused op blocks
+   * cooperatively until the gateway resumes it. Optional — without it the tool
+   * path behaves exactly as before (gateway check + approval only), and op
+   * control reaches the agent solely via the native runtime's own stream.
+   */
+  opControl?: OpControl;
 }
 
 const DEFAULT_APPROVAL_TIMEOUT_MS = 30_000;
+
+/**
+ * Resolve the op id (`"{traceId}:{spanId}"`) for a wrapped tool call.
+ *
+ * Prefers an explicit `opId` on the call's first argument; otherwise composes
+ * it from `traceId` / `spanId` when an adapter threads them through. Returns
+ * `undefined` when no trace identity is present — the call is not part of a
+ * tracked op, so there is nothing for the kill switch to address and op control
+ * is skipped. Mirrors the Python companion's `_extract_op_id`.
+ */
+function extractOpId(args: unknown[]): string | undefined {
+  const first = args[0];
+  if (typeof first !== "object" || first === null) {
+    return undefined;
+  }
+  const fields = first as Record<string, unknown>;
+  const opId = fields.opId;
+  if (typeof opId === "string" && opId.length > 0) {
+    return opId;
+  }
+  const traceId = fields.traceId;
+  if (typeof traceId === "string" && traceId.length > 0) {
+    const spanId = fields.spanId;
+    const span = typeof spanId === "string" ? spanId : "";
+    return `${traceId}:${span}`;
+  }
+  return undefined;
+}
+
+/**
+ * Consult the live op-control kill switch before the gateway is queried.
+ *
+ * A terminated op throws {@link PolicyViolationError} so the tool is blocked
+ * (and the gateway is never reached — the kill switch short-circuits). A paused
+ * op blocks here in `waitForOp` until the gateway resumes (or terminates) it.
+ * A no-op when no subscriber is wired or the call carries no `opId`.
+ *
+ * @throws {PolicyViolationError} when the op has been terminated by the gateway.
+ */
+async function enforceOpControl(
+  opControl: OpControl | undefined,
+  name: string,
+  args: unknown[]
+): Promise<void> {
+  if (!opControl) {
+    return;
+  }
+  const opId = extractOpId(args);
+  if (!opId) {
+    return;
+  }
+  try {
+    await opControl.waitForOp(opId);
+  } catch (error) {
+    if (error instanceof OpTerminatedError) {
+      throw new PolicyViolationError(`Tool '${name}' terminated: ${error.message}`);
+    }
+    throw error;
+  }
+}
 
 async function waitForApprovalWithTimeout(
   gateway: GatewayClient,
@@ -47,6 +132,48 @@ function hasInvoke(
   return typeof tool.invoke === "function";
 }
 
+/**
+ * Run the full pre-execution governance chain for one wrapped tool call.
+ *
+ * Order is load-bearing: the live op-control kill switch (AAASM-3491) runs
+ * first so an operator terminate short-circuits *before* the gateway is queried
+ * and a pause blocks here until resume; only then does the pre-exec gateway
+ * check + approval flow run.
+ *
+ * @throws {PolicyViolationError} when the op is terminated, the gateway denies,
+ *   or an approval is rejected / times out.
+ */
+async function enforceGovernance(
+  name: string,
+  args: unknown[],
+  gateway: GatewayClient,
+  opControl: OpControl | undefined,
+  approvalTimeoutMs: number
+): Promise<void> {
+  await enforceOpControl(opControl, name, args);
+
+  const runId = `run_${randomUUID()}`;
+  const decision = await gateway.check({
+    action: "tool_call",
+    toolName: name,
+    args,
+    runId
+  });
+
+  if (decision.denied) {
+    throw new PolicyViolationError(`Tool '${name}' blocked: ${decision.reason ?? "Denied"}`);
+  }
+
+  if (decision.pending) {
+    const finalDecision = await waitForApprovalWithTimeout(gateway, name, runId, approvalTimeoutMs);
+    if (finalDecision.denied) {
+      throw new PolicyViolationError(
+        `Approval rejected for '${name}': ${finalDecision.reason ?? "Rejected"}`
+      );
+    }
+  }
+}
+
 function wrapSingleTool(
   name: string,
   tool: Record<string, unknown>,
@@ -54,65 +181,18 @@ function wrapSingleTool(
   options: WithAssemblyOptions
 ): void {
   const approvalTimeoutMs = options.approvalTimeoutMs ?? DEFAULT_APPROVAL_TIMEOUT_MS;
+  const opControl = options.opControl;
 
   if (hasExecute(tool)) {
     const originalExecute = tool.execute;
     tool.execute = async (...args: unknown[]) => {
-      const runId = `run_${randomUUID()}`;
-      const decision = await gateway.check({
-        action: "tool_call",
-        toolName: name,
-        args,
-        runId
-      });
-
-      if (decision.denied) {
-        throw new PolicyViolationError(
-          `Tool '${name}' blocked: ${decision.reason ?? "Denied"}`
-        );
-      }
-
-      if (decision.pending) {
-        const finalDecision = await waitForApprovalWithTimeout(
-          gateway, name, runId, approvalTimeoutMs
-        );
-        if (finalDecision.denied) {
-          throw new PolicyViolationError(
-            `Approval rejected for '${name}': ${finalDecision.reason ?? "Rejected"}`
-          );
-        }
-      }
-
+      await enforceGovernance(name, args, gateway, opControl, approvalTimeoutMs);
       return originalExecute(...args);
     };
   } else if (hasInvoke(tool)) {
     const originalInvoke = tool.invoke;
     tool.invoke = async (...args: unknown[]) => {
-      const runId = `run_${randomUUID()}`;
-      const decision = await gateway.check({
-        action: "tool_call",
-        toolName: name,
-        args,
-        runId
-      });
-
-      if (decision.denied) {
-        throw new PolicyViolationError(
-          `Tool '${name}' blocked: ${decision.reason ?? "Denied"}`
-        );
-      }
-
-      if (decision.pending) {
-        const finalDecision = await waitForApprovalWithTimeout(
-          gateway, name, runId, approvalTimeoutMs
-        );
-        if (finalDecision.denied) {
-          throw new PolicyViolationError(
-            `Approval rejected for '${name}': ${finalDecision.reason ?? "Rejected"}`
-          );
-        }
-      }
-
+      await enforceGovernance(name, args, gateway, opControl, approvalTimeoutMs);
       return originalInvoke(...args);
     };
   }

--- a/tests/with-assembly-op-control.test.ts
+++ b/tests/with-assembly-op-control.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+import { OpTerminatedError } from "../src/errors/op-terminated-error.js";
+import { PolicyViolationError } from "../src/errors/policy-violation-error.js";
+import type { GatewayClient } from "../src/gateway/client.js";
+import type { OpControl } from "../src/wrappers/with-assembly.js";
+import { withAssembly } from "../src/wrappers/with-assembly.js";
+
+function createMockGateway(overrides: Partial<GatewayClient> = {}): GatewayClient {
+  return {
+    mode: "sdk-only",
+    start: vi.fn(async () => undefined),
+    close: vi.fn(async () => undefined),
+    check: vi.fn(async () => ({ denied: false, pending: false })),
+    waitForApproval: vi.fn(async () => ({ denied: false })),
+    record: vi.fn(async () => undefined),
+    recordResult: vi.fn(async () => undefined),
+    scanPrompts: vi.fn(async () => undefined),
+    ...overrides
+  };
+}
+
+/**
+ * Minimal {@link OpControl} stand-in driving `waitForOp` behavior without a live
+ * gRPC stream — mirrors the Python companion's `_FakeOpControl`. A terminated
+ * op rejects with {@link OpTerminatedError}; a paused op blocks until released.
+ */
+class FakeOpControl implements OpControl {
+  public readonly awaited: string[] = [];
+  private readonly terminated: Set<string>;
+  private readonly pausedOps: Set<string>;
+  private readonly releasers: Array<() => void> = [];
+
+  constructor(opts: { terminated?: string[]; paused?: string[] } = {}) {
+    this.terminated = new Set(opts.terminated ?? []);
+    this.pausedOps = new Set(opts.paused ?? []);
+  }
+
+  async waitForOp(opId: string): Promise<void> {
+    this.awaited.push(opId);
+    if (this.terminated.has(opId)) {
+      throw new OpTerminatedError(`op ${opId} was terminated by the gateway`, opId);
+    }
+    if (this.pausedOps.has(opId)) {
+      await new Promise<void>((resolve) => {
+        this.releasers.push(resolve);
+      });
+    }
+  }
+
+  /** Resume all blocked `waitForOp` callers (modelling a gateway RESUME). */
+  release(): void {
+    const pending = this.releasers.splice(0);
+    for (const resolve of pending) resolve();
+  }
+}
+
+describe("withAssembly op-control kill switch (AAASM-3491)", () => {
+  it("TERMINATE: denies the tool BEFORE the gateway is queried (short-circuit)", async () => {
+    const gateway = createMockGateway();
+    const opControl = new FakeOpControl({ terminated: ["trace-1:span-1"] });
+    const executeFn: (input: Record<string, unknown>) => Promise<string> = vi.fn(
+      async () => "should not run"
+    );
+    const tools = {
+      search: { description: "Search", execute: executeFn }
+    };
+
+    withAssembly(tools, { gatewayClient: gateway, opControl });
+
+    await expect(tools.search.execute({ traceId: "trace-1", spanId: "span-1" })).rejects.toThrow(
+      PolicyViolationError
+    );
+
+    expect(opControl.awaited).toEqual(["trace-1:span-1"]);
+    // Short-circuit: a terminated op must halt before the gateway check runs.
+    expect(gateway.check).not.toHaveBeenCalled();
+    expect(executeFn).not.toHaveBeenCalled();
+  });
+
+  it("PAUSE→resume: blocks in waitForOp, then proceeds to the gateway on resume", async () => {
+    const gateway = createMockGateway();
+    const opControl = new FakeOpControl({ paused: ["trace-2:span-2"] });
+    const executeFn: (input: Record<string, unknown>) => Promise<string> = vi.fn(
+      async () => "result"
+    );
+    const tools = {
+      search: { description: "Search", execute: executeFn }
+    };
+
+    withAssembly(tools, { gatewayClient: gateway, opControl });
+
+    let settled = false;
+    const call = tools.search
+      .execute({ traceId: "trace-2", spanId: "span-2" })
+      .then((value) => {
+        settled = true;
+        return value;
+      });
+
+    // Yield: while paused the gateway must NOT have been queried and the tool
+    // must NOT have run.
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(gateway.check).not.toHaveBeenCalled();
+    expect(executeFn).not.toHaveBeenCalled();
+
+    opControl.release();
+    const result = await call;
+
+    expect(result).toBe("result");
+    expect(gateway.check).toHaveBeenCalledOnce();
+    expect(executeFn).toHaveBeenCalledOnce();
+    expect(opControl.awaited).toEqual(["trace-2:span-2"]);
+  });
+
+  it("NO trace identity: skips op-control and proceeds normally", async () => {
+    const gateway = createMockGateway();
+    const opControl = new FakeOpControl({ terminated: ["trace-x:span-x"] });
+    const executeFn: (input: Record<string, unknown>) => Promise<string> = vi.fn(
+      async () => "result"
+    );
+    const tools = {
+      search: { description: "Search", execute: executeFn }
+    };
+
+    withAssembly(tools, { gatewayClient: gateway, opControl });
+
+    const result = await tools.search.execute({ query: "hello" });
+
+    expect(result).toBe("result");
+    expect(opControl.awaited).toEqual([]);
+    expect(gateway.check).toHaveBeenCalledOnce();
+    expect(executeFn).toHaveBeenCalledOnce();
+  });
+
+  it("op_id resolution: explicit opId wins; otherwise composes traceId:spanId", async () => {
+    const gateway = createMockGateway();
+    const opControl = new FakeOpControl();
+    const exec: () => (input: Record<string, unknown>) => Promise<string> = () =>
+      vi.fn(async () => "ok");
+    const tools = {
+      explicit: { description: "t", execute: exec() },
+      composed: { description: "t", execute: exec() },
+      traceOnly: { description: "t", execute: exec() }
+    };
+
+    withAssembly(tools, { gatewayClient: gateway, opControl });
+
+    await tools.explicit.execute({ opId: "explicit-id", traceId: "t", spanId: "s" });
+    await tools.composed.execute({ traceId: "trace-9", spanId: "span-9" });
+    await tools.traceOnly.execute({ traceId: "trace-only" });
+
+    expect(opControl.awaited).toEqual(["explicit-id", "trace-9:span-9", "trace-only:"]);
+  });
+
+  it("no opControl wired: tool path is unchanged (gateway check only)", async () => {
+    const gateway = createMockGateway();
+    const executeFn: (input: Record<string, unknown>) => Promise<string> = vi.fn(
+      async () => "result"
+    );
+    const tools = {
+      search: { description: "Search", execute: executeFn }
+    };
+
+    withAssembly(tools, { gatewayClient: gateway });
+
+    const result = await tools.search.execute({ traceId: "trace-1", spanId: "span-1" });
+
+    expect(result).toBe("result");
+    expect(gateway.check).toHaveBeenCalledOnce();
+    expect(executeFn).toHaveBeenCalledOnce();
+  });
+
+  it("invoke path: TERMINATE denies the LangChain-style invoke before the gateway", async () => {
+    const gateway = createMockGateway();
+    const opControl = new FakeOpControl({ terminated: ["trace-3:span-3"] });
+    const invokeFn: (input: Record<string, unknown>) => Promise<string> = vi.fn(
+      async () => "should not run"
+    );
+    const tools = {
+      lcTool: { name: "lcTool", invoke: invokeFn }
+    };
+
+    withAssembly(tools, { gatewayClient: gateway, opControl });
+
+    await expect(tools.lcTool.invoke({ traceId: "trace-3", spanId: "span-3" })).rejects.toThrow(
+      PolicyViolationError
+    );
+
+    expect(gateway.check).not.toHaveBeenCalled();
+    expect(invokeFn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Follow-up to Bug **AAASM-3491** (live kill switch never reached a running agent). The authoritative runtime fix merged in agent-assembly PR #1176 and the python-sdk companion in **python-sdk PR #156** (the reference pattern). The node-sdk already shipped a complete `OpControlSubscriber` in `src/op-control.ts`, but it was **dead code**: not exported from `index.ts` and never consulted by the `withAssembly` tool wrapper, which only did pre-exec `gateway.check()` + `waitForApproval`. This PR exports the subscriber and wires it into the `withAssembly` tool path so an operator terminate/pause reaches a running tool through the SDK layer.

* ### Task tickets:

    * Task ID: AAASM-3500.
    * Relative task IDs:
        * [x] AAASM-3491 (parent bug).
    * Relative PRs:
        * python-sdk #156 (companion / reference pattern).
        * agent-assembly #1176 (authoritative runtime fix).

* ### Key point change (optional):

    * Order is load-bearing: the op-control kill switch runs **before** the gateway check. A terminated op fast-fails the call (short-circuit — the gateway is never queried); a paused op blocks cooperatively in `waitForOp` until the gateway resumes it.
    * `op_id` resolves from an explicit `opId` on the call's first argument, otherwise composes `{traceId}:{spanId}`; absent a trace identity, op control is skipped.
    * The subscriber is threaded through as an **optional** `opControl` dependency on `WithAssemblyOptions` via a narrow `OpControl` seam, mirroring the Python companion's `build_governance_interceptor(op_control=...)`. Without it, the tool path behaves exactly as before.

## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
* Scopes:
    * [x] 🧩 SDK public API
    * [x] 🤖 Framework hooks
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
* Additional description:
    Purely additive. `opControl` is optional; existing `withAssembly` callers are unaffected.

## _Description_

* `src/wrappers/with-assembly.ts`: add the `OpControl` seam + optional `opControl` option; consult op-control before the gateway check in both the `execute` and `invoke` tool paths (terminate → `PolicyViolationError`, pause → cooperative block); add `extractOpId` (`opId` else `{traceId}:{spanId}`).
* `src/wrappers/index.ts`: re-export the `OpControl` type.
* `src/index.ts`: export `OpControlSubscriber`, `OpControlClient`, `OpControlSubscriberOptions`, and `OpTerminatedError` from the package entrypoint so the kill switch is wireable.
* `tests/with-assembly-op-control.test.ts`: regression tests — terminate denies BEFORE the gateway is queried (short-circuit), pause blocks then proceeds on resume, no-trace-identity skips op control, op_id resolution, no-opControl path unchanged, invoke path.

### How to verify

`pnpm test` (320 passed / 2 skipped), `pnpm typecheck`, `pnpm lint`, `pnpm build` — all green locally.

Closes AAASM-3500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
