### PR TITLE
[AAASM-3963] 🔧 (ci): Reconcile Codecov ignore with SonarCloud scope

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,4 @@ codecov:
   strict_yaml_branch: master
 ignore:
   - "native/aa-ffi-node/index.cjs"
+  - "src/proto/generated/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,18 @@
+# Codecov and SonarCloud consume the SAME report: coverage/lcov.info, produced by
+# the single `pnpm test:coverage` run in .github/workflows/quality-report.yml
+# (Codecov via `files: ./coverage/lcov.info`, Sonar via
+# `sonar.javascript.lcov.reportPaths`). The report source is therefore unified —
+# any residual % delta between the two dashboards is engine-level only (Sonar's
+# analyzer vs vitest/v8 line counting) plus scope (Sonar limits to
+# `sonar.sources=src/`), NOT a coverage regression. The `ignore` list below is
+# kept in lockstep with Sonar's exclusions (`src/proto/generated/**`) so both
+# tools measure the same code.
 codecov:
   token: $CODECOV_TOKEN
   branch: master
   strict_yaml_branch: master
 ignore:
   - "native/aa-ffi-node/index.cjs"
+  # Generated protoc-gen-ts_proto output; Sonar excludes it too
+  # (sonar.coverage.exclusions in sonar-project.properties).
   - "src/proto/generated/**"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,6 +13,11 @@ sonar.projectBaseDir=./
 sonar.sources=src/
 sonar.tests=tests/
 sonar.test.inclusions=tests/**/*.test.ts
+# Shared with Codecov: coverage/lcov.info is produced by the single
+# `pnpm test:coverage` run in .github/workflows/quality-report.yml and consumed
+# by BOTH tools (Codecov via `files: ./coverage/lcov.info`). Any residual % delta
+# vs Codecov is engine-level only (Sonar analyzer vs vitest/v8 line counting) plus
+# scope (sonar.sources=src/ below), not a regression.
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.typescript.tsconfigPaths=tsconfig.json
 # src/proto/generated/* is protoc-gen-ts_proto output (marked "DO NOT EDIT").


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

* ### Task summary:

    Reconcile the Codecov coverage scope with SonarCloud so both quality dashboards measure the same code. The report SOURCE is already unified — `.github/workflows/quality-report.yml` runs `pnpm test:coverage` ONCE and both tools consume the same `coverage/lcov.info` (Codecov via `files: ./coverage/lcov.info`, SonarCloud via `sonar.javascript.lcov.reportPaths`). The only residual drift was SCOPE: `codecov.yml` did not ignore the generated proto code that Sonar already excludes.

* ### Task tickets:

    * Task ID: AAASM-3963.
    * Relative task IDs:
        * [x] AAASM-3967 — 🔧 Ignore generated proto in Codecov to match Sonar scope.
        * [x] AAASM-3968 — 📝 Document shared lcov.info coverage source.
        * [ ] AAASM-3970 — ✅ Verify acceptance criteria.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    * `codecov.yml` `ignore` now includes `src/proto/generated/**` (in addition to the existing `native/aa-ffi-node/index.cjs`), matching Sonar's `sonar.coverage.exclusions` / `sonar.exclusions`.
    * Added comments in `codecov.yml` and `sonar-project.properties` recording that both tools share `coverage/lcov.info` from a single `pnpm test:coverage` run, and that any residual % delta is engine-level (Sonar analyzer vs vitest/v8 line counting) + scope (`sonar.sources=src/`), not a regression.

## _Effecting Scope_

* Action Types:
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
* Scopes:
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
        * [x] 📦 Project configurations
    * [x] 📚 Documentation
* Additional description:
    Config + comments only. No source, test, or build-output changes. No coverage regression — the underlying report is unchanged; only Codecov's ignore scope is aligned to Sonar's.

## _Description_

* Add `src/proto/generated/**` to `codecov.yml` `ignore`.
* Document the shared `coverage/lcov.info` source in `codecov.yml` and `sonar-project.properties`.

Closes AAASM-3963

🤖 Generated with [Claude Code](https://claude.com/claude-code)
