### PR TITLE
[AAASM-3693] 📝 (docs/examples): Update SDK version refs to 0.0.1-beta.4

### DIFF
--- a/docs/09-examples/custom-tool-policy.md
+++ b/docs/09-examples/custom-tool-policy.md
@@ -21,7 +21,7 @@ the policy first.
 
 ## The framework / library
 
-None. The example depends only on `@agent-assembly/sdk` (version `0.0.1-alpha.9.1`
+None. The example depends only on `@agent-assembly/sdk` (version `0.0.1-beta.4`
 in its `package.json`). It runs fully offline — no gateway and no `@langchain/core`.
 
 ## How it works

--- a/docs/09-examples/langchain-js-basic-agent.md
+++ b/docs/09-examples/langchain-js-basic-agent.md
@@ -20,7 +20,7 @@ on every tool call the agent makes.
 ## The framework / library
 
 [LangChain.js](https://js.langchain.com)-style agent. The example depends only on
-`@agent-assembly/sdk` (version `0.0.1-alpha.9.1`); it deliberately avoids
+`@agent-assembly/sdk` (version `0.0.1-beta.4`); it deliberately avoids
 `@langchain/core` so it runs fully offline in CI with no API keys.
 
 ## How it works

--- a/docs/09-examples/langgraph-js.md
+++ b/docs/09-examples/langgraph-js.md
@@ -21,7 +21,7 @@ originates — including from inside a graph node.
 ## The framework / library
 
 A hand-rolled [LangGraph.js](https://langchain-ai.github.io/langgraphjs/)-style graph.
-The example depends only on `@agent-assembly/sdk` (version `0.0.1-alpha.9.1`).
+The example depends only on `@agent-assembly/sdk` (version `0.0.1-beta.4`).
 
 :::note Why a hand-rolled graph instead of `@langchain/langgraph`
 The real `@langchain/langgraph` package transitively installs `@langchain/core`. These

--- a/docs/09-examples/mastra.md
+++ b/docs/09-examples/mastra.md
@@ -22,7 +22,7 @@ wrapping their `execute` through `withAssembly`.
 
 [Mastra](https://mastra.ai) — the real `@mastra/core` package (version `^1.0.0` in
 `package.json`), plus `zod` (`^3.25.76`) for the tool schemas and
-`@agent-assembly/sdk` (version `0.0.1-alpha.9.1`). It runs fully offline — no provider
+`@agent-assembly/sdk` (version `0.0.1-beta.4`). It runs fully offline — no provider
 key and no live LLM.
 
 ## How it works

--- a/docs/09-examples/openai-node-tool-policy.md
+++ b/docs/09-examples/openai-node-tool-policy.md
@@ -21,7 +21,7 @@ dispatched through `withAssembly`, so every dispatch is policy-checked before it
 ## The framework / library
 
 OpenAI function-calling format (tool schemas), used without a live OpenAI client.
-The example depends only on `@agent-assembly/sdk` (version `0.0.1-alpha.9.1`) and runs
+The example depends only on `@agent-assembly/sdk` (version `0.0.1-beta.4`) and runs
 fully offline — no gateway and no `@langchain/core`.
 
 ## How it works

--- a/docs/09-examples/setup.md
+++ b/docs/09-examples/setup.md
@@ -16,7 +16,7 @@ can focus on what each example actually demonstrates.
 - **pnpm** — install via `npm install -g pnpm`.
 
 Every example pins `@agent-assembly/sdk` (the [`node-sdk`](https://github.com/ai-agent-assembly/node-sdk)
-package, version `0.0.1-alpha.9.1` at the time of writing) as its only required
+package, version `0.0.1-beta.4` at the time of writing) as its only required
 dependency. The framework-specific examples add one extra package each
 (`@mastra/core` for Mastra, `ai` for the Vercel AI SDK).
 

--- a/docs/09-examples/vercel-ai.md
+++ b/docs/09-examples/vercel-ai.md
@@ -22,7 +22,7 @@ top by wrapping the tool map.
 
 [Vercel AI SDK](https://sdk.vercel.ai) — the real `ai` package (version `^6.0.0` in
 `package.json`), plus `zod` (`^3.25.76`) for input schemas and `@agent-assembly/sdk`
-(version `0.0.1-alpha.9.1`). It runs fully offline — no provider key and no live LLM.
+(version `0.0.1-beta.4`). It runs fully offline — no provider key and no live LLM.
 
 ## How it works
 


### PR DESCRIPTION
## _Target_

Pre-release QA fix (AAASM-3693): the examples documentation under `docs/09-examples/`
cited a stale SDK version `0.0.1-alpha.9.1`, while the package is now `0.0.1-beta.4`
(`package.json` `version`) and the quick-start docs already say beta.4.

* ### Task summary:

    Updated the SDK version reference from `0.0.1-alpha.9.1` to `0.0.1-beta.4`
    across the seven live example pages. Historical `website/versioned_docs/`
    snapshots were intentionally left untouched.

* ### Task tickets:

    * Task ID: AAASM-3693.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    Files changed (all `docs/09-examples/`): `setup.md`, `mastra.md`,
    `langgraph-js.md`, `vercel-ai.md`, `langchain-js-basic-agent.md`,
    `openai-node-tool-policy.md`, `custom-tool-policy.md`.

## _Effecting Scope_

* Action Types:
    * [x] 🔧 Fixing bug
* Scopes:
    * [x] 📚 Documentation
* Additional description:
    Docs-only. No code, build, or runtime impact.

## _Description_

* Replaced `0.0.1-alpha.9.1` with `0.0.1-beta.4` (one occurrence per file) in the
  seven example pages so the documented SDK version matches `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
