### PR TITLE
[AAASM-3998] 🔧 (ci): CI/metadata hardening

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -51,7 +51,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write  # npm OIDC Trusted Publishing + SLSA provenance
 
 jobs:
   publish:


### PR DESCRIPTION
## What

CI/CD hardening for AAASM-3998 (LOW batch), node-sdk slice.

- **Drop redundant workflow-wide `id-token: write`** in `release-node.yml` — both jobs (`publish`, `version-docs`) declare their own job-level `permissions` blocks, which fully override the workflow default, so the top-level `id-token: write` was unused. `publish` retains its own `id-token: write` for npm OIDC Trusted Publishing / SLSA provenance; the workflow default is now `contents: read`.

## Why

Least-privilege: no job relied on the workflow-level `id-token: write`, so removing it shrinks the default token scope without changing behavior.

## How to verify

- `actionlint .github/workflows/release-node.yml` — clean.

## Deferred

- **(f) eBPF loaderd control-plane authz** (agent-assembly `aa-ebpf`) is a deployment concern tracked under **AAASM-3948**. No change here.

Refs AAASM-3998

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73
