### PR TITLE
[AAASM-3707] 🔖 (release): node-sdk v0.0.1-beta.5

### DIFF
--- a/docs/02-quick-start/index.md
+++ b/docs/02-quick-start/index.md
@@ -23,7 +23,7 @@ platform during `postinstall`, so there is no extra build step for typical consu
 The current release line is `0.0.1-beta.x`, published under the npm `beta`
 dist-tag. The public surface (`initAssembly`, `withAssembly`) is stabilizing but may
 change between pre-releases. Pin an exact version for reproducible installs:
-`npm install @agent-assembly/sdk@0.0.1-beta.4`.
+`npm install @agent-assembly/sdk@0.0.1-beta.5`.
 :::
 
 ## 2. Make sure a gateway is reachable

--- a/docs/09-examples/custom-tool-policy.md
+++ b/docs/09-examples/custom-tool-policy.md
@@ -21,7 +21,7 @@ the policy first.
 
 ## The framework / library
 
-None. The example depends only on `@agent-assembly/sdk` (version `0.0.1-beta.4`
+None. The example depends only on `@agent-assembly/sdk` (version `0.0.1-beta.5`
 in its `package.json`). It runs fully offline — no gateway and no `@langchain/core`.
 
 ## How it works

--- a/docs/09-examples/langchain-js-basic-agent.md
+++ b/docs/09-examples/langchain-js-basic-agent.md
@@ -20,7 +20,7 @@ on every tool call the agent makes.
 ## The framework / library
 
 [LangChain.js](https://js.langchain.com)-style agent. The example depends only on
-`@agent-assembly/sdk` (version `0.0.1-beta.4`); it deliberately avoids
+`@agent-assembly/sdk` (version `0.0.1-beta.5`); it deliberately avoids
 `@langchain/core` so it runs fully offline in CI with no API keys.
 
 ## How it works

--- a/docs/09-examples/langgraph-js.md
+++ b/docs/09-examples/langgraph-js.md
@@ -21,7 +21,7 @@ originates — including from inside a graph node.
 ## The framework / library
 
 A hand-rolled [LangGraph.js](https://langchain-ai.github.io/langgraphjs/)-style graph.
-The example depends only on `@agent-assembly/sdk` (version `0.0.1-beta.4`).
+The example depends only on `@agent-assembly/sdk` (version `0.0.1-beta.5`).
 
 :::note Why a hand-rolled graph instead of `@langchain/langgraph`
 The real `@langchain/langgraph` package transitively installs `@langchain/core`. These

--- a/docs/09-examples/mastra.md
+++ b/docs/09-examples/mastra.md
@@ -22,7 +22,7 @@ wrapping their `execute` through `withAssembly`.
 
 [Mastra](https://mastra.ai) — the real `@mastra/core` package (version `^1.0.0` in
 `package.json`), plus `zod` (`^3.25.76`) for the tool schemas and
-`@agent-assembly/sdk` (version `0.0.1-beta.4`). It runs fully offline — no provider
+`@agent-assembly/sdk` (version `0.0.1-beta.5`). It runs fully offline — no provider
 key and no live LLM.
 
 ## How it works

--- a/docs/09-examples/openai-node-tool-policy.md
+++ b/docs/09-examples/openai-node-tool-policy.md
@@ -21,7 +21,7 @@ dispatched through `withAssembly`, so every dispatch is policy-checked before it
 ## The framework / library
 
 OpenAI function-calling format (tool schemas), used without a live OpenAI client.
-The example depends only on `@agent-assembly/sdk` (version `0.0.1-beta.4`) and runs
+The example depends only on `@agent-assembly/sdk` (version `0.0.1-beta.5`) and runs
 fully offline — no gateway and no `@langchain/core`.
 
 ## How it works

--- a/docs/09-examples/setup.md
+++ b/docs/09-examples/setup.md
@@ -16,7 +16,7 @@ can focus on what each example actually demonstrates.
 - **pnpm** — install via `npm install -g pnpm`.
 
 Every example pins `@agent-assembly/sdk` (the [`node-sdk`](https://github.com/ai-agent-assembly/node-sdk)
-package, version `0.0.1-beta.4` at the time of writing) as its only required
+package, version `0.0.1-beta.5` at the time of writing) as its only required
 dependency. The framework-specific examples add one extra package each
 (`@mastra/core` for Mastra, `ai` for the Vercel AI SDK).
 

--- a/docs/09-examples/vercel-ai.md
+++ b/docs/09-examples/vercel-ai.md
@@ -22,7 +22,7 @@ top by wrapping the tool map.
 
 [Vercel AI SDK](https://sdk.vercel.ai) — the real `ai` package (version `^6.0.0` in
 `package.json`), plus `zod` (`^3.25.76`) for input schemas and `@agent-assembly/sdk`
-(version `0.0.1-beta.4`). It runs fully offline — no provider key and no live LLM.
+(version `0.0.1-beta.5`). It runs fully offline — no provider key and no live LLM.
 
 ## How it works
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/sdk",
-  "version": "0.0.1-beta.4",
+  "version": "0.0.1-beta.5",
   "description": "TypeScript SDK for Agent Assembly",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

* ### Task summary:

    **Release-intent PR for node-sdk `@agent-assembly/sdk@0.0.1-beta.5`.** Bumps the local-dev `package.json` version `0.0.1-beta.4` → `0.0.1-beta.5` on the published beta line. This is **PREP ONLY** — it does **not** tag, publish, or trigger any release. After this merges and the owner gives the go, the operator dispatches `release-node.yml` (see publish command below).

    The npm publish version is supplied at release time via `release-node.yml`'s `npm_version` dispatch input; the `package.json` `version` field is local-dev metadata only (matching the established convention from the beta.4 bump commit `81516e11`).

* ### Task tickets:

    * Task ID: AAASM-3707.
    * Relative task IDs:
        * [x] AAASM-3503 (release workflow is `workflow_dispatch`-only; no auto-publish on core `repository_dispatch` — fix merged via #171, present on master).
    * Relative PRs:
        * #171 (AAASM-3503 release operator-gating).

* ### Key point change (optional):

    Single-line change: root `package.json` `"version"` `0.0.1-beta.4` → `0.0.1-beta.5`. The 4 `@agent-assembly/runtime-*` sub-packages and the root `optionalDependencies` (`workspace:*`) are intentionally **not** touched — `release-node.yml`'s "Bump versions across the 5 packages" step rewrites all of them to the dispatch `npm_version` at publish time. This matches the beta.4 release tree exactly (sub-packages stayed at `0.0.1-alpha.4`). No `pnpm-lock.yaml` change is needed — the lockfile does not pin the root package's own version.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
## _Effecting Scope_

* Action Types:
    * [x] 🚀 Release
* Scopes:
    * [x] 🚀 Building
        * [x] 📦 Project configurations
* Additional description:

    Highlights since `v0.0.1-beta.4` (62 commits). Derived from `git log v0.0.1-beta.4..master`:

    * **Security / credential hygiene (AAASM-3645):** scrub credentials from the registration-failure warning; add `redactSecrets`/`redactErrorMessage` helpers; test that `apiKey`/`credentialToken` never reach console output.
    * **Native binding (AAASM-3587):** forward `agent_id` + `sdk_version` through `connect`; read the npm package version and pass it to `connect`; bump `aa-sdk-client` pin to the `sdk_version`-passthrough SHA; drive the handshake in the native UDS mock runtime.
    * **Supply-chain:** generate + attach a CycloneDX SBOM per release; add a pnpm advisory gate workflow; wire dependency-audit into the `CI Success` gate; document canonical package names + supply-chain verification.
    * **Op-control kill switch:** wire the op-control kill switch into `withAssembly`; export `OpControlSubscriber` from the package entrypoint; lazy-load gRPC so the SDK import stays gRPC-free (+ regression tests).
    * **Vercel `ai` adapter (AAASM-3532):** patch the Vercel adapter via a shim instead of mutating frozen ESM; cover the real frozen-`ai` patch path; install real `ai` for adapter testing.
    * **Docs site:** enable local search; wire consent-gated GA4 analytics + cookie-consent banner; add a "Was this page helpful?" feedback widget; document the framework compatibility matrix.
    * **CI / release (AAASM-3503):** make the SDK release operator-dispatch only (no auto-publish on core `repository_dispatch`).
    * **Dependency bumps:** `napi` 3.9.3→3.9.4, `napi-derive` 3.5.6→3.5.7, `rand` 0.8.6→0.10.1, `sha2` 0.10.9→0.11.0, `actions/upload-artifact` 4.6.2→7.0.1.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Bump root `package.json` version `0.0.1-beta.4` → `0.0.1-beta.5`.

---

**Release-intent — publish after merge + owner go.** Do not merge this PR before the owner approves the release. After merge, the operator publishes via `release-node.yml` `workflow_dispatch` (see the dispatch command in the ticket / handoff). This PR itself does **not** tag, publish, or trigger any workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
