### PR TITLE
[AAASM-3683] 🔒 (node-sdk): Pass language-SDK package version through the FFI into the handshake

### DIFF
--- a/native/aa-ffi-node/Cargo.lock
+++ b/native/aa-ffi-node/Cargo.lock
@@ -8,18 +8,22 @@ version = "0.0.0"
 dependencies = [
  "aa-proto",
  "aa-sdk-client",
+ "ed25519-dalek",
+ "hex",
  "napi",
  "napi-build",
  "napi-derive",
  "prost",
+ "rand",
  "serde_json",
+ "sha2 0.10.9",
  "tokio",
 ]
 
 [[package]]
 name = "aa-proto"
 version = "0.0.1-beta.3"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=ebc4d7dc9da81cdf4f265d681c138500ca6e98e7#ebc4d7dc9da81cdf4f265d681c138500ca6e98e7"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=b0576a72422bad7c6f380e666aa6ad70d1939822#b0576a72422bad7c6f380e666aa6ad70d1939822"
 dependencies = [
  "prost",
  "tonic",
@@ -30,7 +34,7 @@ dependencies = [
 [[package]]
 name = "aa-sdk-client"
 version = "0.0.1-beta.3"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=ebc4d7dc9da81cdf4f265d681c138500ca6e98e7#ebc4d7dc9da81cdf4f265d681c138500ca6e98e7"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=b0576a72422bad7c6f380e666aa6ad70d1939822#b0576a72422bad7c6f380e666aa6ad70d1939822"
 dependencies = [
  "aa-proto",
  "aa-security",
@@ -42,12 +46,13 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]
 name = "aa-security"
 version = "0.0.1-beta.3"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=ebc4d7dc9da81cdf4f265d681c138500ca6e98e7#ebc4d7dc9da81cdf4f265d681c138500ca6e98e7"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=b0576a72422bad7c6f380e666aa6ad70d1939822#b0576a72422bad7c6f380e666aa6ad70d1939822"
 dependencies = [
  "aho-corasick",
 ]
@@ -887,6 +892,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1006,27 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
 
 [[package]]
 name = "rand_core"
@@ -1620,10 +1655,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/native/aa-ffi-node/Cargo.toml
+++ b/native/aa-ffi-node/Cargo.toml
@@ -20,14 +20,14 @@ crate-type = ["cdylib"]
 # the agent-assembly workspace; `query_policy` builds a `CheckActionRequest`
 # and reads its `CheckActionResponse` directly from these generated types.
 #
-# Pinned at the agent-assembly PR #1160 squash-merge commit, which adds the
-# `team_id` / `parent_agent_id` fields to `AssemblyConfig` that `register`
-# now forwards onto the native gRPC Register (team-budget attribution +
-# topology lineage). The base 9cde1d83 (AAASM-3396) added
-# `AssemblyClient::register()` (the one direct SDK→gateway gRPC call, per ADR
-# 0004) plus the `gateway_endpoint` field.
-aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "ebc4d7dc9da81cdf4f265d681c138500ca6e98e7", package = "aa-sdk-client" }
-aa-proto = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "ebc4d7dc9da81cdf4f265d681c138500ca6e98e7", package = "aa-proto" }
+# Pinned at agent-assembly AAASM-3683, which adds the `sdk_version` field to
+# `AssemblyConfig` and threads it through `spawn_ipc_thread` into the signed IPC
+# handshake — the version this shim now forwards from the npm package version so
+# downgrade detection reflects the installed @agent-assembly/sdk release.
+# Re-pin to the squash-merge commit once PR #1226 lands on master. (Prior pin
+# ebc4d7dc / AAASM-3415 added `team_id` / `parent_agent_id`, still forwarded.)
+aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "b0576a72422bad7c6f380e666aa6ad70d1939822", package = "aa-sdk-client" }
+aa-proto = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "b0576a72422bad7c6f380e666aa6ad70d1939822", package = "aa-proto" }
 napi = { version = "3", default-features = false, features = ["napi8", "tokio_rt", "serde-json"] }
 napi-derive = "3"
 prost = "0.14"
@@ -43,3 +43,11 @@ napi-build = "2"
 # codec, so it needs the async net/io stack and prost to encode the response.
 prost = "0.14"
 tokio = { version = "1", features = ["rt", "macros", "net", "io-util", "time"] }
