### PR TITLE
[AAASM-3834] 🔖 (release): node-sdk v0.0.1-rc.2

### DIFF
--- a/docs/02-quick-start/index.md
+++ b/docs/02-quick-start/index.md
@@ -23,7 +23,7 @@ platform during `postinstall`, so there is no extra build step for typical consu
 The current release line is `0.0.1-beta.x`, published under the npm `beta`
 dist-tag. The public surface (`initAssembly`, `withAssembly`) is stabilizing but may
 change between pre-releases. Pin an exact version for reproducible installs:
-`npm install @agent-assembly/sdk@0.0.1-rc.1`.
+`npm install @agent-assembly/sdk@0.0.1-rc.2`.
 :::
 
 ## 2. Make sure a gateway is reachable

--- a/docs/09-examples/custom-tool-policy.md
+++ b/docs/09-examples/custom-tool-policy.md
@@ -21,7 +21,7 @@ the policy first.
 
 ## The framework / library
 
-None. The example depends only on `@agent-assembly/sdk` (version `0.0.1-rc.1`
+None. The example depends only on `@agent-assembly/sdk` (version `0.0.1-rc.2`
 in its `package.json`). It runs fully offline — no gateway and no `@langchain/core`.
 
 ## How it works

--- a/docs/09-examples/langchain-js-basic-agent.md
+++ b/docs/09-examples/langchain-js-basic-agent.md
@@ -20,7 +20,7 @@ on every tool call the agent makes.
 ## The framework / library
 
 [LangChain.js](https://js.langchain.com)-style agent. The example depends only on
-`@agent-assembly/sdk` (version `0.0.1-rc.1`); it deliberately avoids
+`@agent-assembly/sdk` (version `0.0.1-rc.2`); it deliberately avoids
 `@langchain/core` so it runs fully offline in CI with no API keys.
 
 ## How it works

--- a/docs/09-examples/langgraph-js.md
+++ b/docs/09-examples/langgraph-js.md
@@ -21,7 +21,7 @@ originates — including from inside a graph node.
 ## The framework / library
 
 A hand-rolled [LangGraph.js](https://langchain-ai.github.io/langgraphjs/)-style graph.
-The example depends only on `@agent-assembly/sdk` (version `0.0.1-rc.1`).
+The example depends only on `@agent-assembly/sdk` (version `0.0.1-rc.2`).
 
 :::note Why a hand-rolled graph instead of `@langchain/langgraph`
 The real `@langchain/langgraph` package transitively installs `@langchain/core`. These

--- a/docs/09-examples/mastra.md
+++ b/docs/09-examples/mastra.md
@@ -22,7 +22,7 @@ wrapping their `execute` through `withAssembly`.
 
 [Mastra](https://mastra.ai) — the real `@mastra/core` package (version `^1.0.0` in
 `package.json`), plus `zod` (`^3.25.76`) for the tool schemas and
-`@agent-assembly/sdk` (version `0.0.1-rc.1`). It runs fully offline — no provider
+`@agent-assembly/sdk` (version `0.0.1-rc.2`). It runs fully offline — no provider
 key and no live LLM.
 
 ## How it works

--- a/docs/09-examples/openai-node-tool-policy.md
+++ b/docs/09-examples/openai-node-tool-policy.md
@@ -21,7 +21,7 @@ dispatched through `withAssembly`, so every dispatch is policy-checked before it
 ## The framework / library
 
 OpenAI function-calling format (tool schemas), used without a live OpenAI client.
-The example depends only on `@agent-assembly/sdk` (version `0.0.1-rc.1`) and runs
+The example depends only on `@agent-assembly/sdk` (version `0.0.1-rc.2`) and runs
 fully offline — no gateway and no `@langchain/core`.
 
 ## How it works

--- a/docs/09-examples/setup.md
+++ b/docs/09-examples/setup.md
@@ -16,7 +16,7 @@ can focus on what each example actually demonstrates.
 - **pnpm** — install via `npm install -g pnpm`.
 
 Every example pins `@agent-assembly/sdk` (the [`node-sdk`](https://github.com/ai-agent-assembly/node-sdk)
-package, version `0.0.1-rc.1` at the time of writing) as its only required
+package, version `0.0.1-rc.2` at the time of writing) as its only required
 dependency. The framework-specific examples add one extra package each
 (`@mastra/core` for Mastra, `ai` for the Vercel AI SDK).
 

--- a/docs/09-examples/vercel-ai.md
+++ b/docs/09-examples/vercel-ai.md
@@ -22,7 +22,7 @@ top by wrapping the tool map.
 
 [Vercel AI SDK](https://sdk.vercel.ai) — the real `ai` package (version `^6.0.0` in
 `package.json`), plus `zod` (`^3.25.76`) for input schemas and `@agent-assembly/sdk`
-(version `0.0.1-rc.1`). It runs fully offline — no provider key and no live LLM.
+(version `0.0.1-rc.2`). It runs fully offline — no provider key and no live LLM.
 
 ## How it works
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agent-assembly/sdk",
-  "version": "0.0.1-rc.1",
+  "version": "0.0.1-rc.2",
   "description": "TypeScript SDK for Agent Assembly",
   "license": "Apache-2.0",
   "type": "module",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.projectName=node-sdk
 # overrides this with -Dsonar.projectVersion=<package.json version> so the
 # SonarCloud quality gate auto-advances each release. Keep this off 0.0.0 (which
 # stalls the gate at "Not computed") and roughly in step with package.json.
-sonar.projectVersion=0.0.1-rc.1
+sonar.projectVersion=0.0.1-rc.2
 
 sonar.projectBaseDir=./
 sonar.sources=src/


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Release-intent (prep-only) version bump of the node-sdk from `0.0.1-rc.1` to `0.0.1-rc.2`, coordinated with the just-released core `v0.0.1-rc.2`. This PR only prepares the version metadata and docs; it does **not** publish, tag, or trigger a release.

* ### Task tickets:

    * Task ID: AAASM-3834.
    * Relative task IDs:
        * [x] AAASM-3834.
    * Relative PRs:
        * #204 (FFI-pin to core `v0.0.1-rc.2`, already merged).
        * #191 (prior rc/beta prep PR — footprint mirrored here).

* ### Key point change (optional):

    * `package.json` `version`: `0.0.1-rc.1` → `0.0.1-rc.2` (only `package.json` declaring the SDK version; the `@agent-assembly/runtime-*` sub-packages use `workspace:*` and are version-decoupled, so they are untouched).
    * Docs SDK version pins bumped to `0.0.1-rc.2` in `docs/02-quick-start/index.md` and `docs/09-examples/*.md` — mirrors exactly what PR #191 touched.
    * `pnpm-lock.yaml` not regenerated: the lockfile does not pin the project's own version (verified no `0.0.1-rc.1` reference, and `pnpm install --frozen-lockfile` succeeds with no drift).

## _Effecting Scope_

* Action Types:
    * [x] 🚀 Release
* Scopes:
    * [x] 🚀 Building
        * [x] 📦 Project configurations
    * [x] 📚 Documentation
* Additional description:
    Prep-only. No source/runtime behavior changes.

## _Description_

* **What changed:** version bump `0.0.1-rc.1` → `0.0.1-rc.2` in root `package.json`, plus the matching SDK version pins in quick-start and example docs (9 files total).
* **Why:** coordinate the node-sdk release line with the just-released core `v0.0.1-rc.2`; the FFI-pin PR #204 (core `v0.0.1-rc.2`) is already merged, so the SDK metadata now needs to advance to rc.2.
* **How to verify:**
    * `pnpm install --frozen-lockfile` — succeeds with no lockfile drift.
    * `pnpm typecheck` — passes.
    * `grep -rn '0\.0\.1-rc\.1' docs/02-quick-start docs/09-examples package.json` — returns nothing.
    * `node -p "require('./package.json').version"` — prints `0.0.1-rc.2`.
* **PREP-ONLY:** this PR does not publish to npm and does not create a git tag. Publishing happens later via the release `workflow_dispatch`.

Closes AAASM-3834

🤖 Generated with [Claude Code](https://claude.com/claude-code)
