### PR TITLE
[AAASM-3925] 🔒 (redact): Widen secret-key coverage + suffix matching

### DIFF
--- a/src/core/redact.ts
+++ b/src/core/redact.ts
@@ -85,15 +85,32 @@ export function redactSecrets(value: unknown): unknown {
 }
 
 /**
- * Render an unknown error for a log message with any `Bearer <token>` / API-key
- * substring scrubbed. Defends the registration-failure warning path: a wrapped
- * transport error could in principle carry an auth header in its message, so we
- * strip the bearer credential before it reaches `console.*` (AAASM-3645).
+ * Render an unknown error for a log message with credential substrings scrubbed.
+ * Defends the registration-failure warning path: a wrapped transport error could
+ * carry an auth header, a bare token, or a tokenised URL in its message, so we
+ * strip the credential before it reaches `console.*` (AAASM-3645, AAASM-3925).
+ *
+ * Beyond the original `Bearer` / `Authorization:` markers this also scrubs bare,
+ * self-identifying token shapes that travel without a header prefix: JSON Web
+ * Tokens (the `eyJ` base64url header), `sk-`-prefixed API keys, and
+ * credential-bearing URL query parameters (`?token=…`, `&api_key=…`). The
+ * patterns are deliberately shape-specific to avoid mangling ordinary prose.
  */
 export function redactErrorMessage(error: unknown): string {
   const raw = String(error);
-  // Replace the credential that follows a `Bearer ` / `Authorization:` marker.
-  return raw
-    .replace(/(Bearer\s+)[\w.\-+/=]+/gi, `$1${REDACTED}`)
-    .replace(/(Authorization\s*[:=]\s*)\S+/gi, `$1${REDACTED}`);
+  return (
+    raw
+      // Credential following a `Bearer ` / `Authorization:` marker.
+      .replace(/(Bearer\s+)[\w.\-+/=]+/gi, `$1${REDACTED}`)
+      .replace(/(Authorization\s*[:=]\s*)\S+/gi, `$1${REDACTED}`)
+      // Bare JWTs: `eyJ<base64url header>.<payload>[.<signature>]`.
+      .replace(/eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)?/g, REDACTED)
+      // Bare `sk-`-prefixed API keys (OpenAI-style) of credential length.
+      .replace(/\bsk-[A-Za-z0-9_-]{8,}/g, REDACTED)
+      // Credential-bearing URL query parameters (key contains token/secret/etc.).
+      .replace(
+        /([?&][\w-]*(?:token|key|secret|password|credential)[\w-]*=)[^&\s"']+/gi,
+        `$1${REDACTED}`
+      )
+  );
 }

--- a/src/core/redact.ts
+++ b/src/core/redact.ts
@@ -30,8 +30,37 @@ const SECRET_KEYS: ReadonlySet<string> = new Set([
   "secret",
   "x-api-key",
   "cookie",
-  "set-cookie"
+  "set-cookie",
+  // AAASM-3925: additional credential-bearing key names seen in the wild
+  // (OAuth tokens, mTLS material, session handles, hyphenated header forms).
+  "access_token",
+  "refresh_token",
+  "client_secret",
+  "private_key",
+  "credential",
+  "passwd",
+  "session",
+  "api-key"
 ]);
+
+/**
+ * Suffix / substring patterns that catch *future* credential-key variants the
+ * exact {@link SECRET_KEYS} set has not enumerated (AAASM-3925). Applied to the
+ * lower-cased key name.
+ *
+ * `secret` and `token` are matched as **suffixes** (`endsWith`), not substrings,
+ * on purpose: `client_secret` / `clientSecret` and `accessToken` / `csrf_token`
+ * are caught while a benign key that merely *starts* with the word (e.g.
+ * `secretSantaName`, `tokenCount`) is preserved. `password` is matched as a
+ * substring because every key containing it is credential-bearing.
+ */
+function isSecretKey(rawKey: string): boolean {
+  const key = rawKey.toLowerCase();
+  if (SECRET_KEYS.has(key)) {
+    return true;
+  }
+  return key.endsWith("token") || key.endsWith("secret") || key.includes("password");
+}
 
 /** Placeholder substituted for any redacted credential value. */
 export const REDACTED = "<redacted>";
@@ -48,7 +77,7 @@ export function redactSecrets(value: unknown): unknown {
   if (value !== null && typeof value === "object") {
     const out: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value)) {
-      out[key] = SECRET_KEYS.has(key.toLowerCase()) ? REDACTED : redactSecrets(val);
+      out[key] = isSecretKey(key) ? REDACTED : redactSecrets(val);
     }
     return out;
   }

--- a/tests/credential-redaction.test.ts
+++ b/tests/credential-redaction.test.ts
@@ -73,14 +73,84 @@ describe("redactSecrets (AAASM-3645)", () => {
     expect(safe).toContain(REDACTED);
     expect(safe).toContain("visible");
   });
