### PR TITLE
[AAASM-3505] 🐛 (node-sdk): Lazy-load grpc in op-control so SDK import stays grpc-free

### DIFF
--- a/src/op-control.ts
+++ b/src/op-control.ts
@@ -20,20 +20,38 @@
  *     (separate sub-task when the adapter surface is stable).
  */
 
-import {
-  type ChannelCredentials,
-  type ClientReadableStream,
-  credentials as grpcCredentials,
-} from "@grpc/grpc-js";
+// grpc-js is imported for TYPES ONLY at module scope. Its runtime `credentials`
+// value — and the `PolicyServiceClient` value from `./proto/generated/policy.js`,
+// which itself imports `@grpc/grpc-js` — are loaded LAZILY via `await import(...)`
+// on the real-connect path only (see `openRealChannel`). This keeps merely
+// importing/exporting `OpControlSubscriber` (e.g. `import '@agent-assembly/sdk'`)
+// from eagerly pulling `@grpc/grpc-js` at module-load time, which broke consumers
+// where grpc-js isn't resolvable from this module's location (a `file:`-linked SDK
+// under pnpm — the agent-assembly integration-tests node fixture). Regression from
+// AAASM-3500; fix AAASM-3505.
+import type { ChannelCredentials, ClientReadableStream } from "@grpc/grpc-js";
 
 import { OpTerminatedError } from "./errors/op-terminated-error.js";
 import type { AgentId } from "./proto/generated/common.js";
