### PR TITLE
[AAASM-2774] 🔧 (sonar): Wire projectVersion off 0.0.0 + cover in release skills

### DIFF
--- a/.claude/skills/release-runbook/SKILL.md
+++ b/.claude/skills/release-runbook/SKILL.md
@@ -228,6 +228,14 @@ state machine:
 - Downloading + staging the `aasm-*.tar.gz` binaries.
 - The post-publish `v<version>` git tag + GitHub Release.
 - The Docusaurus docs-version snapshot PR (`version-docs` job).
+- The SonarCloud `sonar.projectVersion`. `quality-report.yml` overrides the
+  `sonar-project.properties` value with `-Dsonar.projectVersion=<package.json
+  version>` at scan time, so the quality gate auto-advances once the five
+  `package.json` files are bumped — no manual `sonar.projectVersion` bump is
+  required on the release path (AAASM-2774). Keep the static fallback in
+  `sonar-project.properties` roughly in step with `package.json` so the gate
+  never falls back to `0.0.0` ("Not computed") if the scan ever runs without the
+  CI override.
 
 ## Detailed references
 

--- a/.claude/skills/sdk-only-release/SKILL.md
+++ b/.claude/skills/sdk-only-release/SKILL.md
@@ -160,6 +160,12 @@ Three operator-side rules govern every dispatch:
   `repository_dispatch`); refresh docs separately if needed.
 - dist-tag promotion is a separate operator step from an authenticated
   terminal: `npm dist-tag add @agent-assembly/sdk@<X> alpha`.
+- The SonarCloud `sonar.projectVersion` needs **no** manual bump for an SDK-only
+  release. `quality-report.yml` derives it from `package.json` at scan time
+  (`-Dsonar.projectVersion=<version>`), so once `<npm_version>` is committed to
+  `package.json` the quality gate tracks it automatically (AAASM-2774). Keep the
+  static fallback in `sonar-project.properties` roughly in step so the gate never
+  reverts to `0.0.0` ("Not computed").
 
 ## Do NOT manually run
 

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -60,8 +60,17 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
 
+      - name: Resolve package version for Sonar
+        id: sonar_version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
       - name: SonarQube Scan
         if: ${{ env.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         env:
           SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
+        with:
+          # Override sonar-project.properties' static fallback so the quality
+          # gate version always tracks package.json and auto-advances per release.
+          args: >
+            -Dsonar.projectVersion=${{ steps.sonar_version.outputs.version }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,11 @@ sonar.projectKey=ai-agent-assembly_node-sdk
 sonar.organization=ai-agent-assembly
 
 sonar.projectName=node-sdk
-sonar.projectVersion=0.0.0
+# Static fallback only. The CI scan (.github/workflows/quality-report.yml)
+# overrides this with -Dsonar.projectVersion=<package.json version> so the
+# SonarCloud quality gate auto-advances each release. Keep this off 0.0.0 (which
+# stalls the gate at "Not computed") and roughly in step with package.json.
+sonar.projectVersion=0.0.1-rc.1
 
 sonar.projectBaseDir=./
 sonar.sources=src/


### PR DESCRIPTION
## _Target_

Fix the SonarCloud quality gate showing **"Not computed"** on `node-sdk`, caused by `sonar.projectVersion=0.0.0` in `sonar-project.properties`, and make the version self-maintaining across releases.

* ### Task summary:

    * Set `sonar.projectVersion` off `0.0.0` (static fallback now `0.0.1-rc.1`, the current `package.json` version).
    * Wired the CI Sonar scan to **dynamically derive** `sonar.projectVersion` from `package.json` (`-Dsonar.projectVersion=<version>`), so the gate auto-advances every release with no manual bump.
    * Documented the auto-derive behaviour in both release skills so future releases keep the gate current.

* ### Task tickets:

    * Task ID: AAASM-2774.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    * `.github/workflows/quality-report.yml`: new `Resolve package version for Sonar` step reads `package.json` `version` into a step output; the `SonarQube Scan` step passes it via `args: -Dsonar.projectVersion=...`. This overrides the static value at scan time, so the gate version always tracks `package.json`.
    * `sonar-project.properties`: `0.0.0` -> `0.0.1-rc.1`, kept only as a fallback (the CI override is authoritative). Annotated so it stays off `0.0.0`.
    * `.claude/skills/release-runbook/SKILL.md` + `.claude/skills/sdk-only-release/SKILL.md`: note that `sonar.projectVersion` is auto-derived from `package.json` -- no manual bump required on the release path.

## _Effecting Scope_

* Action Types:
    * [x] 🔧 Fixing bug
* Scopes:
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
        * [x] 📦 Project configurations
    * [x] 📚 Documentation
* Additional description:
    Config + workflow + docs only; no source or test changes. Validated with `pnpm install`, `pnpm lint`, `pnpm typecheck` (all clean).

## _Description_

* `sonar.projectVersion=0.0.0` left the SonarCloud gate "Not computed". This sets a real version and, more importantly, wires CI to derive it from `package.json` so it auto-advances each release. Both release runbooks now document the auto-derive so the gate never regresses to `0.0.0`.

Closes AAASM-2774

🤖 Generated with [Claude Code](https://claude.com/claude-code)
