### PR TITLE
[AAASM-3552] 📈 (docs): Wire GA4 analytics into the Docusaurus site

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -131,6 +131,13 @@ const config: Config = {
         theme: {
           customCss: "./src/css/custom.css",
         },
+        // Google Analytics 4 (AAASM-3552). Built-in gtag support shipped by
+        // preset-classic — no extra dependency. `anonymizeIP` truncates the
+        // visitor IP before it reaches Google. The Measurement ID is public.
+        gtag: {
+          trackingID: "G-6FHQKGLDE4",
+          anonymizeIP: true,
+        },
       } satisfies Preset.Options,
     ],
   ],


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Wire Google Analytics 4 into the Node SDK Docusaurus docs site so we can measure documentation traffic. Uses the `gtag` support built into `@docusaurus/preset-classic` (already a dependency), so **no new package** is added.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: AAASM-3552.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    Added a `gtag` block to the classic preset options in `website/docusaurus.config.ts`:

    ```ts
    gtag: {
      trackingID: "G-6FHQKGLDE4",
      anonymizeIP: true,
    },
    ```

    * **Measurement ID `G-6FHQKGLDE4` is public** (it ships in client-side HTML by design), so committing it directly is safe.
    * `anonymizeIP: true` truncates the visitor IP before it reaches Google.
    * **Cookie consent — recommended fast-follow:** gtag sets analytics cookies. There is no consent banner on the site today, so as a follow-up we should add a cookie-consent banner before (or gating) GA initialization to satisfy GDPR/ePrivacy expectations.

## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
    * [ ] 🟠 Has breaking change
* Scopes:
    * [x] 📚 Documentation
    * [x] 📦 Project configurations
* Additional description:
    Docs-site config only. No SDK runtime, API, or type changes.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Added a `gtag` block (`trackingID: G-6FHQKGLDE4`, `anonymizeIP: true`) to the `preset-classic` options in `website/docusaurus.config.ts`.
* Verified `pnpm build` succeeds (installed via `pnpm install --ignore-workspace` per the documented docs-build path) and that `G-6FHQKGLDE4` (the `gtag/js?id=...` loader) is emitted into every page under `website/build/`.

Closes AAASM-3552.
