### PR TITLE
🤖 (aa-ffi-node): Bump agent-assembly git pins to v0.0.1-beta.4

### DIFF
--- a/native/aa-ffi-node/Cargo.lock
+++ b/native/aa-ffi-node/Cargo.lock
@@ -22,8 +22,8 @@ dependencies = [
 
 [[package]]
 name = "aa-proto"
-version = "0.0.1-beta.3"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=b0576a72422bad7c6f380e666aa6ad70d1939822#b0576a72422bad7c6f380e666aa6ad70d1939822"
+version = "0.0.1-beta.4"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=743646f0080b33df675db3d6a0e37efedbc49f79#743646f0080b33df675db3d6a0e37efedbc49f79"
 dependencies = [
  "prost",
  "tonic",
@@ -33,8 +33,8 @@ dependencies = [
 
 [[package]]
 name = "aa-sdk-client"
-version = "0.0.1-beta.3"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=b0576a72422bad7c6f380e666aa6ad70d1939822#b0576a72422bad7c6f380e666aa6ad70d1939822"
+version = "0.0.1-beta.4"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=743646f0080b33df675db3d6a0e37efedbc49f79#743646f0080b33df675db3d6a0e37efedbc49f79"
 dependencies = [
  "aa-proto",
  "aa-security",
@@ -51,8 +51,8 @@ dependencies = [
 
 [[package]]
 name = "aa-security"
-version = "0.0.1-beta.3"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=b0576a72422bad7c6f380e666aa6ad70d1939822#b0576a72422bad7c6f380e666aa6ad70d1939822"
+version = "0.0.1-beta.4"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=743646f0080b33df675db3d6a0e37efedbc49f79#743646f0080b33df675db3d6a0e37efedbc49f79"
 dependencies = [
  "aho-corasick",
 ]

--- a/native/aa-ffi-node/Cargo.toml
+++ b/native/aa-ffi-node/Cargo.toml
@@ -26,8 +26,8 @@ crate-type = ["cdylib"]
 # downgrade detection reflects the installed @agent-assembly/sdk release.
 # Re-pin to the squash-merge commit once PR #1226 lands on master. (Prior pin
 # ebc4d7dc / AAASM-3415 added `team_id` / `parent_agent_id`, still forwarded.)
-aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "b0576a72422bad7c6f380e666aa6ad70d1939822", package = "aa-sdk-client" }
-aa-proto = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "b0576a72422bad7c6f380e666aa6ad70d1939822", package = "aa-proto" }
+aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "743646f0080b33df675db3d6a0e37efedbc49f79", package = "aa-sdk-client" }
+aa-proto = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "743646f0080b33df675db3d6a0e37efedbc49f79", package = "aa-proto" }
 napi = { version = "3", default-features = false, features = ["napi8", "tokio_rt", "serde-json"] }
 napi-derive = "3"
 prost = "0.14"


### PR DESCRIPTION
Auto-bump every agent-assembly git-SHA pin (`aa-sdk-client`,
`aa-proto`, and any other shared crate) in
`native/aa-ffi-node/Cargo.toml` to track agent-assembly release
`v0.0.1-beta.4` (commit `743646f0080b33df675db3d6a0e37efedbc49f79`).

Per ADR 0003 all aa-* git deps must share one rev so cargo resolves
a single checkout of the agent-assembly workspace; this PR bumps them
in lockstep (AAASM-3468).

Why: without this PR, the SDK source pin drifts behind the published
agent-assembly binaries (AAASM-2880 observed an 8-day drift behind
alpha-9). Merging this PR on `node-sdk` realigns the native shim
with the matching upstream tag.

Upstream tag: https://github.com/ai-agent-assembly/agent-assembly/releases/tag/v0.0.1-beta.4
Source workflow: https://github.com/ai-agent-assembly/agent-assembly/actions/runs/28144287756