### PR TITLE
[AAASM-3678] ✅ (sonar): add assertion to packaging lazy-load test

### DIFF
--- a/tests/packaging/op-control-grpc-lazy-load.test.ts
+++ b/tests/packaging/op-control-grpc-lazy-load.test.ts
@@ -68,10 +68,18 @@ describe("packaging op-control grpc lazy-load", () => {
           console.error("FAIL: @grpc/grpc-js was eagerly loaded");
           process.exit(1);
         }
+        console.log("OK: grpc-js absent from require.cache");
         process.exit(0);
       `;
-      // Inherit a clean run; throws on non-zero exit, failing the test.
-      execFileSync(process.execPath, ["-e", probe], { stdio: "pipe" });
+      // Run the probe in a clean child process. `execFileSync` throws on a
+      // non-zero exit (the grpc-loaded failure path above), and we additionally
+      // assert on the explicit success marker so the lazy-load guarantee is
+      // checked positively rather than only via the absence of a throw.
+      const probeOutput = execFileSync(process.execPath, ["-e", probe], {
+        stdio: "pipe",
+        encoding: "utf8",
+      });
+      expect(probeOutput).toContain("OK: grpc-js absent from require.cache");
     });
   }, 120000);
 });


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Resolve the last open SonarCloud code smell on `ai-agent-assembly_node-sdk`: BLOCKER `typescript:S2699` ("Add at least one assertion to this test case") at `tests/packaging/op-control-grpc-lazy-load.test.ts:46`.

* ### Task tickets:

    * Task ID: AAASM-3678.
    * Relative task IDs:
        * [x] AAASM-3505 / AAASM-3500 (the lazy-load regression these tests guard).
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    The `importing the built op-control entry does not load @grpc/grpc-js` test exercised behaviour entirely through `execFileSync`, which throws on a non-zero child-process exit. That is a real check, but Sonar's S2699 detector looks for a recognizable `expect()`/assert in the test body and found none, flagging it as a test with no assertion.

    Fix: the probe now prints an explicit `OK: grpc-js absent from require.cache` success marker; the test captures the child's stdout (`encoding: "utf8"`) and asserts `expect(probeOutput).toContain(...)`. The throw-on-non-zero-exit behaviour is retained as defense in depth, so the lazy-load guarantee is now verified both positively (marker present) and negatively (child fails → throw).

## _Effecting Scope_

* Action Types:
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
* Scopes:
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
* Additional description:
    Test-only change. No production/runtime code touched.

## _Description_

* Add an explicit success marker + `expect().toContain()` assertion to the grpc lazy-load packaging test so its assertion is recognizable to SonarCloud (S2699), without weakening the existing throw-based failure path.

How to verify:
* `pnpm test -- tests/packaging/op-control-grpc-lazy-load.test.ts` — both cases green; the AAASM-3678 case passes (1.6s locally).
* `pnpm lint` — clean.

Closes AAASM-3678.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
