### PR TITLE
[AAASM-3810] 🐛 (tests): Fix Windows npm pack destination handling

### DIFF
--- a/tests/packaging/package-size.test.ts
+++ b/tests/packaging/package-size.test.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -17,9 +17,20 @@ describe("packaging size budget", () => {
 
       const packDir = fs.mkdtempSync(path.resolve(process.cwd(), ".pack-"));
 
+      // Pass the temp-dir path as a discrete argument. On Windows, shell-built
+      // command strings can corrupt absolute paths used as npm arguments.
       const packEntries = JSON.parse(
-        execSync(
-          `npm pack --json --ignore-scripts --cache ./.npm-cache --pack-destination ${packDir}`,
+        execFileSync(
+          "npm",
+          [
+            "pack",
+            "--json",
+            "--ignore-scripts",
+            "--cache",
+            "./.npm-cache",
+            "--pack-destination",
+            packDir
+          ],
           {
             encoding: "utf8",
             stdio: "pipe"


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Fix the Windows-sensitive npm pack invocation in the package-size packaging test so `test-matrix.yml` can run the packaging check consistently on `windows-latest`.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: AAASM-3810.
    * Relative task IDs:
        * [ ] AAASM-3773
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    * As-is: `tests/packaging/package-size.test.ts` built `npm pack` as a shell command string and interpolated the absolute temporary pack destination path.
    * To-be: the test calls `execFileSync("npm", [...])` and passes `--pack-destination` as a discrete argument, matching the already-hardened `npm-pack-content` test pattern.
    * Security/robustness: avoids shell argument parsing and path corruption for temporary paths.

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [ ] ✨ Adding new something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [x] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [ ] 🤖 Framework hooks
    * [ ] 🫀 Data model and types
    * [ ] ⛑️ Error handling
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
    * [ ] 📚 Documentation
* Additional description:
    This change only affects test code and does not change runtime SDK behavior or package exports.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Replaced shell-interpolated `npm pack` execution in `tests/packaging/package-size.test.ts` with `execFileSync` argument passing.
* Verified locally:
    * `pnpm vitest run tests/packaging/package-size.test.ts tests/packaging/npm-pack-content.test.ts`
    * `pnpm run typecheck`
    * `pnpm vitest run --exclude tests/runtime.test.ts`
* Note: full `pnpm test` is not runnable in this sandbox because `tests/runtime.test.ts` hits local `listen EPERM 127.0.0.1`; this is a local sandbox restriction, not part of this Windows packaging fix.
