### PR TITLE
[AAASM-3996] 🔒 (node-sdk): Fail-closed on runtime-unreachable under enforce (py/go parity)

### DIFF
--- a/src/core/init-assembly.ts
+++ b/src/core/init-assembly.ts
@@ -135,7 +135,7 @@ export function createClient(
         apiKey: config.apiKey ?? "",
         mode: "napi-inprocess"
       });
-    return createNativeGatewayClient(mode, nativeClient, config.agentId, httpBaseUrl);
+    return createNativeGatewayClient(mode, nativeClient, config.agentId, httpBaseUrl, config.enforcementMode);
   }
 
   return createNoopGatewayClient(mode, httpBaseUrl);

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -7,6 +7,7 @@ import type {
   GatewayResultRecord
 } from "../types/gateway-governance.js";
 import type { AssemblyMode } from "../types/assembly-mode.js";
+import type { EnforcementMode } from "../types/enforcement-mode.js";
 import type { NativeClient } from "../native/client.js";
 
 export interface GatewayClient {
@@ -75,18 +76,25 @@ function toNativeQuery(
  *   - `pending` → `{ pending: true }` (routes to the approval path)
  *   - allow / redact / unspecified → `{ denied: false }`
  *
- * **Fail-open (security-critical):** the SDK is advisory, not a security
- * boundary. The native primitive already returns `allow` when the runtime is
- * unreachable or too slow; on top of that, any local fault while querying is
- * swallowed here and resolves neutral, so a missing or degraded runtime never
- * blocks the agent. The proxy / eBPF layers remain authoritative.
+ * **Enforcement posture (AAASM-3996 — py/go parity, AAASM-3920):** under
+ * `enforce` the SDK is a fail-closed control: a caught local fault or an
+ * unreachable runtime while querying resolves to `{ denied: true }` so a
+ * stalled/killed sidecar cannot turn deny-on-failure into allow-on-failure.
+ * In any other posture (`observe` / `disabled` / unset) the SDK stays advisory
+ * — the fault is swallowed and resolves neutral (`{ denied: false }`) so a
+ * missing or degraded runtime never blocks the agent. The proxy / eBPF layers
+ * remain authoritative in every posture.
  */
 export function createNativeGatewayClient(
   mode: AssemblyMode,
   nativeClient: NativeClient,
   agentId?: string,
-  httpBaseUrl?: string
+  httpBaseUrl?: string,
+  enforcementMode?: EnforcementMode
 ): GatewayClient {
+  // Fail-closed posture mirrors the go SDK's `failClosed` and the Python
+  // enforce guard: only an explicit `"enforce"` denies on fault (AAASM-3920).
+  const failClosed = enforcementMode === "enforce";
   return {
     mode,
     ...(httpBaseUrl === undefined ? {} : { httpBaseUrl }),
@@ -103,8 +111,10 @@ export function createNativeGatewayClient(
           ...(verdict.reason === undefined ? {} : { reason: verdict.reason })
         };
       } catch {
-        // Fail open: a local fault talking to the runtime must never block.
-        return { denied: false, pending: false };
+        // Under enforce a local fault / unreachable runtime must deny rather
+        // than downgrade to allow-on-failure (AAASM-3996). Otherwise the SDK
+        // stays advisory and fails open.
+        return { denied: failClosed, pending: false };
       }
     },
     waitForApproval: async () => ({ denied: false }),

--- a/tests/native-gateway-enforcement.test.ts
+++ b/tests/native-gateway-enforcement.test.ts
@@ -88,6 +88,50 @@ describe("native gateway enforcement (AAASM-3050)", () => {
     expect(executeFn).toHaveBeenCalledOnce();
   });
 
+  it("FAIL-CLOSED: under enforce, an unreachable runtime denies the tool (AAASM-3996)", async () => {
+    // py/go parity (AAASM-3920): when the caller opts into enforce, a caught
+    // local fault / unreachable runtime must deny rather than fail open, so a
+    // stalled or killed sidecar cannot downgrade deny-on-failure to allow.
+    const gateway = createNativeGatewayClient(
+      "napi-inprocess",
+      fakeNativeClient(async () => {
+        throw new Error("AA_ERR_CONNECT:no runtime listening");
+      }),
+      "agent-1",
+      undefined,
+      "enforce"
+    );
+
+    // The gateway decision itself denies on fault under enforce.
+    const decision = await gateway.check({ action: "tool_call", toolName: "delete_all", runId: "run-1" });
+    expect(decision).toEqual({ denied: true, pending: false });
+
+    // End-to-end: the wrapper blocks the tool and never runs its body.
+    const executeFn = vi.fn(async () => "should-not-run");
+    const tools = { delete_all: { description: "danger", execute: executeFn } };
+    withAssembly(tools, { gatewayClient: gateway });
+
+    await expect(tools.delete_all.execute()).rejects.toThrow(PolicyViolationError);
+    expect(executeFn).not.toHaveBeenCalled();
+  });
+
+  it("ADVISORY: under observe, an unreachable runtime still fails open", async () => {
+    // Non-enforce postures keep the advisory fail-open: a missing runtime must
+    // not block the agent.
+    const gateway = createNativeGatewayClient(
+      "napi-inprocess",
+      fakeNativeClient(async () => {
+        throw new Error("AA_ERR_CONNECT:no runtime listening");
+      }),
+      "agent-1",
+      undefined,
+      "observe"
+    );
+
+    const decision = await gateway.check({ action: "tool_call", toolName: "search", runId: "run-2" });
+    expect(decision).toEqual({ denied: false, pending: false });
+  });
+
   it("defaults denied/pending to false and omits reason when the verdict is bare", async () => {
     // A verdict object with no denied/pending/reason exercises the `?? false`
     // fallbacks and the reason-omission branch.


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Bring the node-sdk's in-process (napi-inprocess) gateway client to
    python/go (AAASM-3920) fail-closed parity: under `enforce`, a caught native
    fault / unreachable runtime must **deny** rather than silently fail open.

* ### Task tickets:

    * Task ID: N/A (Low batch — no dedicated node subtask).
    * Relative task IDs:
        * [x] Refs AAASM-3996 (node parity portion)
        * [x] Parity with AAASM-3920 (python/go fail-closed-under-enforce)
    * Relative PRs:
        * agent-assembly (Rust part): `[AAASM-3989] 🔒 (aa-sdk-client): Cap IPC frame + fail-closed on unknown decision`

* ### Key point change (optional):

    `createNativeGatewayClient.check()` previously swallowed any caught native
    fault and resolved `{ denied: false }` — a fail-open even under enforce, so a
    stalled/killed runtime let a denied action proceed. The enforcement mode is
    now threaded into the client; under `enforce` a caught fault / unreachable
    runtime resolves `{ denied: true }`. Non-enforce postures
    (`observe`/`disabled`/unset) keep the advisory fail-open.

## _Effecting Scope_

* Action Types:
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
    * [x] 🔧 Fixing bug
* Scopes:
    * [x] 🪡 API client and transport
    * [x] ⛑️ Error handling
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
* Additional description:

    Only in-process `napi-inprocess` `check()` behaviour under enforce changes;
    default (unset enforcement mode) and observe callers are unaffected. The
    proxy / eBPF layers remain authoritative in every posture.

## _Description_

* `src/gateway/client.ts` — add an optional `enforcementMode` parameter to
  `createNativeGatewayClient`; on a caught `queryPolicy` fault return
  `{ denied: enforcementMode === "enforce" }`.
* `src/core/init-assembly.ts` — pass `config.enforcementMode` when constructing
  the native gateway client.
* `tests/native-gateway-enforcement.test.ts` — new tests: enforce +
  runtime-unreachable → denied (unit + end-to-end via `withAssembly`); observe +
  unreachable → still fails open.

### Verification

- `pnpm install` — clean
- `pnpm test` — 346 passed, 2 skipped
- `pnpm typecheck` — clean
- `pnpm lint` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73


[AAASM-3989]: https://lightning-dust-mite.atlassian.net/browse/AAASM-3989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