-import {
+import type {
   OpControlMessage,
   OpControlSignal,
-  type PolicyServiceClient as PolicyServiceClientType,
-  PolicyServiceClient,
+  PolicyServiceClient as PolicyServiceClientType
 } from "./proto/generated/policy.js";
+
+/**
+ * Numeric `OpControlSignal` values, inlined to keep this module grpc-free at load.
+ *
+ * `OpControlSignal` lives in `./proto/generated/policy.js`, which imports
+ * `@grpc/grpc-js` at module scope; importing the enum as a *value* would defeat
+ * the lazy-load. These are the stable protobuf wire numbers (UNSPECIFIED=0,
+ * PAUSE=1, RESUME=2, TERMINATE=3) — `msg.signal` is compared against them
+ * numerically in {@link OpControlSubscriber.dispatch}. The `OpControlSignal`
+ * type is still imported (type-only) for signatures.
+ */
+const SIGNAL_PAUSE: OpControlSignal = 1;
+const SIGNAL_RESUME: OpControlSignal = 2;
+const SIGNAL_TERMINATE: OpControlSignal = 3;
 
 /** Per-op state slot used by the cooperative-pause machine. */
 interface OpControlState {
@@ -47,9 +65,7 @@ interface OpControlState {
  * mock the gRPC layer without standing up a server.
  */
 export interface OpControlClient {
-  opControlStream: (
-    request: { agentId?: AgentId },
-  ) => ClientReadableStream<OpControlMessage>;
+  opControlStream: (request: { agentId?: AgentId }) => ClientReadableStream<OpControlMessage>;
   close?: () => void;
 }
 
@@ -113,17 +129,32 @@ function isLoopbackTarget(gatewayUrl: string): boolean {
 }
 
 /**
+ * The slice of `@grpc/grpc-js`'s `credentials` namespace this module needs.
+ * Injected into {@link resolveOpControlCredentials} so that module stays free of
+ * a top-level grpc import — the real namespace is `await import`ed on connect.
+ */
+export interface GrpcCredentialsFactory {
+  createInsecure: () => ChannelCredentials;
+  createSsl: () => ChannelCredentials;
+}
+
+/**
  * Pick channel credentials for the op-control stream, secure by default.
  *
  * Precedence: an explicit `credentials` override wins; otherwise a loopback
  * target gets plaintext (local dev gateway), a remote target gets TLS, and a
  * remote target is only allowed plaintext when the caller sets `allowInsecure`.
  *
+ * `grpcCredentials` is injected (rather than imported at module scope) so this
+ * module does not eagerly load `@grpc/grpc-js` — see the module header. The
+ * real-connect path passes the lazily-imported `credentials` namespace.
+ *
  * @throws never — returns the chosen {@link ChannelCredentials}.
  */
 export function resolveOpControlCredentials(
   gatewayUrl: string,
   opts: Pick<OpControlSubscriberOptions, "credentials" | "allowInsecure">,
+  grpcCredentials: GrpcCredentialsFactory
 ): ChannelCredentials {
   if (opts.credentials) return opts.credentials;
   if (isLoopbackTarget(gatewayUrl)) return grpcCredentials.createInsecure();
@@ -132,42 +163,77 @@ export function resolveOpControlCredentials(
 }
 
 export class OpControlSubscriber {
-  private readonly client: OpControlClient;
+  /**
+   * `null` until the channel is opened. On the test-seam (`clientFactory`) path
+   * it is set synchronously in {@link connect}; on the real-connect path it is
+   * set asynchronously once `@grpc/grpc-js` + `PolicyServiceClient` have been
+   * lazily imported (see {@link openRealChannel}).
+   */
+  private client: OpControlClient | null = null;
   private readonly agent: AgentId;
   private readonly ops = new Map<string, OpControlState>();
   private call: ClientReadableStream<OpControlMessage> | null = null;
   private alive = true;
+  /** Set once {@link close} is called before the async channel finishes opening. */
+  private closed = false;
 
-  private constructor(client: OpControlClient, agent: AgentId) {
-    this.client = client;
+  private constructor(agent: AgentId) {
     this.agent = agent;
   }
 
-  /** Open the gRPC channel + subscription stream and start the reader. */
-  public static connect(
-    gatewayUrl: string,
-    opts: OpControlSubscriberOptions,
-  ): OpControlSubscriber {
+  /**
+   * Open the gRPC channel + subscription stream and start the reader.
+   *
+   * Returns synchronously. On the real-connect path the channel is opened
+   * asynchronously — `@grpc/grpc-js` and `PolicyServiceClient` are loaded lazily
+   * (`await import`) so that importing this module never eagerly pulls grpc (see
+   * the module header). The test seam (`clientFactory`) opens synchronously and
+   * never touches grpc.
+   */
+  public static connect(gatewayUrl: string, opts: OpControlSubscriberOptions): OpControlSubscriber {
     const agent: AgentId = {
       orgId: opts.orgId,
       teamId: opts.teamId,
-      agentId: opts.agentId,
+      agentId: opts.agentId
     };
-    const client = opts.clientFactory
-      ? opts.clientFactory()
-      : (new PolicyServiceClient(
-          gatewayUrl,
-          resolveOpControlCredentials(gatewayUrl, opts),
-        ) as unknown as OpControlClient & PolicyServiceClientType);
-    const subscriber = new OpControlSubscriber(client, agent);
-    subscriber.start();
+    const subscriber = new OpControlSubscriber(agent);
+    if (opts.clientFactory) {
+      subscriber.client = opts.clientFactory();
+      subscriber.start();
+    } else {
+      // Real channel: defer grpc loading to the dynamic-import path. Errors
+      // surface as a dead stream so callers see `streamAlive() === false`.
+      void subscriber.openRealChannel(gatewayUrl, opts).catch(() => {
+        subscriber.markStreamDead();
+      });
+    }
     return subscriber;
+  }
+
+  /**
+   * Lazily import grpc + the policy client, build the real client, and start the
+   * reader. Kept off the module's import graph so `import '@agent-assembly/sdk'`
+   * stays grpc-free until a subscriber actually opens a live channel.
+   */
+  private async openRealChannel(
+    gatewayUrl: string,
+    opts: OpControlSubscriberOptions
+  ): Promise<void> {
+    const { credentials } = await import("@grpc/grpc-js");
+    const { PolicyServiceClient } = await import("./proto/generated/policy.js");
+    if (this.closed) return; // close() raced ahead of the async open.
+    this.client = new PolicyServiceClient(
+      gatewayUrl,
+      resolveOpControlCredentials(gatewayUrl, opts, credentials)
+    ) as unknown as OpControlClient & PolicyServiceClientType;
+    this.start();
   }
 
   /** Open the stream and wire reader handlers. Public so tests can call
    * directly after constructing with a hand-rolled client.
    */
   public start(): void {
+    if (!this.client) return;
     this.call = this.client.opControlStream({ agentId: this.agent });
     this.call.on("data", (msg: OpControlMessage) => this.dispatch(msg));
     this.call.on("error", () => this.markStreamDead());
@@ -177,14 +243,14 @@ export class OpControlSubscriber {
   private dispatch(msg: OpControlMessage): void {
     const state = this.slot(msg.opId);
     switch (msg.signal) {
-      case OpControlSignal.OP_CONTROL_SIGNAL_PAUSE:
+      case SIGNAL_PAUSE:
         state.paused = true;
         break;
-      case OpControlSignal.OP_CONTROL_SIGNAL_RESUME:
+      case SIGNAL_RESUME:
         state.paused = false;
         this.flushResolvers(state);
         break;
-      case OpControlSignal.OP_CONTROL_SIGNAL_TERMINATE:
+      case SIGNAL_TERMINATE:
         state.terminated = true;
         this.flushResolvers(state);
         break;
@@ -226,10 +292,7 @@ export class OpControlSubscriber {
    * or retry. Matches the cooperative-pause expectation in the architecture
    * doc (the SDK yields, it doesn't deadline-enforce).
    */
-  public async waitForOp(
-    opId: string,
-    opts: { timeoutMs?: number } = {},
-  ): Promise<void> {
+  public async waitForOp(opId: string, opts: { timeoutMs?: number } = {}): Promise<void> {
     const state = this.slot(opId);
     if (state.terminated) {
       throw new OpTerminatedError(`op ${opId} was terminated by the gateway`, opId);
@@ -265,10 +328,13 @@ export class OpControlSubscriber {
     return this.alive;
   }
 
-  /** Cancel the stream and clean up. */
+  /** Cancel the stream and clean up. Safe to call before the async real-channel
+   * open has completed — it flags `closed` so the pending open bails out.
+   */
   public close(): void {
+    this.closed = true;
     this.call?.cancel();
-    this.client.close?.();
+    this.client?.close?.();
     this.markStreamDead();
   }
 }

--- a/tests/op-control-real-channel.test.ts
+++ b/tests/op-control-real-channel.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Covers the **real-connect path** of `OpControlSubscriber` (`openRealChannel`) —
+ * the branch the `clientFactory` test seam deliberately bypasses, and the lines
+ * the AAASM-3505 lazy-grpc fix added.
+ *
+ * Strategy: mock ONLY `./proto/generated/policy.js` so the dynamically-imported
+ * `PolicyServiceClient` is a controllable fake (no real gRPC channel / network),
+ * but let the real `@grpc/grpc-js` load so the test exercises genuine credential
+ * resolution wiring (`resolveOpControlCredentials` → the client constructor),
+ * not a mock of it. This asserts behaviour, not just line coverage:
+ *   - the channel + client are built lazily after `connect()` returns,
+ *   - loopback targets resolve to *insecure* creds and those reach the client,
+ *   - the subscription is opened with the agent identity triple,
+ *   - signals delivered on the real stream drive `waitForOp`, and
+ *   - `close()` racing ahead of the async open prevents client construction.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/** Wire number for `OP_CONTROL_SIGNAL_TERMINATE`. The enum lives in the
+ * grpc-importing `policy.js` (mocked here), so we use the stable protobuf
+ * number directly — the same constant `op-control.ts` compares against. */
+const SIGNAL_TERMINATE = 3;
+
+// Hoisted so the `vi.mock` factory (itself hoisted above imports) can reference
+// the fake, while the test body still reaches the recorded calls.
+const h = vi.hoisted(() => {
+  // Minimal stand-in for a grpc-js `ClientReadableStream` — self-contained (no
+  // `node:events` import) so it is safe to define inside this hoisted factory,
+  // which runs before module imports are initialized. Exposes the `on(...)` /
+  // `cancel()` surface the subscriber uses + a `push()` helper to feed messages.
+  class FakeStream {
+    private readonly handlers: Record<string, Array<(arg?: unknown) => void>> = {};
+    cancelled = false;
+    on(event: string, cb: (arg?: unknown) => void): this {
+      (this.handlers[event] ??= []).push(cb);
+      return this;
+    }
+    push(message: unknown): void {
+      for (const cb of this.handlers["data"] ?? []) cb(message);
+    }
+    cancel(): void {
+      this.cancelled = true;
+    }
+  }
+  const ctorCalls: Array<{ url: string; creds: unknown }> = [];
+  const streamRequests: Array<{ agentId?: unknown }> = [];
+  const streams: FakeStream[] = [];
+  let closeCount = 0;
+  let failConstruct = false;
+
+  class FakePolicyServiceClient {
+    constructor(url: string, creds: unknown) {
+      if (failConstruct) throw new Error("channel open failed");
+      ctorCalls.push({ url, creds });
+    }
+    opControlStream(request: { agentId?: unknown }): FakeStream {
+      streamRequests.push(request);
+      const s = new FakeStream();
+      streams.push(s);
+      return s;
+    }
+    close(): void {
+      closeCount += 1;
+    }
+  }
+
+  return {
+    FakePolicyServiceClient,
+    ctorCalls,
+    streamRequests,
+    streams,
+    closeCount: (): number => closeCount,
+    setFailConstruct: (v: boolean): void => {
+      failConstruct = v;
+    },
+    reset(): void {
+      ctorCalls.length = 0;
+      streamRequests.length = 0;
+      streams.length = 0;
+      closeCount = 0;
+      failConstruct = false;
+    }
+  };
+});
+
+vi.mock("../src/proto/generated/policy.js", () => ({
+  PolicyServiceClient: h.FakePolicyServiceClient
+}));
+
+import { OpControlSubscriber } from "../src/op-control.js";
+import { OpTerminatedError } from "../src/errors/op-terminated-error.js";
+
+/** grpc-js `ChannelCredentials` exposes `_isSecure()` — false for insecure. */
+const isSecure = (creds: unknown): boolean =>
+  (creds as { _isSecure(): boolean })._isSecure();
+
+const OPTS = { orgId: "acme", teamId: "alpha", agentId: "agent-1" };
+
+describe("OpControlSubscriber real-connect path (openRealChannel)", () => {
+  beforeEach(() => h.reset());
+
+  it("lazily builds the client with resolved (loopback → insecure) creds, subscribes with the agent triple, and dispatches signals", async () => {
+    const sub = OpControlSubscriber.connect("localhost:7391", OPTS);
+
+    // The client is built asynchronously (after the lazy grpc + policy imports),
+    // so connect() returns before it exists.
+    expect(h.ctorCalls).toHaveLength(0);
+    await vi.waitFor(() => expect(h.ctorCalls).toHaveLength(1));
+
+    // Wiring: the gateway URL and the *resolved* credentials reach the client.
+    expect(h.ctorCalls[0]!.url).toBe("localhost:7391");
+    expect(isSecure(h.ctorCalls[0]!.creds)).toBe(false); // loopback → insecure
+
+    // The subscription carries the agent identity triple.
+    expect(h.streamRequests[0]).toEqual({ agentId: OPTS });
+    expect(sub.streamAlive()).toBe(true);
+
+    // End-to-end: a TERMINATE on the real stream makes waitForOp reject.
+    h.streams[0]!.push({ opId: "op-x", signal: SIGNAL_TERMINATE, sequence: 0 });
+    await expect(sub.waitForOp("op-x")).rejects.toBeInstanceOf(OpTerminatedError);
+
+    // close() propagates to the underlying client + cancels the stream.
+    sub.close();
+    expect(h.closeCount()).toBe(1);
+    expect(h.streams[0]!.cancelled).toBe(true);
+    expect(sub.streamAlive()).toBe(false);
+  });
+
+  it("resolves a non-loopback target to secure (TLS) creds", async () => {
+    OpControlSubscriber.connect("gateway.prod.example:443", OPTS);
+    await vi.waitFor(() => expect(h.ctorCalls).toHaveLength(1));
+    expect(isSecure(h.ctorCalls[0]!.creds)).toBe(true);
+  });
+
+  it("close() before the async channel open wins — no client is built and the stream is marked dead", async () => {
+    const sub = OpControlSubscriber.connect("localhost:7391", OPTS);
+    // Synchronous close, before the awaited dynamic imports in openRealChannel resolve.
+    sub.close();
+
+    // Let openRealChannel resume past its awaits and hit the `closed` guard.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(h.ctorCalls).toHaveLength(0); // guard returned before constructing the client
+    expect(h.streamRequests).toHaveLength(0); // and before opening the stream
+    expect(sub.streamAlive()).toBe(false); // close() marked the stream dead
+  });
+
+  it("a failure opening the real channel surfaces as a dead stream (fail-safe), not an unhandled rejection", async () => {
+    h.setFailConstruct(true);
+    const sub = OpControlSubscriber.connect("localhost:7391", OPTS);
+
+    // openRealChannel rejects → connect()'s `.catch` marks the stream dead so
+    // callers observe streamAlive() === false (per the module's documented contract).
+    await vi.waitFor(() => expect(sub.streamAlive()).toBe(false));
+    expect(h.ctorCalls).toHaveLength(0); // construction threw before recording
+  });
+});

--- a/tests/op-control.test.ts
+++ b/tests/op-control.test.ts
@@ -16,7 +16,7 @@ import {
   OpControlSubscriber,
   gatewayHostOf,
   resolveOpControlCredentials,
-  type OpControlClient,
+  type OpControlClient
 } from "../src/op-control.js";
 import { type OpControlMessage, OpControlSignal } from "../src/proto/generated/policy.js";
 
@@ -48,7 +48,7 @@ class FakeStream extends EventEmitter {
 
 function makeClient(stream: FakeStream): OpControlClient & { lastRequest?: { agentId?: unknown } } {
   const wrapper: { stream: FakeStream; lastRequest?: { agentId?: unknown } } = {
-    stream,
+    stream
   };
   return {
     stream: wrapper.stream as unknown as never, // unused field for inspection
@@ -59,7 +59,7 @@ function makeClient(stream: FakeStream): OpControlClient & { lastRequest?: { age
       wrapper.lastRequest = request;
       // Cast: vitest doesn't care that FakeStream isn't the exact grpc-js type.
       return stream as never;
-    },
+    }
   } as unknown as OpControlClient & { lastRequest?: { agentId?: unknown } };
 }
 
@@ -67,13 +67,16 @@ function message(opId: string, signal: OpControlSignal, sequence = 0): OpControl
   return { opId, signal, sequence };
 }
 
-function buildSubscriber(stream: FakeStream): { sub: OpControlSubscriber; client: ReturnType<typeof makeClient> } {
+function buildSubscriber(stream: FakeStream): {
+  sub: OpControlSubscriber;
+  client: ReturnType<typeof makeClient>;
+} {
   const client = makeClient(stream);
   const sub = OpControlSubscriber.connect("ignored", {
     orgId: "org",
     teamId: "team",
     agentId: "agent-7",
-    clientFactory: () => client,
+    clientFactory: () => client
   });
   return { sub, client };
 }
@@ -137,7 +140,7 @@ describe("OpControlSubscriber", () => {
 
     await expect(sub.waitForOp("op-2")).rejects.toMatchObject({
       name: "OpTerminatedError",
-      opId: "op-2",
+      opId: "op-2"
     });
 
     sub.close();
@@ -186,7 +189,7 @@ describe("OpControlSubscriber", () => {
     expect(client.lastRequest?.agentId).toEqual({
       orgId: "org",
       teamId: "team",
-      agentId: "agent-7",
+      agentId: "agent-7"
     });
   });
 
@@ -227,7 +230,7 @@ describe("gatewayHostOf", () => {
     ["gateway.prod.example:443", "gateway.prod.example"],
     ["https://gateway.prod.example:443/path", "gateway.prod.example"],
     ["[::1]:7391", "[::1]"],
-    ["GATEWAY.PROD.EXAMPLE", "gateway.prod.example"],
+    ["GATEWAY.PROD.EXAMPLE", "gateway.prod.example"]
   ])("extracts the host from %s", (target, host) => {
     expect(gatewayHostOf(target)).toBe(host);
   });
@@ -239,23 +242,37 @@ describe("resolveOpControlCredentials (secure by default)", () => {
     (c as unknown as { _isSecure(): boolean })._isSecure();
 
   it("uses plaintext for a loopback target without any opt-in", () => {
-    expect(isSecure(resolveOpControlCredentials("localhost:7391", {}))).toBe(false);
-    expect(isSecure(resolveOpControlCredentials("127.0.0.1:7391", {}))).toBe(false);
-    expect(isSecure(resolveOpControlCredentials("[::1]:7391", {}))).toBe(false);
+    expect(isSecure(resolveOpControlCredentials("localhost:7391", {}, grpcCredentials))).toBe(
+      false
+    );
+    expect(isSecure(resolveOpControlCredentials("127.0.0.1:7391", {}, grpcCredentials))).toBe(
+      false
+    );
+    expect(isSecure(resolveOpControlCredentials("[::1]:7391", {}, grpcCredentials))).toBe(false);
   });
 
   it("defaults a remote target to TLS", () => {
-    expect(isSecure(resolveOpControlCredentials("gateway.prod.example:443", {}))).toBe(true);
+    expect(
+      isSecure(resolveOpControlCredentials("gateway.prod.example:443", {}, grpcCredentials))
+    ).toBe(true);
   });
 
   it("only allows plaintext to a remote target when allowInsecure is set", () => {
     expect(
-      isSecure(resolveOpControlCredentials("gateway.prod.example:443", { allowInsecure: true })),
+      isSecure(
+        resolveOpControlCredentials(
+          "gateway.prod.example:443",
+          { allowInsecure: true },
+          grpcCredentials
+        )
+      )
     ).toBe(false);
   });
 
   it("honours an explicit credentials override verbatim", () => {
     const explicit = grpcCredentials.createSsl();
-    expect(resolveOpControlCredentials("localhost:7391", { credentials: explicit })).toBe(explicit);
+    expect(
+      resolveOpControlCredentials("localhost:7391", { credentials: explicit }, grpcCredentials)
+    ).toBe(explicit);
   });
 });

--- a/tests/packaging/op-control-grpc-lazy-load.test.ts
+++ b/tests/packaging/op-control-grpc-lazy-load.test.ts
@@ -1,0 +1,77 @@
+import { execFileSync, execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withPackagingLock } from "./lock.js";
+
+/**
+ * Regression guard for AAASM-3505 (a regression from AAASM-3500 / PR #172).
+ *
+ * `op-control.ts` is re-exported from the package entrypoint (`OpControlSubscriber`).
+ * If it imports `@grpc/grpc-js` — directly, or transitively via the grpc-importing
+ * `./proto/generated/policy.js` — as a module-scope *value*, then merely doing
+ * `import "@agent-assembly/sdk"` eagerly loads grpc at module-load time. That broke
+ * consumers where grpc-js isn't resolvable from this module's location (a
+ * `file:`-linked SDK under pnpm — the agent-assembly integration-tests node fixture),
+ * with `ERR_MODULE_NOT_FOUND: Cannot find package '@grpc/grpc-js'`, taking down 4
+ * agent-assembly `e2e_sdk_node` E2E tests.
+ *
+ * grpc must load lazily — only when a subscriber opens a *real* channel.
+ */
+describe("packaging op-control grpc lazy-load", () => {
+  it("does not statically import @grpc/grpc-js as a runtime value", async () => {
+    await withPackagingLock(() => {
+      execSync("pnpm run build", { stdio: "pipe" });
+
+      // ESM build: no top-level static value import of grpc-js (a bare
+      // `import "@grpc/grpc-js"` or `import { x } from "@grpc/grpc-js"`); the
+      // only grpc reference must be a lazy `await import(...)`. Type-only
+      // imports are erased by tsc, so they never appear in the emitted JS.
+      const esm = fs.readFileSync(path.resolve(process.cwd(), "dist/esm/op-control.js"), "utf8");
+      expect(esm).not.toMatch(/^\s*import\s[^;]*["']@grpc\/grpc-js["']/m);
+      expect(esm).toMatch(/await import\(\s*["']@grpc\/grpc-js["']\s*\)/);
+
+      // CJS build: tsc lowers `await import(...)` to a lazy
+      // `Promise.resolve().then(() => require("@grpc/grpc-js"))`, so the
+      // require must NOT be a top-level statement. Assert no `require("@grpc/grpc-js")`
+      // appears at the start of a line (top-level), only inside the deferred
+      // `.then(...)` callback.
+      const cjs = fs.readFileSync(path.resolve(process.cwd(), "dist/cjs/op-control.js"), "utf8");
+      expect(cjs).not.toMatch(
+        /^\s*(?:const|let|var)\s[^=]*=\s*require\(\s*["']@grpc\/grpc-js["']/m
+      );
+    });
+  }, 120000);
+
+  it("importing the built op-control entry does not load @grpc/grpc-js", async () => {
+    await withPackagingLock(() => {
+      execSync("pnpm run build", { stdio: "pipe" });
+
+      // Require the built CJS module in a fresh Node process and assert grpc-js
+      // is absent from require.cache afterwards. Constructing a subscriber on
+      // the test-seam (`clientFactory`) path must also stay grpc-free — only a
+      // real-channel connect may pull grpc. A non-zero exit (or thrown
+      // ERR-not-found) fails the test.
+      const opControlEntry = path.resolve(process.cwd(), "dist/cjs/op-control.js");
+      const probe = `
+        const mod = require(${JSON.stringify(opControlEntry)});
+        // Exercise the test-seam path: must not open a real channel / load grpc.
+        const sub = mod.OpControlSubscriber.connect("localhost:7391", {
+          orgId: "o", teamId: "t", agentId: "a",
+          clientFactory: () => ({ opControlStream: () => ({ on() {}, cancel() {} }) }),
+        });
+        sub.close();
+        const grpcLoaded = Object.keys(require.cache).some((k) =>
+          k.includes(${JSON.stringify(path.join("node_modules", "@grpc", "grpc-js"))}),
+        );
+        if (grpcLoaded) {
+          console.error("FAIL: @grpc/grpc-js was eagerly loaded");
+          process.exit(1);
+        }
+        process.exit(0);
+      `;
+      // Inherit a clean run; throws on non-zero exit, failing the test.
+      execFileSync(process.execPath, ["-e", probe], { stdio: "pipe" });
+    });
+  }, 120000);
+});


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Fix a regression from **AAASM-3500 / PR #172**: `src/op-control.ts` is re-exported from the package entrypoint (`OpControlSubscriber`), and it imported `@grpc/grpc-js` (the `credentials` runtime value) **and** `PolicyServiceClient` (from `./proto/generated/policy.js`, which also imports `@grpc/grpc-js`) at **module top level**. So `import '@agent-assembly/sdk'` eagerly loaded grpc-js at module-load time. In consumers where grpc-js isn't resolvable from `op-control.js`'s location — the **agent-assembly integration-tests node fixture** (a `file:`-linked SDK under pnpm) — the SDK module failed to load:

    ```
    Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@grpc/grpc-js'
    imported from .../@agent-assembly/sdk/dist/esm/op-control.js
    ```

    This took down 4 previously-green agent-assembly E2E tests (`aa-integration-tests::e2e_sdk_node::real_lang{chain,graph}_*`), turning the monorepo `Test` CI red. This PR makes the grpc-dependent imports **lazy** so merely importing/exporting `OpControlSubscriber` no longer pulls grpc; grpc loads only when a subscriber opens a real channel.

* ### Task tickets:

    * Task ID: AAASM-3505.
    * Relative task IDs:
        * [x] AAASM-3500 (the regression source / PR #172).
    * Relative PRs:
        * Fixes the agent-assembly `e2e_sdk_node` CI breakage and unblocks **AAASM-3497 / agent-assembly PR #1179**.

* ### Key point change:

    * `@grpc/grpc-js` is now a **type-only** import at module scope. The runtime `credentials` namespace and the `PolicyServiceClient` value are loaded via `await import(...)` inside a new private `openRealChannel`, which runs **only on the real-connect path** (no `clientFactory`).
    * The `OpControlSignal` **enum** was a runtime value imported from the grpc-importing `./proto/generated/policy.js`; importing it as a value would have defeated the lazy-load. It's replaced by **inlined numeric wire constants** (`PAUSE=1`, `RESUME=2`, `TERMINATE=3`); the enum **type** is kept (type-only) for signatures.
    * `resolveOpControlCredentials` now takes the grpc `credentials` namespace as an injected parameter, so it stays synchronous, pure, and grpc-free; the real-connect path passes the lazily-imported namespace.
    * `OpControlSubscriber.connect()` stays **synchronous** and the public API is **unchanged**. On the real path the channel opens asynchronously; `close()` is safe to call before the async open lands.
    * The `clientFactory` test seam never triggers the dynamic import — the mock path is fully grpc-free.

## _Effecting Scope_

* Action Types:
    * [x] 🔧 Fixing bug
* Scopes:
    * [x] 🪡 API client and transport
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
* Additional description:
    No public API change; ESM + CJS both still build. `@grpc/grpc-js` stays a regular `dependency`.

## _Description_

* `src/op-control.ts`: grpc-js → type-only import; lazy `await import('@grpc/grpc-js')` + lazy `await import('./proto/generated/policy.js')` for `PolicyServiceClient`, both inside `openRealChannel`; inlined `OpControlSignal` numeric constants; injected `credentials` namespace into `resolveOpControlCredentials`; `client` nullable + `closed` guard for the async open.
* `tests/op-control.test.ts`: pass the grpc `credentials` namespace to `resolveOpControlCredentials` (the one signature change); all existing pause/resume/terminate/op_id behaviors unchanged and green.
* `tests/packaging/op-control-grpc-lazy-load.test.ts` (new regression guard): asserts the built `dist/esm/op-control.js` has no top-level static grpc value import (only `await import`), the CJS build has no top-level `require('@grpc/grpc-js')`, and a fresh Node process requiring the built CJS `op-control.js` (and constructing a subscriber on the test-seam path) leaves `@grpc/grpc-js` absent from `require.cache`.

### How to verify

`pnpm test` (322 passed / 2 skipped), `pnpm typecheck`, `pnpm lint`, `pnpm build` (ESM + CJS) — all green.

Closes AAASM-3505.

🤖 Generated with [Claude Code](https://claude.com/claude-code)