### PR TITLE
[AAASM-4017] 🔧 (ci): Migrate npm publish to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -56,6 +56,13 @@ jobs:
   publish:
     name: Publish @agent-assembly/sdk + 4 runtime sub-packages to npm
     runs-on: ubuntu-latest
+    # AAASM-4017: gate the OIDC-authenticated npm publish behind a protected
+    # GitHub Environment. The npm "trusted publisher" config on npmjs.com must
+    # name this repo + this workflow file + THIS environment; adding required
+    # reviewers to the `npm` environment gives a human approval checkpoint
+    # before any publish runs. Both the GitHub Environment and the npmjs
+    # trusted-publisher config are manual, admin-only setup — see the PR body.
+    environment: npm
     permissions:
       contents: write  # AAASM-2955: create the git tag + GitHub Release for the published version
       id-token: write  # npm OIDC Trusted Publishing + SLSA provenance
@@ -74,8 +81,18 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 22
+          # registry-url is still required: it pins the publish registry (and
+          # thus the OIDC audience) to npmjs.org. With no NODE_AUTH_TOKEN set on
+          # the publish steps below, npm >= 11.5.1 falls through to OIDC trusted
+          # publishing rather than a stored token.
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
+
+      # AAASM-4017: OIDC trusted publishing is GA only in npm CLI >= 11.5.1, but
+      # Node 22 bundles an older npm. Upgrade the global npm that the
+      # `npm publish` steps below invoke so the OIDC token-exchange path exists.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
 
       - run: pnpm install --frozen-lockfile
 
@@ -334,9 +351,14 @@ jobs:
         # gate. workflow_dispatch with dry-run=true must skip every step
         # that mutates the npm registry.
         if: steps.tag.outputs.publish_mode == 'all' && steps.tag.outputs.dry_run != 'true'
+        # AAASM-4017: authenticate via npm OIDC trusted publishing instead of a
+        # long-lived NODE_AUTH_TOKEN. With id-token:write + the `npm`
+        # environment (above) and a trusted publisher configured on npmjs.org,
+        # npm >= 11.5.1 mints a short-lived, publish-scoped credential from the
+        # workflow's OIDC identity — so no stored token is needed to publish the
+        # package contents. NPM_CONFIG_PROVENANCE keeps SLSA provenance on.
         env:
           NPM_CONFIG_PROVENANCE: "true"
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
           VERSION=$(node -p "require('./package.json').version")
@@ -350,8 +372,11 @@ jobs:
           echo "Publishing runtime sub-packages at version=$VERSION dist-tag arg='$DIST_TAG'"
           for pkg in runtime-linux-x64 runtime-linux-arm64 runtime-darwin-x64 runtime-darwin-arm64; do
             echo "::group::publish @agent-assembly/${pkg}"
+            # npm publish (not pnpm) drives OIDC trusted publishing; --provenance
+            # attaches the SLSA attestation. --no-git-checks was pnpm-only and
+            # has no npm equivalent (npm does not gate publish on git state).
             # shellcheck disable=SC2086
-            pnpm publish --access public --no-git-checks $DIST_TAG "packages/${pkg}"
+            npm publish --access public --provenance $DIST_TAG "packages/${pkg}"
             echo "::endgroup::"
           done
 
@@ -361,9 +386,10 @@ jobs:
         # both modes still skip cleanly when the operator dispatches with
         # dry-run=true.
         if: steps.tag.outputs.dry_run != 'true'
+        # AAASM-4017: OIDC trusted publishing — no NODE_AUTH_TOKEN. See the
+        # runtime-sub-packages publish step above for the full rationale.
         env:
           NPM_CONFIG_PROVENANCE: "true"
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
           # Derive the npm dist-tag from the SemVer pre-release identifier.
@@ -375,7 +401,7 @@ jobs:
           fi
           echo "Publishing main SDK at version=$VERSION dist-tag arg='$DIST_TAG'"
           # shellcheck disable=SC2086
-          pnpm publish --access public --no-git-checks $DIST_TAG
+          npm publish --access public --provenance $DIST_TAG
 
       # AAASM-3840: keep the npm `latest` dist-tag current.
       #
@@ -400,6 +426,15 @@ jobs:
       # step) so every real publish re-asserts the invariant.
       - name: Update `latest` dist-tag to newest published version
         if: steps.tag.outputs.dry_run != 'true'
