### PR TITLE
[AAASM-3759] 🔧 (docs): Point node-sdk canonical/OG URLs to docs.agent-assembly.com

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -27,7 +27,13 @@ const config: Config = {
     v4: true,
   },
 
-  url: "https://ai-agent-assembly.github.io",
+  // Production docs origin. Docusaurus derives the emitted `<link
+  // rel="canonical">` and OpenGraph `og:url` from `url` + `baseUrl`, so this
+  // points at the custom docs domain the hub serves the module under
+  // (https://docs.agent-assembly.com/node-sdk/...). The GitHub Pages
+  // deployment (ai-agent-assembly.github.io/node-sdk/) keeps working as a
+  // mirror because in-site routing is driven by `baseUrl`, not `url`.
+  url: "https://docs.agent-assembly.com",
   baseUrl: "/node-sdk/",
 
   organizationName: "ai-agent-assembly",


### PR DESCRIPTION
## _Target_

Docs now live at `docs.agent-assembly.com`, but the node-sdk Docusaurus site still emitted its `canonical` link and OpenGraph `og:url` against the old GitHub Pages origin (`ai-agent-assembly.github.io/node-sdk/...`). Search engines and link unfurlers were being pointed at the legacy mirror origin.

* ### Task summary:

    Repoint the Docusaurus `url` from `https://ai-agent-assembly.github.io` to `https://docs.agent-assembly.com`. Docusaurus derives the emitted `<link rel="canonical">` and `og:url` from `url` + `baseUrl`, so this single change corrects both. `baseUrl` stays `/node-sdk/` (the path the hub serves the module under), and in-site routing is `baseUrl`-relative, so the GitHub Pages deployment keeps working as a mirror.

* ### Task tickets:

    * Task ID: AAASM-3759.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    As-is: `<link rel=canonical href=https://ai-agent-assembly.github.io/node-sdk/...>`
    To-be: `<link rel=canonical href=https://docs.agent-assembly.com/node-sdk/...>` (same for `og:url`).

## _Effecting Scope_

* Action Types:
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
    * [x] 🔧 Fixing bug
* Scopes:
    * [x] 📚 Documentation
* Additional description:
    Only the docs canonical/OG origin is touched. Navbar/footer cross-SDK links still point at the per-site origins and are intentionally left out of scope.

## _Description_

* `website/docusaurus.config.ts`: set `url: "https://docs.agent-assembly.com"` (was `https://ai-agent-assembly.github.io`); `baseUrl` unchanged (`/node-sdk/`).

### Validation

* `pnpm install --ignore-workspace` + `pnpm build` of the Docusaurus site — build **green** (`onBrokenLinks: "throw"`, `onBrokenAnchors: "throw"` both pass; no broken internal links).
* Grepped built HTML: all 249 pages now emit `rel=canonical href=https://docs.agent-assembly.com/node-sdk/...` and `og:url content=https://docs.agent-assembly.com/node-sdk/...`. Zero `github.io` occurrences in any `canonical`/`og:url` tag.
* Versioned-docs switcher / routing unaffected (only the absolute origin used for canonical/OG/sitemap changed; routing is `baseUrl`-driven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cc1vBBiNxp9qLKQ5Gq85w8
