### PR TITLE
[AAASM-3568] 🔒 (node-sdk): SDK supply-chain attestation + SBOM + advisory gate

### DIFF
--- a/.github/workflows/ci-success.yml
+++ b/.github/workflows/ci-success.yml
@@ -17,6 +17,7 @@ on:
       - module-system-smoke
       - pre-commit-checks
       - quality-report
+      - dependency-audit
     types:
       - completed
 

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,74 @@
+name: dependency-audit
+
+# Advisory gate for the npm dependency tree (AAASM-3616, Story AAASM-3568).
+#
+# Fails CI when a dependency carries a known advisory at >= high severity, so a
+# poisoned transitive dep cannot ride into an npm publish via the lockfile. This
+# is the node-sdk counterpart to go-sdk's govulncheck gate and python-sdk's
+# pip-audit gate — the three SDK ecosystems are now uniformly advisory-gated.
+#
+# Allowlist for unfixable advisories
+# ----------------------------------
+# `pnpm audit` reads an allowlist from the root package.json under
+# `pnpm.auditConfig.ignoreGhsas` (and/or `ignoreCves`). Mirror go-sdk's
+# `KNOWN_UNFIXED` convention: only add an advisory there when NO fixed version
+# exists yet, with a dated comment recording why and what we are waiting on.
+# Start with none ignored. Example:
+#
+#   "pnpm": {
+#     "auditConfig": {
+#       "ignoreGhsas": [
+#         "GHSA-xxxx-xxxx-xxxx"  // 2026-06-23: no fix released; awaiting upstream <ver>
+#       ]
+#     }
+#   }
+#
+# Triggers mirror test-matrix.yml so the gate runs on the same code-bearing
+# PRs/pushes and the ci-success.yml aggregate gate can wait on it by name.
+
+on:
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
+  push:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.33.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Non-zero exit (an advisory at >= high that is not in the
+      # pnpm.auditConfig allowlist) fails the job and blocks the release path.
+      - name: Audit dependencies for known advisories
+        run: pnpm audit --audit-level=high

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -298,6 +298,21 @@ jobs:
       - name: Build main SDK (ESM + CJS)
         run: pnpm build
 
+      # AAASM-3619: generate a CycloneDX SBOM for the workspace so every
+      # release ships a consumer-verifiable dependency manifest alongside npm
+      # provenance (NPM_CONFIG_PROVENANCE above). Runs on every dispatch
+      # (incl. dry-run) so a dry-run validates generation; the real-publish
+      # path attaches it to the GitHub Release below.
+      - name: Generate CycloneDX SBOM
+        run: pnpm dlx @cyclonedx/cyclonedx-npm --output-format JSON --output-file sbom.cdx.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom-cyclonedx
+          path: sbom.cdx.json
+          if-no-files-found: error
+
       # Publish the 4 runtime sub-packages first. The main SDK's
       # optionalDependencies (declared under AAASM-1221) point at the
       # `@agent-assembly/runtime-*` versions we're publishing here;
@@ -367,23 +382,27 @@ jobs:
         run: |
           set -euo pipefail
           tag="v${NPM_VERSION}"
+          # Create the Release unless it already exists (idempotent re-run).
           if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "::notice::GitHub Release $tag already exists — leaving it untouched (idempotent re-run)."
-            exit 0
+            echo "::notice::GitHub Release $tag already exists — leaving its metadata untouched (idempotent re-run)."
+          else
+            # Mark pre-release for any SemVer pre-release identifier (e.g.
+            # 0.0.1-beta.1); a bare X.Y.Z is a stable release.
+            prerelease_flag=""
+            if [[ "$NPM_VERSION" == *-* ]]; then
+              prerelease_flag="--prerelease"
+            fi
+            # shellcheck disable=SC2086
+            gh release create "$tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --target "$GITHUB_SHA" \
+              --title "$tag" \
+              $prerelease_flag \
+              --notes "node-sdk @agent-assembly/sdk@${NPM_VERSION} (bundled aasm binaries from agent-assembly ${BINARY_SOURCE_TAG})."
           fi
-          # Mark pre-release for any SemVer pre-release identifier (e.g.
-          # 0.0.1-beta.1); a bare X.Y.Z is a stable release.
-          prerelease_flag=""
-          if [[ "$NPM_VERSION" == *-* ]]; then
-            prerelease_flag="--prerelease"
-          fi
-          # shellcheck disable=SC2086
-          gh release create "$tag" \
-            --repo "$GITHUB_REPOSITORY" \
-            --target "$GITHUB_SHA" \
-            --title "$tag" \
-            $prerelease_flag \
-            --notes "node-sdk @agent-assembly/sdk@${NPM_VERSION} (bundled aasm binaries from agent-assembly ${BINARY_SOURCE_TAG})."
+          # AAASM-3619: attach the CycloneDX SBOM to the Release. --clobber
+          # keeps this idempotent across re-runs (overwrites a stale asset).
+          gh release upload "$tag" sbom.cdx.json --repo "$GITHUB_REPOSITORY" --clobber
 
   # AAASM-2751: cut the immutable Docusaurus docs snapshot for this release
   # and repoint the channel metadata. This runs ONLY after `publish` succeeds,

--- a/README.md
+++ b/README.md
@@ -314,5 +314,8 @@ across all SDKs.
   via the repository's
   [security advisories](https://github.com/ai-agent-assembly/node-sdk/security/advisories)
   page so a fix can be coordinated before disclosure.
+- **Canonical package names + verifying your install** — see [SECURITY.md](./SECURITY.md)
+  for the authoritative `@agent-assembly/*` package list (to spot typosquats) and how to
+  verify npm provenance (`npm audit signatures`) and the per-release CycloneDX SBOM.
 - **Contributing** — see [CONTRIBUTING.md](./CONTRIBUTING.md) for environment setup, the
   adapter-authoring guide, and the test/commit conventions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do **not** file a public issue for a security vulnerability. Report it
+privately via the repository's
+[security advisories](https://github.com/ai-agent-assembly/node-sdk/security/advisories)
+page so a fix can be coordinated before disclosure.
+
+## Canonical package names
+
+The Node SDK is published to npm **only** under the `@agent-assembly` scope. The
+canonical packages are:
+
+| Package | Role |
+|---|---|
+| `@agent-assembly/sdk` | The SDK itself (the package you install). |
+| `@agent-assembly/runtime-linux-x64` | Bundled `aasm` runtime binary, optional dependency. |
+| `@agent-assembly/runtime-linux-arm64` | Bundled `aasm` runtime binary, optional dependency. |
+| `@agent-assembly/runtime-darwin-x64` | Bundled `aasm` runtime binary, optional dependency. |
+| `@agent-assembly/runtime-darwin-arm64` | Bundled `aasm` runtime binary, optional dependency. |
+
+The four `runtime-*` packages are pulled in automatically as
+`optionalDependencies` of `@agent-assembly/sdk`; you never install them directly.
+
+**Anything outside this list is not us.** Unscoped names (e.g. `agent-assembly`),
+look-alike scopes, or near-miss spellings are typosquats — do not install them.
+
+## Verifying what you installed
+
+Every release is published through an operator-gated, OIDC-authenticated pipeline
+(`release-node.yml`) and ships two consumer-verifiable integrity signals.
+
+### 1. npm provenance (SLSA)
+
+Each package is published with `--provenance`, so npm records a signed,
+tamper-evident link back to the exact GitHub Actions run and source commit that
+built it. Verify it:
+
+```bash
+# Verify the registry signatures + provenance attestations of your install tree.
+npm audit signatures
+```
+
+You can also see the **Provenance** panel on the package page at
+<https://www.npmjs.com/package/@agent-assembly/sdk>. A package built outside the
+sanctioned pipeline carries no provenance — its absence is the tell.
+
+### 2. CycloneDX SBOM
+
+Each GitHub Release attaches a CycloneDX Software Bill of Materials,
+`sbom.cdx.json`, listing the exact dependency set that release was built against.
+Download it from the matching release on the
+[Releases page](https://github.com/ai-agent-assembly/node-sdk/releases) and
+cross-check it against your installed tree and your advisory feed of choice.
+
+## CI advisory gate
+
+Dependencies are scanned on every PR and push by the `dependency-audit` workflow
+(`pnpm audit --audit-level=high`); a known-vuln dependency fails CI and blocks the
+release. Advisories with no available fix are allowlisted, with a dated rationale,
+in the root `package.json` under `pnpm.auditConfig`.


### PR DESCRIPTION
## Description

Hardens the Node SDK's distribution supply chain (Story AAASM-3568). Three changes, no behavior change to the SDK itself:

- **Advisory gate (AAASM-3616):** new `dependency-audit` workflow runs `pnpm audit --audit-level=high` on the same code-bearing PR/push triggers as `test-matrix`, and is wired into the `CI Success` aggregate gate. A known-vuln dependency now fails CI and blocks the release. Unfixable advisories are allowlisted (with a dated rationale) in root `package.json` `pnpm.auditConfig.ignoreGhsas` — none ignored today. This makes node the third SDK ecosystem with a uniform advisory gate (alongside go's govulncheck and python's pip-audit).
- **CycloneDX SBOM (AAASM-3619):** `release-node.yml` now generates `sbom.cdx.json` (`@cyclonedx/cyclonedx-npm`) after the build, uploads it as a workflow artifact on every dispatch (incl. dry-run, which validates generation), and attaches it to the GitHub Release on the real-publish path. The release-cut step's idempotent re-run branch still (re-)uploads the SBOM via `--clobber`. Completes the consumer-verifiable manifest alongside the existing npm provenance (`NPM_CONFIG_PROVENANCE`).
- **Docs (AAASM-3628):** new `SECURITY.md` lists the canonical `@agent-assembly/*` package names (SDK + 4 `runtime-*` sub-packages) to counter typosquats, and documents how a consumer verifies an install — `npm audit signatures` / the registry Provenance panel, plus the per-release SBOM. Linked from the README.

The operator-gated, FFI-pin-lockstep publish pipeline (AAASM-3503 / AAASM-3468) is unchanged — no dry-run gating or publish-order changes.

## Type of Change

- [ ] ✨ New feature
- [ ] 🔧 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📚 Documentation update
- [x] 🚀 Release
- [x] 🔒 Security / supply-chain hardening (CI + release workflow)

## Breaking Changes

- [x] No
- [ ] Yes (please describe below)

## Related Issues

- Related JIRA ticket: AAASM-3568 (Story); subtasks AAASM-3616, AAASM-3619, AAASM-3628
- Related GitHub issues: N/A

## Testing

Describe the testing performed for this PR:

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed — `actionlint` clean on all three changed workflows; YAML parses (`yaml.safe_load`). The release-workflow SBOM step and the advisory gate exercise on the next dispatch/CI run (no local registry).
- [x] No tests required (explain why) — changes are CI/release workflow YAML + Markdown docs; no SDK source touched.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated if needed
- [x] All tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
