### PR TITLE
[AAASM-4000] 🔧 (ci): Align Codecov scope to sonar.sources (drop scripts/)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -16,3 +16,8 @@ ignore:
   # Generated protoc-gen-ts_proto output; Sonar excludes it too
   # (sonar.coverage.exclusions in sonar-project.properties).
   - "src/proto/generated/**"
+  # Build/release helper scripts. vitest's coverage.include pulls scripts/*.mjs
+  # into lcov.info, but Sonar measures only sonar.sources=src/, so Codecov
+  # counted them and Sonar did not — the sole cause of the headline % gap.
+  # Ignoring them makes Codecov's measured set equal src/ (minus generated proto).
+  - "scripts/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,10 +3,12 @@
 # (Codecov via `files: ./coverage/lcov.info`, Sonar via
 # `sonar.javascript.lcov.reportPaths`). The report source is therefore unified —
 # any residual % delta between the two dashboards is engine-level only (Sonar's
-# analyzer vs vitest/v8 line counting) plus scope (Sonar limits to
-# `sonar.sources=src/`), NOT a coverage regression. The `ignore` list below is
-# kept in lockstep with Sonar's exclusions (`src/proto/generated/**`) so both
-# tools measure the same code.
+# analyzer vs vitest/v8 line counting), NOT a coverage regression. The `ignore`
+# list below reconciles Codecov's measured file set with Sonar's scope
+# (`sonar.sources=src/`): it drops the generated proto (`src/proto/generated/**`,
+# mirroring `sonar.coverage.exclusions`) AND the build/release helper scripts
+# (`scripts/**`) that vitest pulls into lcov.info but Sonar never measures, so
+# both tools now count the same effective set (`src/` minus generated code).
 codecov:
   token: $CODECOV_TOKEN
   branch: master


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Reconcile Codecov's measured file set with SonarCloud's scope for **node-sdk** so the two dashboards' headline coverage % converge (Epic AAASM-3999). Both tools read the same `coverage/lcov.info`; the ~15pt gap (Codecov 82% vs Sonar 96.9%) came entirely from Codecov counting the `scripts/**` build/release helper files that Sonar (`sonar.sources=src/`) never measures.

* ### Task tickets:

    * Task ID: [AAASM-4000](https://lightning-dust-mite.atlassian.net/browse/AAASM-4000) (Story, under Epic [AAASM-3999](https://lightning-dust-mite.atlassian.net/browse/AAASM-3999)).
    * Relative task IDs:
        * [x] [AAASM-4003](https://lightning-dust-mite.atlassian.net/browse/AAASM-4003) — Add `scripts/**` to `codecov.yml` ignore.
        * [x] [AAASM-4005](https://lightning-dust-mite.atlassian.net/browse/AAASM-4005) — Document the reconciled scope in the header comment.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    Investigated the actual lcov file set (not guessed). `pnpm test:coverage` emits two path roots: `src/**` and `scripts/**`. vitest's `coverage.include: ["src/**/*.ts", "scripts/**/*.mjs"]` puts 5 helper scripts into the report:

    | file | lines hit / found |
    | --- | --- |
    | scripts/gen-proto.mjs | 0 / 67 |
    | scripts/postinstall.mjs | 108 / 108 |
    | scripts/version-channels.mjs | 0 / 185 |
    | scripts/version-channels.test.mjs | 0 / 129 |
    | scripts/write-cjs-package-json.mjs | 28 / 28 |

    Grouped line coverage from the lcov:
    * All files (Codecov's current set): 2205/2622 = **84.1%** (badge shows 82%).
    * `scripts/` only: 136/517 = **26.3%** — the denominator drag.
    * `src/` only (= `sonar.sources`, Sonar's set): 2069/2105 = **98.3%** (Sonar reports 96.9%; small residual = Sonar's line-engine re-derivation).

    Adding `scripts/**` to `codecov.yml ignore` makes Codecov's measured set equal `src/` (minus the already-excluded generated proto), so **expected post-fix Codecov ≈ 98%**, converging with Sonar 96.9% within the Epic's documented tolerance. Sonar scope is untouched → no Quality Gate impact. vitest is intentionally left as-is so `scripts/` coverage stays visible in local `text` output; only Codecov's headline denominator is reconciled.

## _Effecting Scope_

* Action Types:
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
* Scopes:
    * [x] 🚀 Building
        * [x] 🤖 CI/CD
        * [x] 📦 Project configurations
* Additional description:
    Config-only change. No source, test, or runtime behaviour is affected.

## _Description_

* Add `scripts/**` to `codecov.yml` `ignore` so Codecov measures the same file set as `sonar.sources=src/`.
* Update the `codecov.yml` header comment to document that the ignore list now drops both the generated proto and `scripts/**`, keeping Codecov and Sonar on the same effective set.

Closes AAASM-4000


[AAASM-4000]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-3999]: https://lightning-dust-mite.atlassian.net/browse/AAASM-3999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-4003]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-4005]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