### PR TITLE
[AAASM-3555] 👍 (docs): Add "Was this page helpful?" feedback widget to the Docusaurus site

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -93,6 +93,11 @@ const config: Config = {
   clientModules: [
     require.resolve("./src/analytics/gtagRouteTracker.ts"),
     require.resolve("./src/analytics/consentBanner.ts"),
+    // "Was this page helpful? 👍 / 👎" doc feedback widget (AAASM-3555). A
+    // client module rather than a DocItem/Footer swizzle: Docusaurus flags
+    // wrap-swizzling that internal component as unsafe (`--danger` required).
+    // The widget reuses the self-managed `window.gtag` from AAASM-3552/3554.
+    require.resolve("./src/analytics/feedbackWidget.ts"),
   ],
 
   markdown: {

--- a/website/src/analytics/feedbackWidget.css
+++ b/website/src/analytics/feedbackWidget.css
@@ -1,0 +1,63 @@
+/**
+ * "Was this page helpful?" feedback widget styles (AAASM-3555).
+ *
+ * The widget is appended to the bottom of each doc page's <article> by
+ * feedbackWidget.ts. Layout uses the same Infima design tokens as the rest of
+ * the site so it adapts to light/dark automatically.
+ */
+
+.feedbackWidget {
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--ifm-toc-border-color);
+}
+
+.feedbackWidget__heading {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.feedbackWidget__buttons {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.feedbackWidget__button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 1rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--ifm-font-color-base);
+  background-color: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-button-border-radius, 0.4rem);
+  cursor: pointer;
+  transition:
+    border-color var(--ifm-transition-fast, 200ms),
+    background-color var(--ifm-transition-fast, 200ms);
+}
+
+.feedbackWidget__button:hover {
+  border-color: var(--ifm-color-primary);
+  background-color: var(--ifm-color-emphasis-100);
+}
+
+.feedbackWidget__button:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
+.feedbackWidget__ack {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.feedbackWidget__improve {
+  display: inline-block;
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+}

--- a/website/src/analytics/feedbackWidget.ts
+++ b/website/src/analytics/feedbackWidget.ts
@@ -1,0 +1,159 @@
+/**
+ * "Was this page helpful? 👍 / 👎" feedback widget (AAASM-3555).
+ *
+ * Appended to the bottom of every documentation page's <article>. On a click it
+ * fires a GA4 `feedback` event through the self-managed gtag set up in
+ * AAASM-3552/3554 (`window.gtag`), then swaps the buttons for an
+ * acknowledgement. A 👎 also reveals a link to a pre-filled GitHub issue so the
+ * visitor can tell us what to improve.
+ *
+ * Why a clientModules injector rather than a swizzle of `@theme/DocItem/Footer`:
+ * Docusaurus flags a wrap-swizzle of DocItem/Footer as "unsafe to perform"
+ * (internal component, `--danger` required, likely to break on theme upgrades).
+ * This injector follows the same `onRouteDidUpdate` client-module pattern the
+ * site already uses for analytics (gtagRouteTracker.ts) and stays decoupled
+ * from internal theme component shapes.
+ *
+ * The whole widget is built with `document.createElement` + `textContent`
+ * (never `innerHTML` of dynamic data) to stay CodeQL-clean.
+ */
+import "./feedbackWidget.css";
+
+type Gtag = (...args: unknown[]) => void;
+
+const WIDGET_ID = "aa-doc-feedback";
+const ISSUE_BASE = "https://github.com/ai-agent-assembly/node-sdk/issues/new";
+
+// Minimal shape of the history `Location` Docusaurus passes to client-module
+// route hooks. Declared locally to avoid a direct `history` type dependency.
+interface RouteLocation {
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+/** Send the GA4 feedback event, guarding on a usable gtag. Consent Mode gates
+ *  storage automatically, so we fire regardless of the visitor's choice. */
+function sendFeedback(value: 1 | 0): void {
+  const gtag = (window as unknown as {gtag?: Gtag}).gtag;
+  if (typeof gtag === "function") {
+    gtag("event", "feedback", {
+      value,
+      page_path: window.location.pathname,
+    });
+  }
+}
+
+/** Build the pre-filled "improve this page" GitHub issue URL for 👎. */
+function improveIssueUrl(): string {
+  const title = `Docs feedback: ${encodeURIComponent(
+    window.location.pathname,
+  )}`;
+  const body = encodeURIComponent(
+    `Page: ${window.location.href}\n\nWhat could be improved?\n`,
+  );
+  return `${ISSUE_BASE}?labels=docs,feedback&title=${title}&body=${body}`;
+}
+
+/** Replace the widget's contents with the post-click acknowledgement. */
+function showAcknowledgement(widget: HTMLElement, positive: boolean): void {
+  while (widget.firstChild) {
+    widget.removeChild(widget.firstChild);
+  }
+
+  const ack = document.createElement("p");
+  ack.className = "feedbackWidget__ack";
+  ack.textContent = "Thanks for your feedback!";
+  widget.appendChild(ack);
+
+  if (!positive) {
+    const improve = document.createElement("a");
+    improve.className = "feedbackWidget__improve";
+    improve.href = improveIssueUrl();
+    improve.target = "_blank";
+    improve.rel = "noopener";
+    improve.textContent = "Tell us what we can improve →";
+    widget.appendChild(improve);
+  }
+}
+
+function makeButton(
+  label: string,
+  ariaLabel: string,
+  onClick: () => void,
+): HTMLButtonElement {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "feedbackWidget__button";
+  button.setAttribute("aria-label", ariaLabel);
+  button.textContent = label;
+  button.addEventListener("click", onClick);
+  return button;
+}
+
+/** Build the full widget element. */
+function buildWidget(): HTMLElement {
+  const widget = document.createElement("div");
+  widget.id = WIDGET_ID;
+  widget.className = "feedbackWidget";
+
+  const heading = document.createElement("p");
+  heading.className = "feedbackWidget__heading";
+  heading.textContent = "Was this page helpful?";
+  widget.appendChild(heading);
+
+  const buttons = document.createElement("div");
+  buttons.className = "feedbackWidget__buttons";
+
+  buttons.appendChild(
+    makeButton("👍", "Yes, this page was helpful", () => {
+      sendFeedback(1);
+      showAcknowledgement(widget, true);
+    }),
+  );
+  buttons.appendChild(
+    makeButton("👎", "No, this page was not helpful", () => {
+      sendFeedback(0);
+      showAcknowledgement(widget, false);
+    }),
+  );
+
+  widget.appendChild(buttons);
+  return widget;
+}
+
+/** Mount the widget at the bottom of the current doc page's <article>, once. */
+function mountWidget(): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+  // Only on doc pages: Docusaurus renders docs inside <article>. Skip pages
+  // (e.g. 404, search) that have no <article>, and never mount twice.
+  const article = document.querySelector("article");
+  if (!article || document.getElementById(WIDGET_ID)) {
+    return;
+  }
+  article.appendChild(buildWidget());
+}
+
+export function onRouteDidUpdate({
+  location,
+  previousLocation,
+}: {
+  location: RouteLocation;
+  previousLocation: RouteLocation | null;
+}): void {
+  // Mount on first load and after every client-side navigation. The DOM has
+  // re-rendered by this hook, so a stale widget from the previous route is
+  // gone and `mountWidget` re-adds a fresh one for the new <article>.
+  if (
+    previousLocation &&
+    location.pathname === previousLocation.pathname &&
+    location.search === previousLocation.search &&
+    location.hash === previousLocation.hash
+  ) {
+    return;
+  }
+  // Defer a tick so the new route's <article> is in the DOM.
+  setTimeout(mountWidget);
+}


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Add a "Was this page helpful? 👍 / 👎" feedback widget to the bottom of every documentation page on the node-sdk Docusaurus site, so we can capture per-page satisfaction in GA4 and route 👎 feedback into pre-filled GitHub issues.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: AAASM-3555.
    * Relative task IDs:
        * [x] AAASM-3552 (gtag init), AAASM-3554 (Consent Mode v2) — this widget reuses the self-managed `window.gtag` they established.
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    **Why a client module, not a swizzle.** The clean Docusaurus path is `swizzle @docusaurus/theme-classic DocItem/Footer --wrap`, but Docusaurus flags a wrap-swizzle of that internal component as *unsafe* (requires `--danger`, breakage-prone across theme upgrades). The ticket explicitly allows a `clientModules` injector as an acceptable alternative, so the widget is a client module that appends to the doc `<article>` on every route update — matching the site's existing analytics client-module pattern (`gtagRouteTracker.ts`, `consentBanner.ts`) and staying decoupled from internal theme shapes.

    Behaviour:
    - Heading "Was this page helpful?" + two keyboard-accessible `<button type="button">` controls (👍 / 👎) with aria-labels.
    - On click: `window.gtag('event', 'feedback', { value: <1|0>, page_path })` (guarded on `typeof window.gtag === 'function'`; Consent Mode gates storage, so it fires regardless of opt-in).
    - After a click the buttons are replaced with "Thanks for your feedback!".
    - 👎 additionally reveals "Tell us what we can improve →" opening a pre-filled GitHub issue (new tab, `rel="noopener"`, `labels=docs,feedback`, encoded title/body).
    - DOM built with `createElement`/`textContent` (no `innerHTML` of dynamic data) — CodeQL-clean. **No new npm dependency.**

[//]: # (What's the scope in project it would affect with your modify?)
## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
* Scopes:
    * [x] 📚 Documentation
    * Additional description: docs-site only (`website/`); no SDK/runtime code touched; no new dependency.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* `website/src/analytics/feedbackWidget.css` — token-driven widget styles (light/dark via existing Infima tokens).
* `website/src/analytics/feedbackWidget.ts` — the widget client module (`onRouteDidUpdate` mounts it into `<article>`; gtag event; ack; pre-filled issue link).
* `website/docusaurus.config.ts` — register the module in `clientModules`.

### How to verify

```bash
cd website
pnpm install --ignore-workspace
pnpm typecheck   # clean
pnpm build       # [SUCCESS]
```

Then load any doc page from `website/build/` (e.g. `/configuration/`): the widget renders at the bottom of the article. Verified runtime behaviour (mount, idempotent re-mount on navigation, 👍 → `value:1`, 👎 → `value:0` + pre-filled issue link `target=_blank rel=noopener`) by executing the source module against a DOM/`window.gtag` shim.

Note: pre-existing typedoc `TS2304` warnings (e.g. `Cannot find name 'setTimeout'` in `../src/...`) appear in the build log; they originate from the parent SDK source typedoc pass, not this change, and the build still ends in `[SUCCESS]`.

Part of AAASM-3555 (node-sdk site).
