### PR TITLE
[AAASM-3723] 🐛 (ci): Fix CycloneDX SBOM npm-ls tree check in release-node.yml

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -303,8 +303,19 @@ jobs:
       # provenance (NPM_CONFIG_PROVENANCE above). Runs on every dispatch
       # (incl. dry-run) so a dry-run validates generation; the real-publish
       # path attaches it to the GitHub Release below.
+      #
+      # AAASM-3723: this repo installs with `pnpm install --frozen-lockfile`,
+      # so node_modules is pnpm's symlinked layout with no package-lock.json.
+      # cyclonedx-npm shells out to `npm ls` to walk the tree, which flags
+      # devDependencies of transitive deps (e.g. safe-publish-latest required
+      # by math-intrinsics) as "missing" and exits non-zero — aborting the
+      # release before publish. `--omit dev` builds a production-only tree
+      # (the right scope for a release SBOM anyway), and `--ignore-npm-errors`
+      # tolerates the residual npm-ls noise from the pnpm node_modules layout.
+      # This is purely the dependency-manifest step; it does not touch the
+      # OIDC trusted-publish / SLSA provenance path below.
       - name: Generate CycloneDX SBOM
-        run: pnpm dlx @cyclonedx/cyclonedx-npm --output-format JSON --output-file sbom.cdx.json
+        run: pnpm dlx @cyclonedx/cyclonedx-npm --omit dev --ignore-npm-errors --output-format JSON --output-file sbom.cdx.json
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Description

Fixes the node beta.5 release dry-run failure ([run 28152202879](https://github.com/ai-agent-assembly/node-sdk/actions/runs/28152202879)). The failing step was **Generate CycloneDX SBOM** (inside the publish job), not the publish/provenance itself:
```
npm error missing: safe-publish-latest@^2.0.0, required by math-intrinsics@1.1.0
...
Error: npm-ls exited with errors: 1   (exit 254)
```

**Root cause:** the job installs with `pnpm install --frozen-lockfile` (pnpm's symlinked `node_modules`, no `package-lock.json`). `@cyclonedx/cyclonedx-npm` shells out to `npm ls` to walk the tree, which flags **devDependencies of transitive deps** (e.g. `safe-publish-latest` required by `math-intrinsics`) as "missing" and exits non-zero — aborting the release before publish.

**Fix:** `pnpm dlx @cyclonedx/cyclonedx-npm --omit dev --ignore-npm-errors …` — a production-only tree (the correct scope for a release SBOM) plus tolerance for the residual `npm ls` noise from pnpm's layout. This is purely the dependency-manifest step; the **OIDC trusted-publish + SLSA provenance path is untouched**.

**Verified:** re-ran the dry-run on this branch — the publish job is `completed:success` (run 28152672806); docs snapshot correctly skipped; nothing published.

## Type of Change
- [x] 🐛 Bug fix (CI)

## Related Issues
- Closes AAASM-3723 · surfaced by the AAASM-3707 (node beta.5) GATE-2 dry-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
