### PR TITLE
[AAASM-3694] 📝 (docs/release): Fix org id case to ai-agent-assembly in RUNBOOK

### DIFF
--- a/docs/release/RUNBOOK.md
+++ b/docs/release/RUNBOOK.md
@@ -6,7 +6,7 @@
 > story) and AAASM-2858 (this runbook).
 
 This runbook assumes the operator has push rights to
-`AI-agent-assembly/node-sdk` and that the five `@agent-assembly/*` npm
+`ai-agent-assembly/node-sdk` and that the five `@agent-assembly/*` npm
 packages have `@agent-assembly/release-bot` configured as their npm
 Trusted Publisher with the node-sdk repo + `release-node.yml` workflow path.
 


### PR DESCRIPTION
## _Target_

Pre-release QA fix (AAASM-3694): `docs/release/RUNBOOK.md` referenced the org id
with the wrong case (`AI-agent-assembly/node-sdk`). Project policy: the org id is
lowercase `ai-agent-assembly` everywhere.

* ### Task summary:

    Fixed the org id case on line 9 of `docs/release/RUNBOOK.md`
    (`AI-agent-assembly/node-sdk` → `ai-agent-assembly/node-sdk`). The other two
    `--repo` references in the file were already lowercase-correct. Historical
    `website/versioned_docs/` snapshots were left untouched.

* ### Task tickets:

    * Task ID: AAASM-3694.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    Single-line change in `docs/release/RUNBOOK.md`.

## _Effecting Scope_

* Action Types:
    * [x] 🔧 Fixing bug
* Scopes:
    * [x] 📚 Documentation
* Additional description:
    Docs-only. No code, build, or runtime impact.

## _Description_

* Lowercased the org id in the runbook's push-rights precondition line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
