### PR TITLE
[AAASM-3924] 🔧 (ci): Frozen lockfile + scope docs deploy perms

### DIFF
--- a/.github/workflows/build-addon.yml
+++ b/.github/workflows/build-addon.yml
@@ -64,7 +64,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       # On PRs, a fast debug build is enough to prove the addon compiles
       # and the napi bindings load. Release builds (optimised, --platform

--- a/.github/workflows/module-system-smoke.yml
+++ b/.github/workflows/module-system-smoke.yml
@@ -45,7 +45,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Run ESM/CJS smoke tests
         run: pnpm vitest run tests/packaging/esm-resolution.test.ts tests/packaging/cjs-resolution.test.ts

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -40,7 +40,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -11,8 +11,11 @@ on:
       - master
   workflow_dispatch:
 
+# Default to read-only. Only the deploy job (push to master) needs write to
+# push the built site to the gh-pages branch; the build job — which also runs
+# on pull_request — stays read-only.
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -60,8 +63,29 @@ jobs:
         run: pnpm build
         working-directory: website
 
+      - name: Upload built site
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docusaurus-site
+          path: ./website/build
+          retention-days: 1
+
+  deploy:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    # Write is scoped to this push-only deploy job; peaceiris pushes the built
+    # site to the gh-pages branch via GITHUB_TOKEN.
+    permissions:
+      contents: write
+    steps:
+      - name: Download built site
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: docusaurus-site
+          path: ./website/build
+
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -43,7 +43,7 @@ jobs:
           cache: pnpm
 
       - name: Install SDK dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Install website dependencies
         # `--ignore-workspace` tells pnpm to skip the parent

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -44,7 +44,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Generate coverage report
         run: pnpm test:coverage

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -27,7 +27,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Run regression placeholder
         run: pnpm test

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -49,7 +49,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Run tests
         run: pnpm test


### PR DESCRIPTION
## Description

Two CI supply-chain consistency fixes for AAASM-3924:

1. **`--frozen-lockfile` for root-workspace CI installs** — seven root `pnpm install` steps used `--no-frozen-lockfile`, allowing silent `pnpm-lock.yaml` drift in CI (the release path was already frozen). Switched them to `--frozen-lockfile`: `module-system-smoke.yml`, `precommit.yml`, `regression.yml`, `build-addon.yml`, `quality-report.yml`, `test-matrix.yml`, and the SDK install in `publish-docs.yml`. The two documented website installs (`--no-frozen-lockfile --ignore-workspace`, AAASM-1220/1221) are intentionally left as-is.
2. **Scope `publish-docs.yml` write permission** — the top-level `permissions: contents: write` applied to every event, including `pull_request`. Lowered the top level to `contents: read` and split the single job into a read-only `build` job (runs on PR + push, uploads the built site artifact) and a new `deploy` job (`contents: write`, push-to-master only) that downloads the artifact and publishes to `gh-pages`. New artifact actions are SHA-pinned consistent with the rest of the repo.

## Type of Change

- [x] 🔧 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related JIRA ticket: AAASM-3924

Refs AAASM-3924

## Testing

- [x] No tests required (explain why)

YAML/workflow-only change. Validated with `actionlint` (clean). `pnpm-lock.yaml` is present and committed, so `--frozen-lockfile` installs resolve.

## Checklist

- [x] Self-review completed
- [x] Commits are small and follow the Gitmoji convention
