### PR TITLE
[AAASM-3544] 🐛 (test): Guard gateway-resolver auto-start tests when native binary is absent

### DIFF
--- a/tests/gateway-resolver.test.ts
+++ b/tests/gateway-resolver.test.ts
@@ -21,6 +21,17 @@ import {
   waitForHealthz,
 } from "../src/core/gateway-resolver.js";
 import { ConfigurationError, GatewayError } from "../src/errors/index.js";
+import { nativeRuntimeAvailable } from "./helpers/native-runtime.js";
+
+// The auto-start path resolves, allow-lists and spawns the native `aasm`
+// binary, which only ships on platforms with a published runtime package. Those
+// suites assume POSIX install dirs (`/usr/local/bin`, …) and a POSIX `$PATH`
+// shape, so they cannot pass on a platform whose native runtime is absent
+// (Windows today — `@agent-assembly/runtime-win32-x64` is not yet published,
+// AAASM-3544 / AAASM-3809). Guard those cases on actual binary availability,
+// not `process.platform`, so they re-enable automatically once it is published.
+// On Linux/macOS the runtime is present and every case runs unchanged.
+const NATIVE_RUNTIME_AVAILABLE = nativeRuntimeAvailable();
 
 describe("probeHealthz", () => {
   let originalFetch: typeof globalThis.fetch;
@@ -143,7 +154,7 @@ describe("loadConfigFile", () => {
   });
 });
 
-describe("autoStartGateway", () => {
+describe.skipIf(!NATIVE_RUNTIME_AVAILABLE)("autoStartGateway", () => {
   let originalFetch: typeof globalThis.fetch;
   let originalFind: (typeof __testing._seams)["findAasmOnPath"];
   let originalSpawn: (typeof __testing._seams)["spawnAasm"];
@@ -294,9 +305,16 @@ describe("resolveGatewayUrl", () => {
 });
 
 describe("assertAllowedAasmPath", () => {
-  it("accepts an absolute path inside an allow-listed install dir", () => {
-    expect(() => assertAllowedAasmPath("/usr/local/bin/aasm")).not.toThrow();
-  });
+  // The allow-list is built from POSIX install dirs, so a POSIX absolute path
+  // only resolves inside it on a POSIX platform. Guard on native-runtime
+  // availability (absent on Windows today) rather than asserting POSIX layout
+  // on every OS; the two rejection cases below stay platform-independent.
+  it.skipIf(!NATIVE_RUNTIME_AVAILABLE)(
+    "accepts an absolute path inside an allow-listed install dir",
+    () => {
+      expect(() => assertAllowedAasmPath("/usr/local/bin/aasm")).not.toThrow();
+    }
+  );
 
   it("rejects a relative / PATH-injected path", () => {
     expect(() => assertAllowedAasmPath("aasm")).toThrow(ConfigurationError);
@@ -380,7 +398,7 @@ describe("resolveApiKey", () => {
   });
 });
 
-describe("default PATH lookup and spawn seams", () => {
+describe.skipIf(!NATIVE_RUNTIME_AVAILABLE)("default PATH lookup and spawn seams", () => {
   // Capture the production default implementations before any other suite can
   // reassign the mutable _seams entries.
   const defaultFindAasmOnPath = __testing._seams.findAasmOnPath;

--- a/tests/helpers/native-runtime.ts
+++ b/tests/helpers/native-runtime.ts
@@ -1,0 +1,40 @@
+import { createRequire } from "node:module";
+import { arch, platform } from "node:os";
+
+const requireFromHere = createRequire(import.meta.url);
+
+/**
+ * Name of the platform-specific bundled-runtime package that ships the native
+ * `aasm` binary for the given OS/arch, e.g. `@agent-assembly/runtime-linux-x64`.
+ *
+ * Mirrors the `runtime-${platform}-${arch}` naming used by `src/runtime.ts` and
+ * the `optionalDependencies` in package.json. On Windows this resolves to
+ * `@agent-assembly/runtime-win32-x64`, which is not yet built/published
+ * (AAASM-3544 / AAASM-3809).
+ */
+export function runtimePackageName(
+  osPlatform: string = platform(),
+  osArch: string = arch()
+): string {
+  return `@agent-assembly/runtime-${osPlatform}-${osArch}`;
+}
+
+/**
+ * True when the bundled native runtime package for the current platform is
+ * resolvable (installed).
+ *
+ * Returns `false` on platforms with no published runtime package — Windows
+ * today, since `@agent-assembly/runtime-win32-x64` (the napi-rs Windows native
+ * binding / bundled `aasm` runtime) is not yet built or published. Keyed on the
+ * actual package availability rather than `process.platform`, so any suite that
+ * guards on this re-enables itself automatically once the Windows runtime
+ * package is published.
+ */
+export function nativeRuntimeAvailable(): boolean {
+  try {
+    requireFromHere.resolve(`${runtimePackageName()}/package.json`);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## _Target_

Unblock the node-sdk `master` `CI Success` gate, which is red because the `test-matrix` workflow fails on every `windows-latest` cell (Node 18/20/22/24) while `ubuntu-latest` / `macos-latest` pass.

* ### Task summary:

    Guard the `gateway-resolver` auto-start test suites so they skip cleanly on platforms where the native `aasm` runtime binary is absent (Windows today), keyed on **actual binary availability** rather than `process.platform`. Linux/macOS keep full coverage; the guarded cases re-enable automatically once the Windows runtime package is published.

* ### Task tickets:

    * Task ID: AAASM-3544.
    * Relative task IDs:
        * [ ] AAASM-3809 (Windows runtime packaging — see approach (b) below).
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    **Root cause (refined during investigation).** The Windows failures are not literally caused by the postinstall warning — the failing tests mock the auto-start seams and never load the native binary. They fail because the auto-start code path + its test fixtures encode **POSIX-only assumptions** that break on Windows once no native runtime is present:

    | Failing test | Why it fails on Windows |
    |---|---|
    | `autoStartGateway` > "spawns aasm and resolves..." | `assertAllowedAasmPath("/usr/local/bin/aasm")` — `path.win32.resolve` rewrites it to `C:\usr\local\bin\aasm`, which is not under the POSIX allow-list -> `ConfigurationError` thrown where the test expects resolve |
    | `autoStartGateway` > "throws GatewayError when... never ready" | same allow-list rejection -> `ConfigurationError` raised where `GatewayError` is expected |
    | `assertAllowedAasmPath` > "accepts an absolute path inside an allow-listed install dir" | same POSIX allow-list (`/usr/local/bin`, `/opt/homebrew/bin`, ...) does not match a Windows-resolved path |
    | `default PATH lookup...` > "findAasmOnPath returns the first matching binary" | fixture joins `$PATH` with `:` and writes an extension-less `aasm`; on Windows the separator is `;` (and drive letters contain `:`) so the lookup finds nothing |

    These are exactly the "~4 failures" in the ticket.

    **Fix.** A small test helper `tests/helpers/native-runtime.ts` exposes `nativeRuntimeAvailable()`, which returns `true` only when `@agent-assembly/runtime-<platform>-<arch>` (the bundled native `aasm` package) resolves. The three affected suites/cases are guarded with `describe.skipIf(...)` / `it.skipIf(...)` on that flag:
    - `describe.skipIf(!NATIVE)` -> `autoStartGateway`
    - `describe.skipIf(!NATIVE)` -> `default PATH lookup and spawn seams`
    - `it.skipIf(!NATIVE)` -> the single POSIX-absolute `assertAllowedAasmPath` case (its two rejection cases stay platform-independent)

    On Linux/macOS the runtime package is present -> nothing is skipped (verified: 37/37 in this file, 338 passing locally). On Windows the runtime is absent -> the four POSIX-bound cases skip and `test-matrix` goes green. Keyed on package resolvability (not `process.platform`), the guard **self-heals**: once the Windows runtime package ships, the cases run again.

    **Assessment of approach (b) — proper long-term fix (NOT implemented here).** Building & publishing the Windows native runtime package (mirroring the linux/macOS `@agent-assembly/runtime-*` packaging) is the durable fix so postinstall selects a real Windows binary. This is **release/distribution work** that lives in `release-node.yml` / the build-addon pipeline and overlaps **AAASM-3809**; it should be tracked there rather than bundled into this test-only CI unblock. Note also that even after publishing, the auto-start allow-list (`allowedInstallDirs()` in `src/core/gateway-resolver.ts`) and these fixtures would still need Windows-aware paths (`%ProgramFiles%`, `path.delimiter`, `aasm.exe`) to pass on Windows — so approach (b) is a package **and** a small production-allow-list change, not just a publish. Recommendation: extend AAASM-3809 (or open a focused follow-up under it) to cover Windows runtime packaging + Windows-aware allow-list/fixtures; no brand-new top-level ticket is warranted.

    **Related correctness nit (observed, out of scope).** `scripts/postinstall.mjs` resolves `@agent-assembly/<key>` (e.g. `win32-x64-msvc`) while the `optionalDependencies` are named `@agent-assembly/runtime-<platform>-<arch>` (e.g. `runtime-linux-x64`) — the two naming schemes don't line up, and there is no win32 optional dep at all. This guard intentionally keys on the `runtime-*` packages (the ones actually declared/installed), so it is unaffected; the postinstall naming mismatch is worth folding into the approach-(b) follow-up.

## _Effecting Scope_

* Action Types:
    * [x] 🔧 Fixing bug
        * [x] 🟢 No breaking change
* Scopes:
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
* Additional description:
    Test-only change. No production source, public API, or runtime behavior is modified.

## _Description_

* Add `tests/helpers/native-runtime.ts` with `nativeRuntimeAvailable()` / `runtimePackageName()` — detects whether the platform's bundled native runtime package resolves.
* Guard `tests/gateway-resolver.test.ts` auto-start suites with `describe.skipIf` / `it.skipIf` on `nativeRuntimeAvailable()`, with explaining comments.

## _How to verify_

* Locally (macOS/Linux — runtime present): `pnpm install && pnpm test` -> nothing skipped, full coverage (337+ passing; `gateway-resolver.test.ts` runs all 37). `pnpm typecheck` and `pnpm lint` clean.
* Windows: the four POSIX-bound cases skip; the rest of `gateway-resolver.test.ts` and the suite run. **Note:** `test-matrix` only runs the `windows-latest` cells on **push to `master`/tags**, not on PRs (PRs are ubuntu-only for fast/free minutes — see `test-matrix.yml`), so this PR's own CI cannot directly exercise Windows; the Windows cells turn green after merge to `master`.

Closes AAASM-3544

🤖 Generated with [Claude Code](https://claude.com/claude-code)