+# The mock server now performs the AAASM-3587 session handshake (the client
+# signs `nonce || sdk_version` before any heartbeat), so the test verifies the
+# Ed25519 proof. `rand` is value-returning for the nonce (no `[0u8; N]` literal
+# in the signing data-flow → CodeQL-clean).
+ed25519-dalek = "2"
+sha2 = "0.10"
+hex = "0.4"
+rand = "0.8"

--- a/native/aa-ffi-node/index.d.ts
+++ b/native/aa-ffi-node/index.d.ts
@@ -15,8 +15,15 @@ export declare class ClientHandle {
  * Socket resolution, the background IPC thread, and the wire codec are all
  * delegated to `aa-sdk-client`; this shim only validates the argument and
  * wraps the resulting client.
+ *
+ * `agentId` is the agent identity the background thread signs the runtime
+ * session handshake with (AAASM-3587). `sdkVersion` is the user-facing npm
+ * package version (`@agent-assembly/sdk`) the JS layer forwards so it — not the
+ * shared `aa-sdk-client` crate version — is what gets signed into the handshake
+ * proof (AAASM-3683); `undefined` falls back to the crate version (no
+ * regression vs AAASM-3666).
  */
-export declare function connect(socketPath: string): Promise<ClientHandle>
+export declare function connect(socketPath: string, agentId?: string | undefined | null, sdkVersion?: string | undefined | null): Promise<ClientHandle>
 
 /**
  * Shut down the session and join the background IPC thread.

--- a/native/aa-ffi-node/src/lib.rs
+++ b/native/aa-ffi-node/src/lib.rs
@@ -49,23 +49,35 @@ pub struct ClientHandle {
 /// Socket resolution, the background IPC thread, and the wire codec are all
 /// delegated to `aa-sdk-client`; this shim only validates the argument and
 /// wraps the resulting client.
+///
+/// `agentId` is the agent identity the background thread signs the runtime
+/// session handshake with (AAASM-3587). `sdkVersion` is the user-facing npm
+/// package version (`@agent-assembly/sdk`) the JS layer forwards so it — not the
+/// shared `aa-sdk-client` crate version — is what gets signed into the handshake
+/// proof (AAASM-3683); `undefined` falls back to the crate version (no
+/// regression vs AAASM-3666).
 #[napi]
-pub async fn connect(socket_path: String) -> Result<ClientHandle> {
+pub async fn connect(
+  socket_path: String,
+  agent_id: Option<String>,
+  sdk_version: Option<String>,
+) -> Result<ClientHandle> {
   if socket_path.trim().is_empty() {
     return Err(typed_error(ERR_CONNECT, "socketPath cannot be empty"));
   }
 
   let config = AssemblyConfig {
-    agent_id: String::new(),
+    agent_id: agent_id.unwrap_or_default(),
     socket_path: Some(socket_path),
     gateway_endpoint: None,
     team_id: None,
     parent_agent_id: None,
+    sdk_version,
   };
   let resolved = config.resolve_socket_path();
 
-  let ipc =
-    spawn_ipc_thread(resolved).map_err(|err| typed_error(ERR_CONNECT, &err.to_string()))?;
+  let ipc = spawn_ipc_thread(resolved, config.agent_id.clone(), config.resolved_sdk_version())
+    .map_err(|err| typed_error(ERR_CONNECT, &err.to_string()))?;
   let client = AssemblyClient::new(ipc, Vec::new());
 
   Ok(ClientHandle {
@@ -117,6 +129,9 @@ pub async fn register(handle: &ClientHandle, options: RegisterOptions) -> Result
     gateway_endpoint: options.gateway_endpoint,
     team_id: options.team_id,
     parent_agent_id: options.parent_agent_id,
+    // The version is signed at IPC-handshake time (`connect`), not on the
+    // gateway register, so it is not needed for this config.
+    sdk_version: None,
   };
 
   handle
@@ -325,6 +340,66 @@ mod tests {
 
   use super::*;
 
+  /// The agent id the mock-server tests handshake as.
+  const TEST_AGENT_ID: &str = "agent-1";
+
+  /// A distinctive language-package version forwarded into `spawn_ipc_thread`, so
+  /// the deny test asserts the FFI-passed version (not the crate version) reaches
+  /// the signed handshake proof (AAASM-3683).
+  const TEST_SDK_VERSION: &str = "npm-4.5.6";
+
+  /// Server side of the AAASM-3587 session handshake the client now performs
+  /// before any heartbeat: send a nonce challenge, read the signed proof, verify
+  /// it over `nonce || sdk_version` (AAASM-3666), and return the signed version
+  /// so callers can assert the FFI-forwarded version reached the handshake
+  /// (AAASM-3683).
+  async fn server_handshake<S>(stream: &mut S, agent_id: &str) -> String
+  where
+    S: AsyncReadExt + AsyncWriteExt + Unpin,
+  {
+    use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+    use sha2::{Digest, Sha256};
+
+    // Value-returning CSPRNG so no constant literal flows into the signed nonce
+    // (CodeQL hard-coded-crypto).
+    let nonce = rand::random::<[u8; 32]>().to_vec();
+    let challenge = aa_proto::assembly::ipc::v1::HandshakeChallenge { nonce: nonce.clone() };
+    let payload = challenge.encode_to_vec();
+    stream.write_u8(codec::TAG_HANDSHAKE_CHALLENGE).await.unwrap();
+    assert!(payload.len() < 128);
+    stream.write_u8(payload.len() as u8).await.unwrap();
+    stream.write_all(&payload).await.unwrap();
+    stream.flush().await.unwrap();
+
+    assert_eq!(stream.read_u8().await.unwrap(), codec::TAG_HANDSHAKE_PROOF);
+    let mut len: u64 = 0;
+    let mut shift = 0u32;
+    loop {
+      let byte = stream.read_u8().await.unwrap();
+      len |= ((byte & 0x7F) as u64) << shift;
+      if byte & 0x80 == 0 {
+        break;
+      }
+      shift += 7;
+    }
+    let mut buf = vec![0u8; len as usize];
+    stream.read_exact(&mut buf).await.unwrap();
+    let proof = aa_proto::assembly::ipc::v1::HandshakeProof::decode(buf.as_ref()).unwrap();
+
+    let seed: [u8; 32] = Sha256::digest(agent_id.as_bytes()).into();
+    let vk = ed25519_dalek::SigningKey::from_bytes(&seed).verifying_key();
+    assert_eq!(proof.public_key, hex::encode(vk.to_bytes()));
+    let mut signed_payload = nonce.clone();
+    signed_payload.extend_from_slice(proof.sdk_version.as_bytes());
+    let sig: [u8; 64] = proof.signature.as_slice().try_into().unwrap();
+    let vk2 = VerifyingKey::from_bytes(&vk.to_bytes()).unwrap();
+    vk2
+      .verify(&signed_payload, &Signature::from_bytes(&sig))
+      .expect("client handshake proof must verify");
+
+    proof.sdk_version
+  }
+
   /// A `queryPolicy` against a runtime that answers `PolicyQuery` with a Deny
   /// `CheckActionResponse` returns `"deny"` to the JS caller. Mirrors the
   /// shared client's `query_policy_returns_runtime_decision` test, but drives
@@ -340,6 +415,10 @@ mod tests {
     // length-delimiter varint is a single byte.
     let server = tokio::spawn(async move {
       let (mut stream, _) = listener.accept().await.unwrap();
+      // AAASM-3587/3683: the client completes the signed handshake first; assert
+      // the FFI-forwarded version reaches the proof.
+      let signed_version = server_handshake(&mut stream, TEST_AGENT_ID).await;
+      assert_eq!(signed_version, TEST_SDK_VERSION);
       assert_eq!(stream.read_u8().await.unwrap(), codec::TAG_HEARTBEAT);
       assert_eq!(stream.read_u8().await.unwrap(), codec::TAG_POLICY_QUERY);
       let len = stream.read_u8().await.unwrap() as usize;
@@ -364,7 +443,12 @@ mod tests {
       tokio::time::sleep(Duration::from_millis(200)).await;
     });
 
-    let ipc = spawn_ipc_thread(PathBuf::from(&socket_path)).unwrap();
+    let ipc = spawn_ipc_thread(
+      PathBuf::from(&socket_path),
+      TEST_AGENT_ID.to_string(),
+      TEST_SDK_VERSION.to_string(),
+    )
+    .unwrap();
     let handle = ClientHandle {
       inner: Arc::new(AssemblyClient::new(ipc, Vec::new())),
     };
@@ -401,7 +485,12 @@ mod tests {
     let socket_path = format!("/tmp/aa-ffi-node-noserver-{}.sock", std::process::id());
     let _ = std::fs::remove_file(&socket_path);
 
-    let ipc = spawn_ipc_thread(PathBuf::from(&socket_path)).unwrap();
+    let ipc = spawn_ipc_thread(
+      PathBuf::from(&socket_path),
+      TEST_AGENT_ID.to_string(),
+      TEST_SDK_VERSION.to_string(),
+    )
+    .unwrap();
     let handle = ClientHandle {
       inner: Arc::new(AssemblyClient::new(ipc, Vec::new())),
     };

--- a/src/native/client.ts
+++ b/src/native/client.ts
@@ -39,11 +39,31 @@ export interface RegisterOptions {
 }
 
 interface NativeBinding {
-  connect: (socketPath: string) => Promise<object>;
+  connect: (socketPath: string, agentId?: string, sdkVersion?: string) => Promise<object>;
   sendEvent: (handle: object, event: unknown) => void;
   queryPolicy: (handle: object, query: unknown) => Promise<NativePolicyDecision>;
   register?: (handle: object, options: RegisterOptions) => Promise<string>;
   disconnect: (handle: object) => Promise<void>;
+}
+
+/**
+ * Resolve the installed `@agent-assembly/sdk` package version, or `undefined`.
+ *
+ * Forwarded into the native `connect` so the user-facing npm package version —
+ * not the shared `aa-sdk-client` crate version — is what gets signed into the
+ * runtime handshake, giving accurate downgrade detection (AAASM-3683).
+ * `undefined` lets the native shim fall back to the crate version (no
+ * regression vs AAASM-3666). Uses `createRequire(<cwd>/package.json)`, the same
+ * ESM/CJS-safe pattern as the native-binding and runtime-binary resolvers.
+ */
+export function resolveSdkVersion(): string | undefined {
+  try {
+    const requireFromHere = createRequire(path.resolve(process.cwd(), "package.json"));
+    const pkg = requireFromHere("@agent-assembly/sdk/package.json") as { version?: string };
+    return typeof pkg.version === "string" && pkg.version.length > 0 ? pkg.version : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 const NATIVE_BINDING_SINGLETON_KEY = Symbol.for("@agent-assembly/sdk/native-binding");
@@ -201,9 +221,13 @@ export function createNativeClient(options: InitAssemblyOptions): NativeClient {
   let activeHandle: object | undefined;
   let pendingSendError: Error | undefined;
 
+  const sdkVersion = resolveSdkVersion();
+
   const getHandle = async (): Promise<object> => {
     handlePromise ??= binding
-      .connect(socketPath)
+      // Forward the npm package version so it is signed into the handshake
+      // (AAASM-3683); agent id is wired at register time, not connect.
+      .connect(socketPath, undefined, sdkVersion)
       .then((handle) => {
         activeHandle = handle;
         return handle;

--- a/tests/native-client.test.ts
+++ b/tests/native-client.test.ts
@@ -49,7 +49,13 @@ describe("createNativeClient", () => {
       } satisfies MockBinding;
 
       const mod = await loadNativeClientWithRequire(() => {
-        return () => {
+        return (request: string) => {
+          // Count only the native-binding load (the thing under test for
+          // caching); the AAASM-3683 package.json version lookup uses its own
+          // require and must not inflate this count.
+          if (request === "@agent-assembly/sdk/package.json") {
+            return { version: "0.0.0-test" };
+          }
           requireCallCount += 1;
           return binding;
         };
@@ -128,7 +134,10 @@ describe("createNativeClient", () => {
     });
     expect(binding.queryPolicy).toHaveBeenCalledWith({ id: "handle-1" }, query);
 
-    expect(binding.connect).toHaveBeenCalledWith("/tmp/aa.sock");
+    // AAASM-3683: connect now also receives the agent id (wired at register
+    // time, so undefined here) and the resolved sdk_version. Under the mocked
+    // createRequire the package.json lookup yields no version, so it is undefined.
+    expect(binding.connect).toHaveBeenCalledWith("/tmp/aa.sock", undefined, undefined);
     await expect(client.close()).resolves.toBeUndefined();
     expect(binding.disconnect).toHaveBeenCalledTimes(1);
   });
@@ -409,5 +418,55 @@ describe("createNativeClient", () => {
         mode: "napi-inprocess"
       })
     ).toThrow(mod.NativeConnectError);
+  });
+
+  // AAASM-3683: the npm package version is read and forwarded into connect so it
+  // — not the aa-sdk-client crate version — is what gets signed into the
+  // handshake for accurate downgrade detection.
+  it("forwards the resolved sdk_version into the native connect", async () => {
+    const binding = {
+      connect: vi.fn(async () => ({ id: "handle-vers" })),
+      sendEvent: vi.fn(() => undefined),
+      queryPolicy: vi.fn(() => ({ decision: "allow", reason: "" })),
+      disconnect: vi.fn(async () => undefined)
+    } satisfies MockBinding;
+
+    // A require that yields the package version for the package.json lookup and
+    // the binding for the native module path.
+    const mod = await loadNativeClientWithRequire(() => (request: string) => {
+      if (request === "@agent-assembly/sdk/package.json") {
+        return { version: "9.8.7" };
+      }
+      return binding;
+    });
+
+    const client = mod.createNativeClient({
+      gateway: "/tmp/aa.sock",
+      apiKey: "test-key",
+      mode: "napi-inprocess"
+    });
+    await client.queryPolicy({ action: "warmup" });
+
+    expect(binding.connect).toHaveBeenCalledWith("/tmp/aa.sock", undefined, "9.8.7");
+    await client.close();
+  });
+
+  it("resolveSdkVersion returns the package version when present", async () => {
+    const mod = await loadNativeClientWithRequire(() => (request: string) => {
+      if (request === "@agent-assembly/sdk/package.json") {
+        return { version: "1.2.3" };
+      }
+      throw new Error("unexpected require");
+    });
+
+    expect(mod.resolveSdkVersion()).toBe("1.2.3");
+  });
+
+  it("resolveSdkVersion returns undefined when the version cannot be resolved", async () => {
+    const mod = await loadNativeClientWithRequire(() => () => {
+      throw new Error("package.json not found");
+    });
+
+    expect(mod.resolveSdkVersion()).toBeUndefined();
   });
 });

--- a/tests/native-napi-integration.test.ts
+++ b/tests/native-napi-integration.test.ts
@@ -24,9 +24,31 @@ const TAG_POLICY_QUERY = 1;
 const TAG_EVENT_REPORT = 2;
 const TAG_HEARTBEAT = 4;
 const TAG_ACK = 3;
+// SDK → runtime signed handshake proof (AAASM-3587). The runtime issues the
+// challenge first; the SDK replies with this frame before any other traffic.
+const TAG_HANDSHAKE_PROOF = 5;
 // Inbound (runtime → SDK) policy-response tag.
 const TAG_POLICY_RESPONSE = 1;
+// Runtime → SDK handshake challenge (AAASM-3587), the first frame the runtime
+// sends on connect.
+const TAG_HANDSHAKE_CHALLENGE = 5;
 const ACK_FRAME = Buffer.from([TAG_ACK, 0x00]);
+
+// A `HandshakeChallenge { nonce: bytes }` (proto field 1, wire type 2) carrying
+// a fixed 32-byte nonce, framed as [tag, length-delimiter varint, body]. The
+// real runtime issues a random nonce; the mock only needs a decodable challenge
+// so the client completes the AAASM-3587 handshake and starts shipping events.
+// The mock does not verify the resulting proof — that is the authoritative
+// runtime's job; here the handshake just has to advance so the event flow opens.
+const HANDSHAKE_NONCE = Buffer.alloc(32, 0x5a);
+const HANDSHAKE_CHALLENGE_BODY = Buffer.concat([
+  Buffer.from([0x0a, HANDSHAKE_NONCE.length]),
+  HANDSHAKE_NONCE
+]);
+const HANDSHAKE_CHALLENGE_FRAME = Buffer.concat([
+  Buffer.from([TAG_HANDSHAKE_CHALLENGE, HANDSHAKE_CHALLENGE_BODY.length]),
+  HANDSHAKE_CHALLENGE_BODY
+]);
 // A `CheckActionResponse { decision: ALLOW }` — proto field 1 (varint) = 1.
 // Framed as [tag, length-delimiter varint, body]; the 2-byte body fits in a
 // single-byte length varint. The runtime answers a policy-query with this,
@@ -69,17 +91,21 @@ interface MockRuntime {
 
 /**
  * Minimal mock of the aa-runtime UDS endpoint. It speaks just enough of the
- * wire codec to keep the shared client's background IPC thread alive — ACKing
- * every heartbeat / event-report frame, answering a policy-query with an
- * allow `PolicyResponse` (as the real runtime does — an Ack would leave the
- * query blocked until its 5s timeout), and counting the event-report frames it
- * receives. It performs no scanning or redaction; that is the authoritative
- * runtime's job, not the SDK's.
+ * wire codec to keep the shared client's background IPC thread alive — issuing
+ * the AAASM-3587 handshake challenge on connect and consuming the SDK's signed
+ * proof, ACKing every heartbeat / event-report frame, answering a policy-query
+ * with an allow `PolicyResponse` (as the real runtime does — an Ack would leave
+ * the query blocked until its 5s timeout), and counting the event-report frames
+ * it receives. It performs no scanning, redaction, or proof verification; that
+ * is the authoritative runtime's job, not the SDK's.
  */
 function startMockRuntime(socketPath: string): Promise<MockRuntime> {
   let events = 0;
   const server = net.createServer((sock) => {
     let buf = Buffer.alloc(0);
+    // AAASM-3587: the runtime sends the handshake challenge first; the client's
+    // IPC thread completes the handshake (fail-closed) before any other traffic.
+    sock.write(HANDSHAKE_CHALLENGE_FRAME);
     sock.on("data", (chunk: Buffer) => {
       buf = Buffer.concat([buf, chunk]);
       let offset = 0;
@@ -89,6 +115,16 @@ function startMockRuntime(socketPath: string): Promise<MockRuntime> {
         if (tag === TAG_HEARTBEAT) {
           offset += 1;
           sock.write(ACK_FRAME);
+          continue;
+        }
+        if (tag === TAG_HANDSHAKE_PROOF) {
+          // Length-delimited proof frame; consume and discard it (the mock does
+          // not verify the proof). Wait for the whole frame before advancing.
+          const varint = readVarint(buf, offset + 1);
+          if (!varint) break;
+          const frameEnd = offset + 1 + varint.bytes + varint.value;
+          if (frameEnd > buf.length) break;
+          offset = frameEnd;
           continue;
         }
         if (tag === TAG_EVENT_REPORT || tag === TAG_POLICY_QUERY) {


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Follow-up to agent-assembly AAASM-3683. AAASM-3666 signs an `sdk_version` into the IPC handshake, but it was sourced from the shared `aa-sdk-client` crate version. This PR makes the Node SDK forward its **npm package version** through the FFI so the version signed into the handshake reflects the installed `@agent-assembly/sdk` release, giving AAASM-3571 accurate downgrade detection.

* ### Task tickets:

    * Task ID: AAASM-3683.
    * Relative task IDs:
        * AAASM-3666, AAASM-3571, AAASM-3415
    * Relative PRs:
        * agent-assembly PR #1226 (re-pin to its squash-merge SHA before merge)

* ### Key point change:

    * Re-pins `aa-sdk-client`/`aa-proto` to agent-assembly AAASM-3683 (adds `sdk_version` to `AssemblyConfig` + threads it through `spawn_ipc_thread`). **Must be re-pinned to the squash-merge SHA once PR #1226 lands.**
    * `connect` now accepts optional `agentId` / `sdkVersion` and passes them into `spawn_ipc_thread`.
    * `createNativeClient` resolves the installed `@agent-assembly/sdk` version (`resolveSdkVersion`, via `createRequire` of the package.json) and forwards it; `undefined` falls back to the crate version (no regression vs 3666).

## _Effecting Scope_

* Action Types:
    * [x] ✨ Adding new something
        * [x] 🟢 No breaking change
* Scopes:
    * [x] 🪡 API client and transport
    * [x] 🔗 Dependencies
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing

* Additional description:

    Testing: `pnpm typecheck`, `pnpm lint`, `pnpm native:build`, and `pnpm test` (337 passed, 2 skipped) all green locally. The mock-server Rust test in `aa-ffi-node` performs the handshake and asserts the FFI-passed version reaches the signed proof (run with `RUSTFLAGS="-C link-arg=-undefined -C link-arg=dynamic_lookup" cargo test`, the macOS napi-link workaround). New vitest tests assert `connect` is called with the resolved version and `resolveSdkVersion` reads the package.json version.

## _Description_

* `native/aa-ffi-node`: `connect(socketPath, agentId?, sdkVersion?)` forwards into the handshake; pin bumped; mock server now does the AAASM-3587 handshake.
* `src/native/client.ts`: `resolveSdkVersion()` + forwards it into `connect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
