### PR TITLE
[AAASM-3554] 🍪 (docs): Add GDPR cookie-consent gating to the Docusaurus site

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -8,6 +8,16 @@ import type * as Preset from "@docusaurus/preset-classic";
 // is cut, so they live in data, not inline. See ../docs/releasing.md.
 import versionChannels from "./versionChannels.json";
 
+// Google Analytics + GDPR consent gating (AAASM-3554, fast-follow to
+// AAASM-3552). We self-manage the gtag init instead of using preset-classic's
+// `gtag` option so the Consent-Mode default-denied state is guaranteed to be
+// in place BEFORE the first GA hit. See ./src/analytics/consentInit.ts.
+import {
+  GA_MEASUREMENT_ID,
+  consentDefaultScript,
+  gtagConfigScript,
+} from "./src/analytics/consentInit";
+
 const config: Config = {
   title: "@agent-assembly/sdk",
   tagline: "TypeScript and Node.js SDK for Agent Assembly",
@@ -25,6 +35,65 @@ const config: Config = {
 
   onBrokenLinks: "throw",
   onBrokenAnchors: "throw",
+
+  // Self-managed Google Analytics with Consent Mode v2 (AAASM-3554).
+  //
+  // These two <head> scripts replace preset-classic's `gtag` option. They are
+  // injected in array order at the position of `<%~ it.headTags %>` in the SSG
+  // template — i.e. before the deferred app bundle and before any GA hit:
+  //
+  //   1. consentDefaultScript — defines `dataLayer`/`gtag`, sets Consent-Mode
+  //      default to DENIED for analytics + ads storage, then restores a stored
+  //      opt-in. This MUST run first so GA writes no cookie until opt-in.
+  //   2. the gtag.js loader (async) + gtagConfigScript — loads gtag and fires
+  //      `gtag('config', ...)` (the first hit), which now respects the
+  //      already-denied default above.
+  //
+  // Owning the whole init (rather than relying on `config.headTags`, which
+  // Docusaurus appends AFTER plugin head tags) is what guarantees the
+  // deny-before-hit ordering. The opt-in banner lives in clientModules below.
+  headTags: [
+    {
+      tagName: "script",
+      attributes: {},
+      innerHTML: consentDefaultScript,
+    },
+    {
+      tagName: "link",
+      attributes: {
+        rel: "preconnect",
+        href: "https://www.google-analytics.com",
+      },
+    },
+    {
+      tagName: "link",
+      attributes: {
+        rel: "preconnect",
+        href: "https://www.googletagmanager.com",
+      },
+    },
+    {
+      tagName: "script",
+      attributes: {
+        // headTags config validation requires string attribute values.
+        async: "true",
+        src: `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`,
+      },
+    },
+    {
+      tagName: "script",
+      attributes: {},
+      innerHTML: gtagConfigScript,
+    },
+  ],
+
+  // Vanilla-JS opt-in cookie-consent banner + SPA page-view tracker
+  // (AAASM-3554). The tracker replaces the route tracking we lose by not using
+  // the preset `gtag` plugin.
+  clientModules: [
+    require.resolve("./src/analytics/gtagRouteTracker.ts"),
+    require.resolve("./src/analytics/consentBanner.ts"),
+  ],
 
   markdown: {
     mermaid: true,
@@ -131,13 +200,9 @@ const config: Config = {
         theme: {
           customCss: "./src/css/custom.css",
         },
-        // Google Analytics 4 (AAASM-3552). Built-in gtag support shipped by
-        // preset-classic — no extra dependency. `anonymizeIP` truncates the
-        // visitor IP before it reaches Google. The Measurement ID is public.
-        gtag: {
-          trackingID: "G-6FHQKGLDE4",
-          anonymizeIP: true,
-        },
+        // Google Analytics 4 is initialised via `headTags` above (AAASM-3554)
+        // instead of preset-classic's `gtag` option, so the Consent-Mode
+        // default-denied init is guaranteed to run before the first GA hit.
       } satisfies Preset.Options,
     ],
   ],

--- a/website/src/analytics/consentBanner.css
+++ b/website/src/analytics/consentBanner.css
@@ -1,0 +1,64 @@
+/**
+ * Cookie-consent opt-in banner (AAASM-3554).
+ *
+ * Styling is intentionally minimal and self-contained so the banner has no
+ * dependency on the docs theme bundle and can render the instant the client
+ * module runs. Colours reuse the Infima theme variables Docusaurus already
+ * defines, with hard fallbacks so the banner is legible even before the theme
+ * CSS has loaded.
+ */
+.aa-consent-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem 1rem;
+  padding: 0.85rem 1rem;
+  background: var(--ifm-background-surface-color, #ffffff);
+  color: var(--ifm-font-color-base, #1c1e21);
+  border-top: 1px solid var(--ifm-color-emphasis-300, #dadde1);
+  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.12);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.aa-consent-banner__text {
+  flex: 1 1 280px;
+  max-width: 60ch;
+  margin: 0;
+}
+
+.aa-consent-banner__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.aa-consent-banner__button {
+  cursor: pointer;
+  border: 1px solid var(--ifm-color-emphasis-300, #dadde1);
+  border-radius: var(--ifm-button-border-radius, 6px);
+  padding: 0.4rem 1rem;
+  font: inherit;
+  font-weight: 600;
+}
+
+.aa-consent-banner__button:focus-visible {
+  outline: 2px solid var(--ifm-color-primary, #2e8555);
+  outline-offset: 2px;
+}
+
+.aa-consent-banner__button--accept {
+  background: var(--ifm-color-primary, #2e8555);
+  color: #ffffff;
+  border-color: var(--ifm-color-primary, #2e8555);
+}
+
+.aa-consent-banner__button--reject {
+  background: transparent;
+  color: var(--ifm-font-color-base, #1c1e21);
+}

--- a/website/src/analytics/consentBanner.ts
+++ b/website/src/analytics/consentBanner.ts
@@ -1,0 +1,127 @@
+/**
+ * Cookie-consent opt-in banner client module (AAASM-3554).
+ *
+ * GDPR-compliant opt-in gate for Google Analytics. The Consent-Mode default is
+ * set to `denied` for every storage type by the head script in
+ * `docusaurus.config.ts` *before* the first gtag hit, so no analytics cookie is
+ * written until the visitor explicitly accepts here.
+ *
+ * This module is dependency-free vanilla JS: it builds the banner with
+ * `document.createElement` + `textContent` (never `innerHTML`, to stay
+ * CodeQL-clean) and wires Accept / Reject buttons that flip Consent Mode and
+ * persist the choice in `localStorage`. Once a choice is stored the banner is
+ * never shown again.
+ */
+import "./consentBanner.css";
+
+// Shared with the head consent-default script in docusaurus.config.ts.
+const STORAGE_KEY = "aa-analytics-consent";
+const GRANTED = "granted";
+const DENIED = "denied";
+const BANNER_ID = "aa-consent-banner";
+
+type Gtag = (...args: unknown[]) => void;
+
+function getStoredChoice(): string | null {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    // localStorage can throw in private-mode / disabled-storage browsers.
+    return null;
+  }
+}
+
+function storeChoice(value: string): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, value);
+  } catch {
+    // Best-effort: if persistence fails the banner simply shows again later.
+  }
+}
+
+function updateConsent(granted: boolean): void {
+  const gtag = (window as unknown as { gtag?: Gtag }).gtag;
+  if (typeof gtag === "function") {
+    gtag("consent", "update", {
+      analytics_storage: granted ? GRANTED : DENIED,
+    });
+  }
+}
+
+function removeBanner(): void {
+  const existing = document.getElementById(BANNER_ID);
+  existing?.parentNode?.removeChild(existing);
+}
+
+function makeButton(label: string, modifier: string): HTMLButtonElement {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = `aa-consent-banner__button aa-consent-banner__button--${modifier}`;
+  button.textContent = label;
+  return button;
+}
+
+function renderBanner(): void {
+  if (document.getElementById(BANNER_ID)) {
+    return;
+  }
+
+  const banner = document.createElement("div");
+  banner.id = BANNER_ID;
+  banner.className = "aa-consent-banner";
+  banner.setAttribute("role", "region");
+  banner.setAttribute("aria-label", "Cookie consent");
+
+  const text = document.createElement("p");
+  text.className = "aa-consent-banner__text";
+  text.textContent =
+    "We use Google Analytics to understand how the docs are used. Analytics " +
+    "cookies stay off until you accept.";
+
+  const actions = document.createElement("div");
+  actions.className = "aa-consent-banner__actions";
+
+  const accept = makeButton("Accept", "accept");
+  const reject = makeButton("Reject", "reject");
+
+  accept.addEventListener("click", () => {
+    updateConsent(true);
+    storeChoice(GRANTED);
+    removeBanner();
+  });
+
+  reject.addEventListener("click", () => {
+    updateConsent(false);
+    storeChoice(DENIED);
+    removeBanner();
+  });
+
+  actions.appendChild(accept);
+  actions.appendChild(reject);
+  banner.appendChild(text);
+  banner.appendChild(actions);
+  document.body.appendChild(banner);
+
+  // Keyboard-accessible: move focus to the primary action so a keyboard user
+  // can act on the banner immediately and Tab between the two buttons.
+  accept.focus();
+}
+
+function init(): void {
+  // A stored choice (granted or denied) means the visitor already opted in or
+  // out — never show the banner again.
+  if (getStoredChoice() !== null) {
+    return;
+  }
+  renderBanner();
+}
+
+// Docusaurus client modules run in the browser only, but guard anyway so the
+// SSG build (which imports this module) never touches `document`.
+if (typeof document !== "undefined") {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+}

--- a/website/src/analytics/consentInit.ts
+++ b/website/src/analytics/consentInit.ts
@@ -1,0 +1,57 @@
+/**
+ * Consent-Mode v2 default-denied bootstrap for Google Analytics (AAASM-3554).
+ *
+ * This string is injected verbatim as the `innerHTML` of the FIRST `headTags`
+ * <script> in `docusaurus.config.ts`, ahead of the gtag.js loader and the
+ * `gtag('config', ...)` hit. Running it first is what makes the site
+ * GDPR-compliant: analytics/ads storage is denied by default, so gtag writes
+ * no cookie until the visitor opts in via the banner.
+ *
+ * Order of operations in the snippet (all before the first GA hit):
+ *   1. init `window.dataLayer` and the `gtag` shim
+ *   2. `gtag('consent','default', {... 'denied'})` for analytics + ads storage
+ *   3. re-apply a previously stored opt-in (`localStorage['aa-analytics-consent']
+ *      === 'granted'`) via `gtag('consent','update', ...)`
+ *
+ * We deliberately do NOT use preset-classic's `gtag` option here: Docusaurus
+ * appends `config.headTags` AFTER plugin-injected head tags, so a separate
+ * head entry could not be guaranteed to precede the preset's `gtag('config')`
+ * hit. By owning the whole init we get a deterministic deny-before-hit order.
+ * The gtag.js loader and `gtag('config')` call live in the SECOND head script.
+ */
+
+/** GA4 Measurement ID (public, not a secret). */
+export const GA_MEASUREMENT_ID = "G-6FHQKGLDE4";
+
+/** localStorage key shared with the consent banner client module. */
+export const CONSENT_STORAGE_KEY = "aa-analytics-consent";
+
+/**
+ * Consent-Mode default: deny analytics + advertising storage before any hit,
+ * then restore a stored opt-in. Runs synchronously in <head>.
+ */
+export const consentDefaultScript = `
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('consent', 'default', {
+  'analytics_storage': 'denied',
+  'ad_storage': 'denied',
+  'ad_user_data': 'denied',
+  'ad_personalization': 'denied'
+});
+try {
+  if (window.localStorage.getItem('${CONSENT_STORAGE_KEY}') === 'granted') {
+    gtag('consent', 'update', { 'analytics_storage': 'granted' });
+  }
+} catch (e) {}
+`;
+
+/**
+ * gtag.js loader bootstrap. Runs AFTER {@link consentDefaultScript}, so the
+ * default-denied consent state is already in `dataLayer` before `config` fires
+ * the first hit. `anonymize_ip` mirrors the previous preset configuration.
+ */
+export const gtagConfigScript = `
+gtag('js', new Date());
+gtag('config', '${GA_MEASUREMENT_ID}', { 'anonymize_ip': true });
+`;

--- a/website/src/analytics/gtagRouteTracker.ts
+++ b/website/src/analytics/gtagRouteTracker.ts
@@ -1,0 +1,51 @@
+/**
+ * SPA page-view tracker for the self-managed gtag setup (AAASM-3554).
+ *
+ * Because we no longer use preset-classic's built-in `gtag` plugin (so we can
+ * guarantee the Consent-Mode default-denied init runs before the first hit —
+ * see `docusaurus.config.ts`), we also lose that plugin's route-change
+ * page-view tracking. This client module restores it with the same behaviour:
+ * on every client-side navigation it sends an updated `page_path` and a
+ * `page_view` event. Consent Mode still gates whether GA stores anything, so
+ * this is safe to fire regardless of the visitor's choice.
+ */
+type Gtag = (...args: unknown[]) => void;
+
+// Minimal shape of the history `Location` Docusaurus passes to client-module
+// route hooks. Declared locally to avoid a direct `history` type dependency.
+interface RouteLocation {
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+export function onRouteDidUpdate({
+  location,
+  previousLocation,
+}: {
+  location: RouteLocation;
+  previousLocation: RouteLocation | null;
+}): void {
+  if (
+    !previousLocation ||
+    (location.pathname === previousLocation.pathname &&
+      location.search === previousLocation.search &&
+      location.hash === previousLocation.hash)
+  ) {
+    return;
+  }
+
+  // Defer to the next tick so react-helmet-async has updated the document
+  // title before we report the page view (mirrors the upstream gtag plugin).
+  setTimeout(() => {
+    const gtag = (window as unknown as { gtag?: Gtag }).gtag;
+    if (typeof gtag === "function") {
+      gtag(
+        "set",
+        "page_path",
+        location.pathname + location.search + location.hash,
+      );
+      gtag("event", "page_view");
+    }
+  });
+}


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Make the node-sdk Docusaurus docs site GDPR-compliant by adding Google Consent Mode v2 gating around the existing GA4 analytics. Analytics is **denied by default** and only enabled after an explicit opt-in via a lightweight cookie-consent banner. This is a fast-follow to AAASM-3552 (which added GA4) and brings the node-sdk site in line with the python-sdk mkdocs site's opt-in behaviour.

* ### Task tickets:

    * Task ID: Part of AAASM-3554 (node-sdk site — one of 4 doc sites).
    * Relative task IDs:
        * [x] AAASM-3552 (added GA4 to this site; this PR gates it).
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    * **Consent default before first hit.** We stop using preset-classic's `gtag` option and self-manage the gtag init via `headTags`. Docusaurus appends `config.headTags` *after* plugin-injected head tags, so a separate consent-default entry could not be guaranteed to precede the preset's `gtag('config')` hit. By owning the whole init we get a deterministic deny-before-hit order:
        1. `consentDefaultScript` — init `dataLayer`/`gtag`, `gtag('consent','default', {...denied})` for `analytics_storage` / `ad_storage` / `ad_user_data` / `ad_personalization`, then restore a stored opt-in (`localStorage['aa-analytics-consent'] === 'granted'`).
        2. gtag.js loader (async) + `gtag('config', 'G-6FHQKGLDE4', {anonymize_ip:true})` — the first hit, now respecting the denied default.
    * **Opt-in banner.** A dependency-free vanilla-JS client module renders a fixed, non-modal, keyboard-accessible banner with Accept / Reject. Accept → `gtag('consent','update',{analytics_storage:'granted'})` + persist `granted`; Reject → persist `denied`; both hide the banner. A stored choice suppresses the banner. Built with `createElement` + `textContent` (no `innerHTML`, CodeQL-clean).
    * **No new dependency.** Pure config + vanilla JS/CSS; `pnpm-lock.yaml` unchanged.
    * A small client module restores SPA route-change `page_view` tracking that was previously provided by the preset gtag plugin.

## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
* Scopes:
    * [x] 📚 Documentation
    * [x] 📦 Project configurations
* Additional description:
    Affects only the standalone `website/` Docusaurus project. No SDK runtime, API, or CI behaviour changes. No new npm dependency.

## _Description_

* `website/src/analytics/consentInit.ts` — consent-default + gtag-config head script sources (Measurement ID + localStorage key shared with the banner).
* `website/src/analytics/consentBanner.ts` + `consentBanner.css` — vanilla-JS opt-in banner client module and its styles.
* `website/src/analytics/gtagRouteTracker.ts` — SPA `page_view` tracker client module (replaces the dropped preset plugin's route tracking).
* `website/docusaurus.config.ts` — remove the preset `gtag` option; add `headTags` (consent-default → preconnect → gtag.js loader → config) and `clientModules` (tracker + banner).

### How to verify

1. Build the standalone site:
   ```bash
   cd website
   pnpm install --ignore-workspace
   pnpm build
   ```
   The build succeeds. `pnpm typecheck` is also clean.
2. **Ordering (built HTML).** In `website/build/index.html` `<head>`, confirm the `gtag('consent','default', {...denied})` + opt-in-restore script appears **before** the `gtag/js?id=G-6FHQKGLDE4` loader and the `gtag('config', ...)` hit. Verified positions: consent-default 3411 < loader 3844 < config 3911.
3. **Cookie / Network behaviour (dev tools).** `pnpm serve`, open the site in a fresh profile:
    * On first load, DevTools → Application → Cookies shows **no** `_ga*` analytics cookies, and DevTools → Network shows the GA `collect` request carrying the denied consent state. The banner is visible.
    * Click **Reject** → banner hides, `localStorage['aa-analytics-consent'] = 'denied'`, still no analytics cookie; reload keeps the banner hidden.
    * Click **Accept** (clear storage first) → `gtag('consent','update',{analytics_storage:'granted'})` fires, `localStorage['aa-analytics-consent'] = 'granted'`, `_ga*` cookies are now set; reload keeps the banner hidden and re-applies the granted consent before the first hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)