### PR TITLE
[AAASM-3570] 🔒 (node-sdk): SDK credential/token hygiene & log-leak prevention

### DIFF
--- a/src/core/init-assembly.ts
+++ b/src/core/init-assembly.ts
@@ -33,6 +33,7 @@ import { hasOpenAIAgentsSDK } from "../hooks/openai-agents-detection.js";
 import { patchOpenAIAgents } from "../hooks/openai-agents.js";
 import { currentAgentId } from "../lineage/index.js";
 import { resolveApiKey, resolveGatewayUrl } from "./gateway-resolver.js";
+import { redactErrorMessage } from "./redact.js";
 
 const requireFromCwd = createRequire(`${process.cwd()}/`);
 
@@ -425,8 +426,11 @@ export async function initAssembly(config: AssemblyConfig = {}): Promise<Assembl
     try {
       await nativeClient.register(buildRegisterOptions(resolvedConfig, frameworks));
     } catch (error) {
+      // Redact any Bearer/auth credential the error message might carry before
+      // it reaches the console — the apiKey/credentialToken must never be logged
+      // (AAASM-3645).
       console.warn(
-        `[agent-assembly] agent registration failed; proceeding unregistered: ${String(error)}`
+        `[agent-assembly] agent registration failed; proceeding unregistered: ${redactErrorMessage(error)}`
       );
     }
     // Topology lineage metadata still flows as an audit event (parent / team /

--- a/src/core/redact.ts
+++ b/src/core/redact.ts
@@ -1,0 +1,62 @@
+/**
+ * Secret-redaction helpers for diagnostic / log output (AAASM-3645).
+ *
+ * The resolved `apiKey` and the proto `credentialToken` must never reach
+ * `console.*` or an accidental `JSON.stringify` dump. These helpers give the
+ * SDK a single, audited way to render config/diagnostics for logging with the
+ * credential fields stripped.
+ *
+ * NOTE: the generated `CheckActionRequest.toJSON()` (src/proto/generated) is
+ * wire-only — it serializes `credentialToken` for transport and must never be
+ * passed to a logger. Use {@link redactSecrets} on any object you intend to log.
+ */
+
+/**
+ * Object keys (lower-cased) whose values are credentials and must never be
+ * logged. Matching is case-insensitive, so list the lower-case form only —
+ * `apiKey`, `apikey`, `API_KEY` all match `"apikey"`.
+ */
+const SECRET_KEYS: ReadonlySet<string> = new Set([
+  "apikey",
+  "api_key",
+  "credentialtoken",
+  "credential_token",
+  "authorization",
+  "token"
+]);
+
+/** Placeholder substituted for any redacted credential value. */
+export const REDACTED = "<redacted>";
+
+/**
+ * Return a deep copy of `value` with every credential-bearing field replaced by
+ * {@link REDACTED}, safe to pass to `console.*` / `JSON.stringify`. Matching is
+ * case-insensitive on the key name. Non-object inputs are returned unchanged.
+ */
+export function redactSecrets(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSecrets(item));
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      out[key] = SECRET_KEYS.has(key.toLowerCase()) ? REDACTED : redactSecrets(val);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Render an unknown error for a log message with any `Bearer <token>` / API-key
+ * substring scrubbed. Defends the registration-failure warning path: a wrapped
+ * transport error could in principle carry an auth header in its message, so we
+ * strip the bearer credential before it reaches `console.*` (AAASM-3645).
+ */
+export function redactErrorMessage(error: unknown): string {
+  const raw = String(error);
+  // Replace the credential that follows a `Bearer ` / `Authorization:` marker.
+  return raw
+    .replace(/(Bearer\s+)[\w.\-+/=]+/gi, `$1${REDACTED}`)
+    .replace(/(Authorization\s*[:=]\s*)\S+/gi, `$1${REDACTED}`);
+}