+        # AAASM-4017: OIDC trusted publishing currently authenticates ONLY the
+        # `npm publish` command (npm/cli#8547). `npm dist-tag add` is a
+        # non-publish registry write that OIDC does not cover, so this step
+        # still needs a token. The blast radius is much smaller than before:
+        # package *contents* now ship tokenlessly via OIDC + provenance above,
+        # and this token only moves a dist-tag pointer. Scope NPM_TOKEN to a
+        # granular automation token limited to @agent-assembly/* dist-tag
+        # management (see PR body); drop this step's token entirely once npm
+        # extends OIDC to dist-tag (npm/cli#8547).
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |


### PR DESCRIPTION
## What

Migrates the `release-node.yml` npm publish job from a long-lived `NPM_TOKEN` to **npm OIDC Trusted Publishing** for the package publish itself.

- Adds a protected `environment: npm` to the `publish` job.
- Upgrades npm to `>= 11.5.1` (`npm install -g npm@latest`) — OIDC trusted publishing is GA only in npm 11.5.1+, and Node 22 bundles an older npm.
- Switches both publish steps (`Publish 4 runtime sub-packages`, `Publish main @agent-assembly/sdk`) from `pnpm publish` to `npm publish --provenance`, and **removes `NODE_AUTH_TOKEN`** — npm mints a short-lived, publish-scoped credential from the workflow's OIDC identity.
- Keeps `NPM_CONFIG_PROVENANCE: "true"` so SLSA provenance still attaches.
- Keeps `workflow_dispatch` trigger, dry-run gating, dist-tag logic, SBOM, and GitHub Release steps unchanged.

Job-level `id-token: write` (+ `contents: write` for the git tag/release) was already present.

## Why

AAASM-4017 [MED]: the workflow set `id-token: write` + `NPM_CONFIG_PROVENANCE: true` but still authenticated the publish with a stored, long-lived `secrets.NPM_TOKEN` and had no `environment:` gate — unlike python-sdk, which uses PyPI Trusted Publishing (OIDC, no stored token) behind `environment: pypi`. This brings node-sdk to parity: the package *contents* now publish tokenlessly via OIDC + provenance.

## Known limitation (one token remains, intentionally)

npm OIDC Trusted Publishing currently authenticates **only** the `npm publish` command ([npm/cli#8547](https://github.com/npm/cli/issues/8547)). The `Update latest dist-tag` step runs `npm dist-tag add`, a non-publish registry write OIDC does not cover, so it **still needs a token**. Blast radius is much smaller: it no longer publishes package contents, only moves a dist-tag pointer. It should be a **granular automation token scoped to `@agent-assembly/*` dist-tag management**. Once npm extends OIDC to dist-tag, that token can be dropped entirely.

## ⚠️ Manual admin setup required before this works

**This code change alone will NOT publish successfully until a repo/npm admin completes both of the following.** Until then, a dispatched release will fail auth at the publish step.

- [ ] **GitHub Environment** — create an Environment named exactly `npm` in this repo (Settings → Environments → New environment). Add **required reviewers** (Pioneer team) so publishes gate on human approval. No secrets need to live in the environment for the OIDC publish itself.
- [ ] **npmjs Trusted Publisher** — on npmjs.com, for **each** published package (`@agent-assembly/sdk`, `@agent-assembly/runtime-linux-x64`, `@agent-assembly/runtime-linux-arm64`, `@agent-assembly/runtime-darwin-x64`, `@agent-assembly/runtime-darwin-arm64`): Package Settings → **Trusted Publisher** → add a GitHub Actions publisher with:
  - Organization/Repository: `ai-agent-assembly/node-sdk`
  - Workflow filename: `release-node.yml`
  - Environment: `npm`
- [ ] **`NPM_TOKEN` secret** — keep a secret named `NPM_TOKEN` available to the workflow, but **downgrade it to a granular automation token scoped only to dist-tag management for `@agent-assembly/*`** (it no longer needs publish scope). Required only by the `Update latest dist-tag` step (see "Known limitation").

## How to verify

- `actionlint .github/workflows/release-node.yml` passes; YAML parses.
- After the manual setup above, dispatch `release-node` with `dry-run=true` (skips registry writes) to confirm the job wiring, then a real pre-release publish to confirm OIDC auth + provenance.

Refs AAASM-4017

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73
