### PR TITLE
[AAASM-3841] 📝 (docs): Record sonar.projectVersion bump in node-sdk release runbook

### DIFF
--- a/.claude/skills/release-runbook/SKILL.md
+++ b/.claude/skills/release-runbook/SKILL.md
@@ -140,6 +140,13 @@ the release, *before* the tag is cut.
    `version`. Leave the four runtime sub-package `package.json` files at their
    tree value — `release-node.yml` rewrites all five from `npm_version` at
    publish. Touch `pnpm-lock.yaml` only if it pins the root package's version.
+   **In the same version-bump prep commit, bump `sonar.projectVersion` in
+   `sonar-project.properties`** to the new version. The static value is the
+   source-of-truth / local-scan fallback; CI overrides it dynamically at scan
+   time (`quality-report.yml` passes `-Dsonar.projectVersion=<package.json
+   version>`), so drift never breaks CI — but the static value must still track
+   the release. This is the step rc.1 prep PRs missed and rc.2 had to fix by
+   hand; it mirrors the core's `release-tag-cut` automation (AAASM-3819).
 2. **Sweep the docs site for PINNED versions** — these are NOT auto-updated:
    - `docs/02-quick-start/index.md` — the `npm install @agent-assembly/sdk@<X>`
      command is pinned to an explicit version.
@@ -228,14 +235,16 @@ state machine:
 - Downloading + staging the `aasm-*.tar.gz` binaries.
 - The post-publish `v<version>` git tag + GitHub Release.
 - The Docusaurus docs-version snapshot PR (`version-docs` job).
-- The SonarCloud `sonar.projectVersion`. `quality-report.yml` overrides the
+- The CI-side `sonar.projectVersion` override. `quality-report.yml` overrides the
   `sonar-project.properties` value with `-Dsonar.projectVersion=<package.json
   version>` at scan time, so the quality gate auto-advances once the five
-  `package.json` files are bumped — no manual `sonar.projectVersion` bump is
-  required on the release path (AAASM-2774). Keep the static fallback in
-  `sonar-project.properties` roughly in step with `package.json` so the gate
-  never falls back to `0.0.0` ("Not computed") if the scan ever runs without the
-  CI override.
+  `package.json` files are bumped — CI never needs the literal (AAASM-2774). But
+  you still bump the static `sonar.projectVersion` literal as part of the
+  version-bump prep commit (see "Sync docs version refs + example pins" step 1
+  above): it is the source-of-truth / local-scan fallback and must track the
+  release, never sitting at `0.0.0` ("Not computed") if the scan ever runs
+  without the CI override. Mirrors the core's `release-tag-cut` automation
+  (AAASM-3819).
 
 ## Detailed references
 

--- a/.claude/skills/sdk-only-release/SKILL.md
+++ b/.claude/skills/sdk-only-release/SKILL.md
@@ -160,12 +160,16 @@ Three operator-side rules govern every dispatch:
   `repository_dispatch`); refresh docs separately if needed.
 - dist-tag promotion is a separate operator step from an authenticated
   terminal: `npm dist-tag add @agent-assembly/sdk@<X> alpha`.
-- The SonarCloud `sonar.projectVersion` needs **no** manual bump for an SDK-only
-  release. `quality-report.yml` derives it from `package.json` at scan time
+- The CI-side `sonar.projectVersion` override needs no action.
+  `quality-report.yml` derives it from `package.json` at scan time
   (`-Dsonar.projectVersion=<version>`), so once `<npm_version>` is committed to
-  `package.json` the quality gate tracks it automatically (AAASM-2774). Keep the
-  static fallback in `sonar-project.properties` roughly in step so the gate never
-  reverts to `0.0.0` ("Not computed").
+  `package.json` the quality gate tracks it automatically (AAASM-2774). CI never
+  needs the literal — but you **still** bump `sonar.projectVersion` in
+  `sonar-project.properties` to the new version as part of the version-bump prep
+  commit: it is the source-of-truth / local-scan fallback and must track the
+  release, never sitting at `0.0.0` ("Not computed"). Mirrors the core's
+  `release-tag-cut` automation (AAASM-3819); this is the step rc.1 prep PRs
+  missed.
 
 ## Do NOT manually run
 


### PR DESCRIPTION
## _Target_

Codify the `sonar.projectVersion` bump so SDK release-intent prep PRs stop
forgetting it (rc.1 prep PRs skipped it; rc.2 had to fix it by hand).

* ### Task summary:

    Adds an explicit `sonar.projectVersion` bump step to the node-sdk
    release-runbook version-bump prep, and reconciles the existing
    "no manual bump" notes in `release-runbook` and `sdk-only-release` to the
    same guidance: CI overrides the value dynamically at scan time
    (`quality-report.yml` passes `-Dsonar.projectVersion=<package.json version>`),
    so drift never breaks CI, but the static literal in `sonar-project.properties`
    is the source-of-truth / local-scan fallback and must track the release.
    Mirrors the core's `release-tag-cut` automation (AAASM-3819).

* ### Task tickets:

    * Task ID: AAASM-3841.
    * Relative task IDs:
        * [x] AAASM-3819 (core `release-tag-cut` precedent).
    * Relative PRs:
        * python-sdk and go-sdk PRs for AAASM-3841 (one ticket, three SDK PRs;
          `Closes` is on the go-sdk PR).

* ### Key point change (optional):

    Documentation-only. No code, workflow, or `sonar-project.properties` change.

## _Effecting Scope_

* Action Types:
    * [ ] ✨ Adding new something
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [x] 📚 Documentation
* Additional description:
    Edits only `.claude/skills/release-runbook/SKILL.md` and
    `.claude/skills/sdk-only-release/SKILL.md`.

## _Description_

* `release-runbook` step 1 ("Sync docs version refs + example pins") now bumps
  `sonar.projectVersion` in `sonar-project.properties` in the same version-bump
  prep commit.
* The "what the workflow owns" sonar note and the `sdk-only-release` sonar note
  are reconciled to the same source-of-truth framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
