### PR TITLE
[AAASM-3879] 🔧 (ci): Pin checkout + add least-priv permissions

### DIFF
--- a/.github/workflows/build-addon.yml
+++ b/.github/workflows/build-addon.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   napi-build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/module-system-smoke.yml
+++ b/.github/workflows/module-system-smoke.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   module-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/native-pin-consistency.yml
+++ b/.github/workflows/native-pin-consistency.yml
@@ -20,7 +20,7 @@ jobs:
     name: aa-* crates share one git rev
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Assert all agent-assembly git deps share one rev
         run: |
           manifest="native/aa-ffi-node/Cargo.toml"

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 3 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   regression-suite:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Harden node-sdk CI step-action pinning and least-privilege token scope. Part 2 of 2 for AAASM-3879 (the python-sdk half ships as a separate PR, #193).

* ### Task tickets:

    * Task ID: AAASM-3879.
    * Relative PRs:
        * python-sdk: https://github.com/ai-agent-assembly/python-sdk/pull/193

* ### Key point change:

    * `native-pin-consistency.yml`: pin the lone unpinned `actions/checkout@v7` → `@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0` (the SHA already used by every other workflow in this repo).
    * Add a top-level `permissions: contents: read` block to `build-addon`, `test-matrix`, `module-system-smoke`, `precommit`, `regression` — they only build/test, so read-only is sufficient and revokes the default broad `GITHUB_TOKEN` scope.

## _Effecting Scope_

* Action Types:
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
        * [x] 🟢 No breaking change
* Scopes:
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
* Additional description:
    CI-config-only; `actionlint` clean on all six modified workflows.

## _Description_

* SHA-pin the unpinned checkout action and add least-privilege permissions blocks. No runtime/SDK code changes.

Refs AAASM-3879

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf
