### PR TITLE
[AAASM-3896] 🔒 (redact): Widen redacted secret-key list

### DIFF
--- a/src/core/redact.ts
+++ b/src/core/redact.ts
@@ -22,7 +22,15 @@ const SECRET_KEYS: ReadonlySet<string> = new Set([
   "credentialtoken",
   "credential_token",
   "authorization",
-  "token"
+  "token",
+  // AAASM-3896: defence-in-depth for future callers that log arbitrary config
+  // or HTTP header maps. These key names commonly carry credentials even though
+  // the SDK itself does not emit them today, so redact them pre-emptively.
+  "password",
+  "secret",
+  "x-api-key",
+  "cookie",
+  "set-cookie"
 ]);
 
 /** Placeholder substituted for any redacted credential value. */

--- a/tests/credential-redaction.test.ts
+++ b/tests/credential-redaction.test.ts
@@ -50,6 +50,29 @@ describe("redactSecrets (AAASM-3645)", () => {
     expect(safe).toContain("http://gw.test");
     expect(safe).toContain("a");
   });
+
+  it("strips the widened secret-key set: password/secret/x-api-key/cookie/set-cookie (AAASM-3896)", () => {
+    const config = {
+      keepMe: "visible",
+      password: "SENTINEL-PASSWORD",
+      Secret: "SENTINEL-SECRET",
+      "X-API-Key": "SENTINEL-XAPIKEY",
+      Cookie: "SENTINEL-COOKIE",
+      "set-cookie": "SENTINEL-SETCOOKIE"
+    };
+    const safe = JSON.stringify(redactSecrets(config));
+    for (const sentinel of [
+      "SENTINEL-PASSWORD",
+      "SENTINEL-SECRET",
+      "SENTINEL-XAPIKEY",
+      "SENTINEL-COOKIE",
+      "SENTINEL-SETCOOKIE"
+    ]) {
+      expect(safe).not.toContain(sentinel);
+    }
+    expect(safe).toContain(REDACTED);
+    expect(safe).toContain("visible");
+  });
 });
 
 describe("redactErrorMessage (AAASM-3645)", () => {


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Widen the redaction secret-key set in `src/core/redact.ts` so `redactSecrets`
    also strips `password`, `secret`, `x-api-key`, `cookie`, and `set-cookie`
    (case-insensitive). Defence-in-depth for future callers that log arbitrary
    config or HTTP header maps; the SDK does not emit these today.

* ### Task tickets:

    * Task ID: Refs AAASM-3896.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * Part of the AAASM-3896 SDK CI-pinning / hardening sweep (python-sdk + go-sdk companion PRs).

* ### Key point change (optional):

    `SECRET_KEYS` gains 5 entries; a new test in `tests/credential-redaction.test.ts`
    pins that each new key is redacted (case-insensitive) while non-secret fields
    survive.

## _Effecting Scope_

* Action Types:
    * [ ] ✨ Adding new something
    * [ ] ✏️ Modifying existing something
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
        * [x] 🟢 No breaking change
* Scopes:
    * [ ] 🧩 SDK public API
    * [x] ⛑️ Error handling
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
* Additional description:
    No public API change; `redactSecrets`/`redactErrorMessage` signatures unchanged.

## _Description_

* Add `password`, `secret`, `x-api-key`, `cookie`, `set-cookie` to `SECRET_KEYS`.
* Add a unit test covering the widened key list (case-insensitive, non-secret fields preserved).
* Validation: `pnpm exec vitest run tests/credential-redaction.test.ts` (5/5 pass),
  `pnpm typecheck` and `eslint` on the changed files — all clean.


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mSz31RysZF6DYToUoBWLf