+
+  it("strips the AAASM-3925 key set and suffix/substring variants", () => {
+    const config = {
+      access_token: "SENTINEL-ACCESS",
+      refresh_token: "SENTINEL-REFRESH",
+      client_secret: "SENTINEL-CLIENTSECRET",
+      private_key: "SENTINEL-PRIVKEY",
+      credential: "SENTINEL-CRED",
+      passwd: "SENTINEL-PASSWD",
+      session: "SENTINEL-SESSION",
+      "api-key": "SENTINEL-APIKEY",
+      // Suffix / substring matches for future variants.
+      sessionToken: "SENTINEL-SESSIONTOKEN",
+      dbPassword: "SENTINEL-DBPASSWORD",
+      vaultSecret: "SENTINEL-VAULTSECRET"
+    };
+    const safe = JSON.stringify(redactSecrets(config));
+    for (const sentinel of [
+      "SENTINEL-ACCESS",
+      "SENTINEL-REFRESH",
+      "SENTINEL-CLIENTSECRET",
+      "SENTINEL-PRIVKEY",
+      "SENTINEL-CRED",
+      "SENTINEL-PASSWD",
+      "SENTINEL-SESSION",
+      "SENTINEL-APIKEY",
+      "SENTINEL-SESSIONTOKEN",
+      "SENTINEL-DBPASSWORD",
+      "SENTINEL-VAULTSECRET"
+    ]) {
+      expect(safe).not.toContain(sentinel);
+    }
+  });
+
+  it("does NOT over-redact benign keys that only start with a secret word", () => {
+    const config = {
+      secretSantaName: "Alice",
+      tokenCount: 42,
+      keyValueStore: "kv"
+    };
+    const safe = redactSecrets(config) as Record<string, unknown>;
+    expect(safe.secretSantaName).toBe("Alice");
+    expect(safe.tokenCount).toBe(42);
+    expect(safe.keyValueStore).toBe("kv");
+  });
 });
 
-describe("redactErrorMessage (AAASM-3645)", () => {
+describe("redactErrorMessage (AAASM-3645, AAASM-3925)", () => {
   it("scrubs a Bearer credential from an error string", () => {
     const err = new Error(`401 from gateway (Authorization: Bearer ${SENTINEL_KEY})`);
     const scrubbed = redactErrorMessage(err);
     expect(scrubbed).not.toContain(SENTINEL_KEY);
     expect(scrubbed).toContain(REDACTED);
+  });
+
+  it("scrubs a bare JWT carried without a Bearer prefix", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJTRU5USU5FTC1KV1QtU1VCIn0.c2lnbmF0dXJlLXNlbnRpbmVs";
+    const scrubbed = redactErrorMessage(new Error(`token rejected: ${jwt}`));
+    expect(scrubbed).not.toContain("SENTINEL-JWT");
+    expect(scrubbed).not.toContain(jwt);
+    expect(scrubbed).toContain(REDACTED);
+  });
+
+  it("scrubs a bare sk- API key", () => {
+    const scrubbed = redactErrorMessage(new Error("openai error: sk-SENTINELabc123XYZ456"));
+    expect(scrubbed).not.toContain("sk-SENTINELabc123XYZ456");
+    expect(scrubbed).toContain(REDACTED);
+  });
+
+  it("scrubs a credential-bearing URL query parameter", () => {
+    const scrubbed = redactErrorMessage(
+      new Error("GET https://gw.test/cb?access_token=SENTINEL-QTOKEN&page=2 failed")
+    );
+    expect(scrubbed).not.toContain("SENTINEL-QTOKEN");
+    expect(scrubbed).toContain(REDACTED);
+    // Non-credential query params are preserved.
+    expect(scrubbed).toContain("page=2");
   });
 });
 


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Harden the SDK's secret-redaction helpers (`src/core/redact.ts`) against credential leak edge cases: `redactSecrets` missed several common credential key names and `redactErrorMessage` only scrubbed `Bearer`/`Authorization`-prefixed tokens, letting bare JWTs / `sk-` keys / tokenised URLs through.

* ### Task tickets:

    * Task ID: AAASM-3925.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * AI-agent-assembly/agent-assembly#1324 (aa-cli half of the same ticket).

* ### Key point change:

    * `SECRET_KEYS` extended with `access_token`, `refresh_token`, `client_secret`, `private_key`, `credential`, `passwd`, `session`, hyphenated `api-key`.
    * New `isSecretKey()` helper adds suffix/substring matching — `endsWith("token")`, `endsWith("secret")`, `includes("password")` — to catch future variants. Suffix (not substring) matching on `secret`/`token` is deliberate so benign keys like `secretSantaName` / `tokenCount` are **not** over-redacted.
    * `redactErrorMessage` broadened to also scrub bare, self-identifying token shapes: JWTs (`eyJ…`), `sk-` API keys, and credential-bearing URL query params (`?token=…`/`&api_key=…`).
    * Note: `redactSecrets` is latent hardening (no logging path calls it today); the change is additive.

## _Effecting Scope_

* Action Types:
    * [x] 🔧 Fixing bug
        * [x] 🟢 No breaking change
* Scopes:
    * [x] ⛑️ Error handling
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
* Additional description:
    N/A.

## _Description_

* `pnpm test` (full suite, 344 pass), `pnpm typecheck`, and `pnpm lint` all clean. Vitest cases added for the widened key set, the no-over-redaction guarantee, and bare JWT/`sk-`/query-token scrubbing in `redactErrorMessage`.

Refs AAASM-3925 (ticket spans two repos; stays open until both this and agent-assembly#1324 merge).