### PR TITLE
[AAASM-3762] 🔖 (release): node-sdk v0.0.1-rc.1

### DIFF
--- a/docs/02-quick-start/index.md
+++ b/docs/02-quick-start/index.md
@@ -23,7 +23,7 @@ platform during `postinstall`, so there is no extra build step for typical consu
 The current release line is `0.0.1-beta.x`, published under the npm `beta`
 dist-tag. The public surface (`initAssembly`, `withAssembly`) is stabilizing but may
 change between pre-releases. Pin an exact version for reproducible installs:
-`npm install @agent-assembly/sdk@0.0.1-beta.5`.
+`npm install @agent-assembly/sdk@0.0.1-rc.1`.
 :::
 
 ## 2. Make sure a gateway is reachable

--- a/docs/09-examples/custom-tool-policy.md
+++ b/docs/09-examples/custom-tool-policy.md
@@ -21,7 +21,7 @@ the policy first.
 
 ## The framework / library
 
-None. The example depends only on `@agent-assembly/sdk` (version `0.0.1-beta.5`
+None. The example depends only on `@agent-assembly/sdk` (version `0.0.1-rc.1`
 in its `package.json`). It runs fully offline — no gateway and no `@langchain/core`.
 
 ## How it works

--- a/docs/09-examples/langchain-js-basic-agent.md
+++ b/docs/09-examples/langchain-js-basic-agent.md
@@ -20,7 +20,7 @@ on every tool call the agent makes.
 ## The framework / library
 
 [LangChain.js](https://js.langchain.com)-style agent. The example depends only on
-`@agent-assembly/sdk` (version `0.0.1-beta.5`); it deliberately avoids
+`@agent-assembly/sdk` (version `0.0.1-rc.1`); it deliberately avoids
 `@langchain/core` so it runs fully offline in CI with no API keys.
 
 ## How it works

--- a/docs/09-examples/langgraph-js.md
+++ b/docs/09-examples/langgraph-js.md
@@ -21,7 +21,7 @@ originates — including from inside a graph node.
 ## The framework / library
 
 A hand-rolled [LangGraph.js](https://langchain-ai.github.io/langgraphjs/)-style graph.
-The example depends only on `@agent-assembly/sdk` (version `0.0.1-beta.5`).
+The example depends only on `@agent-assembly/sdk` (version `0.0.1-rc.1`).
 
 :::note Why a hand-rolled graph instead of `@langchain/langgraph`
 The real `@langchain/langgraph` package transitively installs `@langchain/core`. These

--- a/docs/09-examples/mastra.md
+++ b/docs/09-examples/mastra.md
@@ -22,7 +22,7 @@ wrapping their `execute` through `withAssembly`.
 
 [Mastra](https://mastra.ai) — the real `@mastra/core` package (version `^1.0.0` in
 `package.json`), plus `zod` (`^3.25.76`) for the tool schemas and
-`@agent-assembly/sdk` (version `0.0.1-beta.5`). It runs fully offline — no provider
+`@agent-assembly/sdk` (version `0.0.1-rc.1`). It runs fully offline — no provider
 key and no live LLM.
 
 ## How it works

--- a/docs/09-examples/openai-node-tool-policy.md
+++ b/docs/09-examples/openai-node-tool-policy.md
@@ -21,7 +21,7 @@ dispatched through `withAssembly`, so every dispatch is policy-checked before it
 ## The framework / library
 
 OpenAI function-calling format (tool schemas), used without a live OpenAI client.
-The example depends only on `@agent-assembly/sdk` (version `0.0.1-beta.5`) and runs
+The example depends only on `@agent-assembly/sdk` (version `0.0.1-rc.1`) and runs
 fully offline — no gateway and no `@langchain/core`.
 
 ## How it works

--- a/docs/09-examples/setup.md
+++ b/docs/09-examples/setup.md
@@ -16,7 +16,7 @@ can focus on what each example actually demonstrates.
 - **pnpm** — install via `npm install -g pnpm`.
 
 Every example pins `@agent-assembly/sdk` (the [`node-sdk`](https://github.com/ai-agent-assembly/node-sdk)
-package, version `0.0.1-beta.5` at the time of writing) as its only required
+package, version `0.0.1-rc.1` at the time of writing) as its only required
 dependency. The framework-specific examples add one extra package each
 (`@mastra/core` for Mastra, `ai` for the Vercel AI SDK).
 

--- a/docs/09-examples/vercel-ai.md
+++ b/docs/09-examples/vercel-ai.md
@@ -22,7 +22,7 @@ top by wrapping the tool map.
 
 [Vercel AI SDK](https://sdk.vercel.ai) — the real `ai` package (version `^6.0.0` in
 `package.json`), plus `zod` (`^3.25.76`) for input schemas and `@agent-assembly/sdk`
-(version `0.0.1-beta.5`). It runs fully offline — no provider key and no live LLM.
+(version `0.0.1-rc.1`). It runs fully offline — no provider key and no live LLM.
 
 ## How it works
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/sdk",
-  "version": "0.0.1-beta.5",
+  "version": "0.0.1-rc.1",
   "description": "TypeScript SDK for Agent Assembly",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

* ### Task summary:

    **Release-intent PR for node-sdk `@agent-assembly/sdk@0.0.1-rc.1`.** Bumps the local-dev `package.json` version `0.0.1-beta.5` → `0.0.1-rc.1`, moving from the beta line onto the first release-candidate. This is **PREP ONLY** — it does **not** tag, publish, or trigger any release. After this merges and the owner gives the go, the operator dispatches `release-node.yml` (see publish note below).

    The npm publish version is supplied at release time via `release-node.yml`'s `npm_version` dispatch input (`npm_version=0.0.1-rc.1`); the `package.json` `version` field is local-dev metadata only (matching the established convention from the beta.4 / beta.5 bump commits).

* ### Task tickets:

    * Task ID: AAASM-3762.
    * Mirrors the prior beta.5 release-intent PR #191 (AAASM-3707).

* ### Key point change (optional):

    Root `package.json` `"version"` `0.0.1-beta.5` → `0.0.1-rc.1`, plus the user-facing SDK version references in the docs/examples (install commands + "version `…`" prose). The 4 `@agent-assembly/runtime-*` sub-packages and the root `optionalDependencies` (`workspace:*`) are intentionally **not** touched — `release-node.yml`'s "Bump versions across the 5 packages" step rewrites all of them to the dispatch `npm_version` at publish time. No `pnpm-lock.yaml` change is needed — the lockfile does not pin the root package's own version. The Docusaurus frozen snapshot under `website/versioned_docs/version-0.0.1-beta.5/` and the channel/version registries (`website/versions.json`, `website/versionChannels.json`) are left untouched — they are the historical beta.5 release record, managed by the release-cut workflow.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
## _Effecting Scope_

* Action Types:
    * [x] 🚀 Release
* Scopes:
    * [x] 🚀 Building
        * [x] 📦 Project configurations
    * [x] 📝 Documentation
* Additional description:

    Release-candidate bump from the beta line. `master` already carries the merged `aa-ffi` pin for `v0.0.1-rc.1` (#196), so the native binding source is aligned with this target.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Bump root `package.json` version `0.0.1-beta.5` → `0.0.1-rc.1`.
* Update user-facing SDK version references from `0.0.1-beta.5` → `0.0.1-rc.1` in the quick-start install command and the eight example pages (`docs/02-quick-start/`, `docs/09-examples/*`).

---

**Release-intent — publish after merge + owner go.** Do not merge this PR before the owner approves the release. After merge, the operator publishes via `release-node.yml` `workflow_dispatch` with `npm_version=0.0.1-rc.1`. This PR itself does **not** tag, publish, or trigger any workflow. Sub-packages and the lockfile are intentionally untouched — the release workflow rewrites them at publish time.

Closes AAASM-3762

🤖 Generated with [Claude Code](https://claude.com/claude-code)