--- a/tests/credential-redaction.test.ts
+++ b/tests/credential-redaction.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { redactErrorMessage, redactSecrets, REDACTED } from "../src/core/redact.js";
+import { CheckActionRequest } from "../src/proto/generated/policy.js";
+
+/**
+ * Credential/token hygiene for the Node SDK (AAASM-3645).
+ *
+ * The resolved `apiKey` and the proto `credentialToken` must never reach
+ * `console.*` or an accidental `JSON.stringify` dump. These tests pin:
+ *   1. `redactSecrets` strips both fields from a CheckActionRequest-shaped
+ *      object and a config object (the wire `toJSON` is NOT for logging).
+ *   2. `redactErrorMessage` scrubs a `Bearer <token>` substring.
+ *   3. End-to-end: the `initAssembly` registration-failure `console.warn` never
+ *      emits a sentinel apiKey/credentialToken, even when the register error
+ *      embeds the bearer header.
+ */
+
+const SENTINEL_KEY = "SENTINEL-API-KEY-DO-NOT-LOG";
+const SENTINEL_TOKEN = "SENTINEL-CRED-TOKEN-DO-NOT-LOG";
+
+describe("redactSecrets (AAASM-3645)", () => {
+  it("strips credentialToken from a CheckActionRequest diagnostic dump", () => {
+    const request = CheckActionRequest.fromPartial({
+      credentialToken: SENTINEL_TOKEN,
+      traceId: "trace-1",
+      actionType: 0
+    });
+
+    // toJSON is wire-only and DOES contain the token — proving the leak path.
+    const wire = JSON.stringify(CheckActionRequest.toJSON(request));
+    expect(wire).toContain(SENTINEL_TOKEN);
+
+    // The redacted form is what may be logged — token gone, shape kept.
+    const safe = JSON.stringify(redactSecrets(CheckActionRequest.toJSON(request)));
+    expect(safe).not.toContain(SENTINEL_TOKEN);
+    expect(safe).toContain(REDACTED);
+    expect(safe).toContain("trace-1");
+  });
+
+  it("strips apiKey from a config object (case-insensitive, nested)", () => {
+    const config = {
+      gatewayUrl: "http://gw.test",
+      apiKey: SENTINEL_KEY,
+      nested: { credential_token: SENTINEL_TOKEN, agentId: "a" }
+    };
+    const safe = JSON.stringify(redactSecrets(config));
+    expect(safe).not.toContain(SENTINEL_KEY);
+    expect(safe).not.toContain(SENTINEL_TOKEN);
+    expect(safe).toContain("http://gw.test");
+    expect(safe).toContain("a");
+  });
+});
+
+describe("redactErrorMessage (AAASM-3645)", () => {
+  it("scrubs a Bearer credential from an error string", () => {
+    const err = new Error(`401 from gateway (Authorization: Bearer ${SENTINEL_KEY})`);
+    const scrubbed = redactErrorMessage(err);
+    expect(scrubbed).not.toContain(SENTINEL_KEY);
+    expect(scrubbed).toContain(REDACTED);
+  });
+});
+
+interface MockBinding {
+  connect: ReturnType<typeof vi.fn>;
+  sendEvent: ReturnType<typeof vi.fn>;
+  queryPolicy: ReturnType<typeof vi.fn>;
+  register: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+}
+
+async function loadWithBinding(binding: MockBinding) {
+  vi.resetModules();
+  vi.doMock("node:module", () => ({
+    createRequire: () => () => binding
+  }));
+  return import("../src/index.js");
+}
+
+describe("initAssembly registration-failure log is credential-free (AAASM-3645)", () => {
+  it("never logs the apiKey/bearer when registration throws an auth error", async () => {
+    const binding: MockBinding = {
+      connect: vi.fn(async () => ({ id: "handle" })),
+      sendEvent: vi.fn(() => undefined),
+      queryPolicy: vi.fn(async () => ({ decision: "allow", reason: "" })),
+      // Worst case: the register error itself carries the bearer header.
+      register: vi.fn(async () => {
+        throw new Error(`AA_ERR_REGISTER: rejected (Authorization: Bearer ${SENTINEL_KEY})`);
+      }),
+      disconnect: vi.fn(async () => undefined)
+    };
+    const { initAssembly } = await loadWithBinding(binding);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const ctx = await initAssembly({
+      gatewayUrl: "/tmp/aa.sock",
+      apiKey: SENTINEL_KEY,
+      agentId: "agent-x",
+      mode: "napi-inprocess"
+    });
+    await ctx.shutdown();
+
+    const logged = warn.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(logged).toContain("proceeding unregistered");
+    expect(logged).not.toContain(SENTINEL_KEY);
+    warn.mockRestore();
+  });
+});


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

* ### Task summary:

    Ensure the Node SDK never writes the resolved `apiKey` or the proto `credentialToken` to `console.*` / logs / accidental JSON dumps (Story AAASM-3570, subtask AAASM-3645).

* ### Task tickets:

    * Task ID: AAASM-3645.
    * Relative task IDs:
        * [x] AAASM-3570 (parent Story)
        * [x] AAASM-3562 (proxy credential hygiene — related)
    * Relative PRs:
        * agent-assembly aa-sdk-client hardening (AAASM-3629/3634/3638)

* ### Key point change (optional):

    * New `src/core/redact.ts`: `redactSecrets()` (deep, case-insensitive strip of `apiKey`/`credentialToken`/`authorization`/`token`) + `redactErrorMessage()` (scrubs `Bearer <token>` / `Authorization:` from an error string).
    * The `initAssembly` registration-failure `console.warn` now routes the error through `redactErrorMessage` so a wrapped transport error carrying an auth header cannot echo the credential to stderr.
    * Audited every `console.*` in `src`: only `init-assembly.ts:428` had config/apiKey in lexical scope; `credentialToken` never appears in any `console.*`. The generated `CheckActionRequest.toJSON()` is documented as wire-only (never log it).

## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
* Scopes:
    * [x] 🪡 API client and transport
    * [x] ⛑️ Error handling
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing

## _Description_

* `redactSecrets` / `redactErrorMessage` give the SDK one audited path to render diagnostics safely.
* Tests: `tests/credential-redaction.test.ts` — `redactSecrets` removes the token from a `CheckActionRequest.toJSON()` dump and `apiKey` from a config object; `redactErrorMessage` scrubs `Bearer`; and an end-to-end `initAssembly` register-failure case asserts the sentinel apiKey never reaches `console.warn`.

Run locally:
- `pnpm test` — 334 passed, 2 skipped
- `pnpm typecheck` — clean
- `pnpm lint` — clean

⚠️ No hard-coded crypto secrets: tests use redaction sentinels only.
