### PR TITLE
[AAASM-4013] 🐛 (sdk): Fail closed on runtime-down + unknown decision under enforce

### DIFF
--- a/src/core/init-assembly.ts
+++ b/src/core/init-assembly.ts
@@ -133,7 +133,10 @@ export function createClient(
       createNativeClient({
         gateway: config.gatewayUrl ?? "",
         apiKey: config.apiKey ?? "",
-        mode: "napi-inprocess"
+        mode: "napi-inprocess",
+        // AAASM-4013: under enforce, a runtime that returns no authoritative
+        // verdict (fail-open sentinel / unknown decision) must deny, not allow.
+        failClosed: config.enforcementMode === "enforce"
       });
     return createNativeGatewayClient(mode, nativeClient, config.agentId, httpBaseUrl, config.enforcementMode);
   }
@@ -408,7 +411,10 @@ export async function initAssembly(config: AssemblyConfig = {}): Promise<Assembl
     nativeClient = createNativeClient({
       gateway: resolvedGatewayUrl,
       apiKey: resolvedApiKey,
-      mode: resolvedConfig.mode === "napi-inprocess" ? "napi-inprocess" : "grpc-sidecar"
+      mode: resolvedConfig.mode === "napi-inprocess" ? "napi-inprocess" : "grpc-sidecar",
+      // AAASM-4013: under enforce, a runtime that returns no authoritative
+      // verdict (fail-open sentinel / unknown decision) must deny, not allow.
+      failClosed: resolvedConfig.enforcementMode === "enforce"
     });
   }
 

--- a/src/native/client.ts
+++ b/src/native/client.ts
@@ -118,21 +118,58 @@ export interface NativeClient {
 }
 
 /**
+ * Reason string the native shim attaches to a fail-open `"allow"` when the
+ * runtime does not answer (AAASM-4013). It must stay byte-for-byte identical to
+ * `FAIL_OPEN_REASON` in `native/aa-ffi-node/src/lib.rs`: the shim folds
+ * `QueryFailed` / `ChannelClosed` / `Shutdown` onto `"allow"` + this reason, so
+ * it is the *only* signal the JS layer has to tell "the runtime failed open"
+ * apart from a genuine policy `"allow"`. Under `failClosed` that distinction is
+ * security-critical.
+ */
+export const FAIL_OPEN_REASON = "aa-runtime unreachable or slow; failing open (advisory SDK)";
+
+/**
  * Translate the native `{decision, reason}` verdict into the SDK's
  * `PolicyResult`. Only `"deny"` blocks; `"pending"` routes to the approval
- * path; `"allow"` / `"redact"` / any unrecognized value proceed. This mirrors
- * the shared enforcement contract across the Python / Go / Node SDKs.
+ * path; `"allow"` / `"redact"` proceed. This mirrors the shared enforcement
+ * contract across the Python / Go / Node SDKs.
  *
- * The native primitive already fails open (returns `"allow"`) when the runtime
- * is unreachable or too slow, so a missing or degraded runtime never blocks.
+ * **Fail-closed (AAASM-4013):** the native shim folds an unreachable / slow /
+ * closed runtime onto `"allow"` + {@link FAIL_OPEN_REASON}, and an
+ * unspecified / unrecognized runtime verdict onto the empty decision `""`.
+ * Neither is an authoritative allow — it is "no verdict came back". When
+ * `failClosed` is set (only under `enforcementMode: "enforce"`) these must
+ * **deny** rather than silently proceed, matching the Python SDK's enforce
+ * posture. When `failClosed` is `false` (observe / disabled / unset) they fail
+ * open, preserving the advisory behavior — the proxy / eBPF layers remain
+ * authoritative.
  */
-function mapDecisionToPolicyResult(verdict: NativePolicyDecision): PolicyResult {
+function mapDecisionToPolicyResult(
+  verdict: NativePolicyDecision,
+  failClosed: boolean
+): PolicyResult {
   switch (verdict.decision) {
     case "deny":
       return { denied: true, pending: false, reason: verdict.reason };
     case "pending":
       return { denied: false, pending: true, reason: verdict.reason };
+    case "allow":
+      if (failClosed && verdict.reason === FAIL_OPEN_REASON) {
+        return { denied: true, pending: false, reason: verdict.reason };
+      }
+      return { denied: false, pending: false };
+    case "redact":
+      return { denied: false, pending: false };
     default:
+      // Empty / unrecognized decision: the runtime produced no authoritative
+      // verdict. Deny under enforce (fail closed); otherwise proceed.
+      if (failClosed) {
+        return {
+          denied: true,
+          pending: false,
+          reason: verdict.reason || "runtime returned no authoritative decision"
+        };
+      }
       return { denied: false, pending: false };
   }
 }
@@ -200,6 +237,10 @@ function loadNativeBinding(): NativeBinding {
 
 export function createNativeClient(options: InitAssemblyOptions): NativeClient {
   const mode = options.mode ?? "grpc-sidecar";
+  // Fail-closed posture (AAASM-4013): deny on a non-authoritative verdict only
+  // under enforce. Defaults to fail-open so observe / disabled / unset are
+  // unchanged.
+  const failClosed = options.failClosed ?? false;
 
   if (mode !== "napi-inprocess") {
     return {
@@ -293,7 +334,7 @@ export function createNativeClient(options: InitAssemblyOptions): NativeClient {
       // or too slow, so a missing or degraded runtime never blocks the agent.
       const handle = await getHandle();
       const verdict = await binding.queryPolicy(handle, action);
-      return mapDecisionToPolicyResult(verdict);
+      return mapDecisionToPolicyResult(verdict, failClosed);
     },
     register: async (options: RegisterOptions) => {
       // Register on the same session the queryPolicy path uses, so the token

--- a/src/types/policy.ts
+++ b/src/types/policy.ts
@@ -4,6 +4,14 @@ export interface InitAssemblyOptions {
   gateway: string;
   apiKey: string;
   mode?: RuntimeMode;
+  /**
+   * Fail-closed posture for the native policy check (AAASM-4013). When `true`
+   * (set only under `enforcementMode: "enforce"`), a runtime that returns no
+   * authoritative verdict — the fail-open sentinel or an unknown decision — is
+   * treated as a denial rather than an allow. Defaults to `false` (fail open),
+   * preserving the advisory behavior for `observe` / `disabled` / unset modes.
+   */
+  failClosed?: boolean;
 }
 
 export interface AssemblyRuntimeHandle {

--- a/tests/create-client-mode-routing.test.ts
+++ b/tests/create-client-mode-routing.test.ts
@@ -78,6 +78,50 @@ describe("createClient mode routing (AAASM-3050)", () => {
     await client.close();
   });
 
+  // AAASM-4013: `createClient` must derive the native fail-closed posture from
+  // `enforcementMode`. Under enforce, a runtime that fails open (returns the
+  // allow sentinel because it is unreachable / slow) must be DENIED end-to-end
+  // through `check()`; without enforce the same sentinel proceeds. This exercises
+  // the `failClosed: config.enforcementMode === "enforce"` plumbing (both ternary
+  // branches) via the real, non-overridden native-client path.
+  const FAIL_OPEN_REASON = "aa-runtime unreachable or slow; failing open (advisory SDK)";
+
+  it("napi-inprocess + enforce: a runtime-down fail-open sentinel is DENIED through check()", async () => {
+    const binding = makeBinding("allow", FAIL_OPEN_REASON);
+    const mod = await loadCreateClientWithBinding(binding);
+
+    const client = mod.createClient({
+      gatewayUrl: "/tmp/aa.sock",
+      apiKey: "k",
+      agentId: "agent-enforce",
+      mode: "napi-inprocess",
+      enforcementMode: "enforce"
+    });
+
+    await expect(
+      client.check({ action: "tool_call", toolName: "rm", runId: "run-enforce" })
+    ).resolves.toEqual({ denied: true, pending: false, reason: FAIL_OPEN_REASON });
+    await client.close();
+  });
+
+  it("napi-inprocess + observe: the same fail-open sentinel proceeds (advisory)", async () => {
+    const binding = makeBinding("allow", FAIL_OPEN_REASON);
+    const mod = await loadCreateClientWithBinding(binding);
+
+    const client = mod.createClient({
+      gatewayUrl: "/tmp/aa.sock",
+      apiKey: "k",
+      agentId: "agent-observe",
+      mode: "napi-inprocess",
+      enforcementMode: "observe"
+    });
+
+    await expect(
+      client.check({ action: "tool_call", toolName: "search", runId: "run-observe" })
+    ).resolves.toEqual({ denied: false, pending: false });
+    await client.close();
+  });
+
   it("sdk-only: check() is allow-by-default and never loads the native binding", async () => {
     const binding = makeBinding("deny", "must-not-be-consulted");
     const mod = await loadCreateClientWithBinding(binding);

--- a/tests/native-client.test.ts
+++ b/tests/native-client.test.ts
@@ -285,6 +285,56 @@ describe("createNativeClient", () => {
       });
       await client.close();
     });
+
+    it("napi-inprocess + failClosed: a REDACT verdict is authoritative and proceeds", async () => {
+      // `redact` is a real runtime verdict (the tool runs, with output
+      // redaction applied downstream), NOT a "no verdict" sentinel — so it must
+      // proceed even under enforce. Only the fail-open sentinel / unknown
+      // decision deny under failClosed.
+      const mod = await loadNativeClientWithBinding(() => ({
+        connect: vi.fn(async () => ({ id: "handle-redact" })),
+        sendEvent: vi.fn(() => undefined),
+        queryPolicy: vi.fn(() => ({ decision: "redact", reason: "secrets stripped" })),
+        disconnect: vi.fn(async () => undefined)
+      }));
+
+      const client = mod.createNativeClient({
+        gateway: "/tmp/aa.sock",
+        apiKey: "test-key",
+        mode: "napi-inprocess",
+        failClosed: true
+      });
+
+      await expect(client.queryPolicy({ action_type: "tool_call" })).resolves.toEqual({
+        denied: false,
+        pending: false
+      });
+      await client.close();
+    });
+
+    it("napi-inprocess without failClosed: an unknown/empty decision still fails open (observe/disabled)", async () => {
+      // The observe/disabled counterpart of the failClosed unknown-decision
+      // test above: with no enforce posture, an unspecified runtime verdict must
+      // NOT start blocking — the proxy / eBPF layers stay authoritative.
+      const mod = await loadNativeClientWithBinding(() => ({
+        connect: vi.fn(async () => ({ id: "handle-unknown-open" })),
+        sendEvent: vi.fn(() => undefined),
+        queryPolicy: vi.fn(() => ({ decision: "", reason: "" })),
+        disconnect: vi.fn(async () => undefined)
+      }));
+
+      const client = mod.createNativeClient({
+        gateway: "/tmp/aa.sock",
+        apiKey: "test-key",
+        mode: "napi-inprocess"
+      });
+
+      await expect(client.queryPolicy({ action_type: "tool_call" })).resolves.toEqual({
+        denied: false,
+        pending: false
+      });
+      await client.close();
+    });
   });
 
   it("maps connect failure to NativeConnectError", async () => {

--- a/tests/native-client.test.ts
+++ b/tests/native-client.test.ts
@@ -187,6 +187,106 @@ describe("createNativeClient", () => {
     await client.close();
   });
 
+  // AAASM-4013: the native shim folds an unreachable/slow/closed runtime onto a
+  // NON-throwing `allow` + FAIL_OPEN_REASON, and an unspecified runtime verdict
+  // onto the empty decision "". Under `failClosed` (enforce) neither is an
+  // authoritative allow, so both must deny rather than silently proceed.
+  describe("fail-closed on non-authoritative verdicts (AAASM-4013)", () => {
+    it("napi-inprocess + failClosed: the fail-open allow sentinel denies", async () => {
+      const mod = await loadNativeClientWithBinding(() => ({
+        connect: vi.fn(async () => ({ id: "handle-sentinel" })),
+        sendEvent: vi.fn(() => undefined),
+        // The REAL runtime-down verdict: a non-throwing allow tagged with the
+        // shim's fail-open reason (not a synthetic throw).
+        queryPolicy: vi.fn(() => ({ decision: "allow", reason: mod.FAIL_OPEN_REASON })),
+        disconnect: vi.fn(async () => undefined)
+      }));
+
+      const client = mod.createNativeClient({
+        gateway: "/tmp/aa.sock",
+        apiKey: "test-key",
+        mode: "napi-inprocess",
+        failClosed: true
+      });
+
+      await expect(client.queryPolicy({ action_type: "tool_call" })).resolves.toEqual({
+        denied: true,
+        pending: false,
+        reason: mod.FAIL_OPEN_REASON
+      });
+      await client.close();
+    });
+
+    it("napi-inprocess + failClosed: an unknown/empty decision denies", async () => {
+      const mod = await loadNativeClientWithBinding(() => ({
+        connect: vi.fn(async () => ({ id: "handle-unknown" })),
+        sendEvent: vi.fn(() => undefined),
+        // Unspecified/garbled runtime verdict maps to "" via decision_to_str.
+        queryPolicy: vi.fn(() => ({ decision: "", reason: "" })),
+        disconnect: vi.fn(async () => undefined)
+      }));
+
+      const client = mod.createNativeClient({
+        gateway: "/tmp/aa.sock",
+        apiKey: "test-key",
+        mode: "napi-inprocess",
+        failClosed: true
+      });
+
+      await expect(client.queryPolicy({ action_type: "tool_call" })).resolves.toEqual({
+        denied: true,
+        pending: false,
+        reason: "runtime returned no authoritative decision"
+      });
+      await client.close();
+    });
+
+    it("napi-inprocess without failClosed: the sentinel still fails open (observe/disabled)", async () => {
+      const mod = await loadNativeClientWithBinding(() => ({
+        connect: vi.fn(async () => ({ id: "handle-open" })),
+        sendEvent: vi.fn(() => undefined),
+        queryPolicy: vi.fn(() => ({ decision: "allow", reason: mod.FAIL_OPEN_REASON })),
+        disconnect: vi.fn(async () => undefined)
+      }));
+
+      const client = mod.createNativeClient({
+        gateway: "/tmp/aa.sock",
+        apiKey: "test-key",
+        mode: "napi-inprocess"
+      });
+
+      await expect(client.queryPolicy({ action_type: "tool_call" })).resolves.toEqual({
+        denied: false,
+        pending: false
+      });
+      await client.close();
+    });
+
+    it("napi-inprocess + failClosed: a genuine authoritative allow still proceeds", async () => {
+      const mod = await loadNativeClientWithBinding(() => ({
+        connect: vi.fn(async () => ({ id: "handle-genuine" })),
+        sendEvent: vi.fn(() => undefined),
+        // A real policy allow (not the fail-open sentinel) must not be denied,
+        // even under enforce.
+        queryPolicy: vi.fn(() => ({ decision: "allow", reason: "policy: permitted" })),
+        disconnect: vi.fn(async () => undefined)
+      }));
+
+      const client = mod.createNativeClient({
+        gateway: "/tmp/aa.sock",
+        apiKey: "test-key",
+        mode: "napi-inprocess",
+        failClosed: true
+      });
+
+      await expect(client.queryPolicy({ action_type: "tool_call" })).resolves.toEqual({
+        denied: false,
+        pending: false
+      });
+      await client.close();
+    });
+  });
+
   it("maps connect failure to NativeConnectError", async () => {
     const mod = await loadNativeClientWithBinding(() => ({
       connect: vi.fn(async () => {

--- a/tests/native-gateway-enforcement.test.ts
+++ b/tests/native-gateway-enforcement.test.ts
@@ -177,3 +177,86 @@ describe("native gateway enforcement (AAASM-3050)", () => {
     expect(executeFn).toHaveBeenCalledOnce();
   });
 });
+
+/**
+ * AAASM-4013 — end-to-end fail-closed enforcement through the REAL native client.
+ *
+ * Unlike the suite above (which hand-rolls a `NativeClient`), these tests drive
+ * the actual `createNativeClient` over a mocked native binding so the real
+ * `{decision, reason}` → `PolicyResult` mapping runs. This is what makes the bug
+ * observable: the shim folds a killed / stalled / unreachable runtime onto a
+ * NON-throwing `allow` + `FAIL_OPEN_REASON` (not a thrown error), and folds an
+ * unspecified verdict onto the empty decision `""`. Under `enforcementMode:
+ * "enforce"` (→ `failClosed: true`) both must block the tool; without it they
+ * fail open, so the tool proceeds (observe / disabled posture).
+ */
+async function realNativeClientWithVerdict(
+  verdict: { decision: string; reason: string },
+  failClosed: boolean
+): Promise<NativeClient> {
+  vi.resetModules();
+  vi.doMock("node:module", () => ({
+    createRequire: () => {
+      const binding = {
+        connect: vi.fn(async () => ({ id: "handle-4013" })),
+        sendEvent: vi.fn(() => undefined),
+        queryPolicy: vi.fn(() => verdict),
+        disconnect: vi.fn(async () => undefined)
+      };
+      return () => binding;
+    }
+  }));
+  const mod = await import("../src/native/client.js");
+  return mod.createNativeClient({
+    gateway: "/tmp/aa.sock",
+    apiKey: "test-key",
+    mode: "napi-inprocess",
+    failClosed
+  });
+}
+
+describe("native gateway fail-closed under enforce (AAASM-4013)", () => {
+  const FAIL_OPEN_REASON = "aa-runtime unreachable or slow; failing open (advisory SDK)";
+
+  it("ENFORCE: a runtime-down allow sentinel blocks the tool (never runs its body)", async () => {
+    const nativeClient = await realNativeClientWithVerdict(
+      { decision: "allow", reason: FAIL_OPEN_REASON },
+      true
+    );
+    const gateway = createNativeGatewayClient("napi-inprocess", nativeClient, "agent-1");
+
+    const executeFn = vi.fn(async () => "ran-despite-runtime-down");
+    const tools = { delete_all: { description: "danger", execute: executeFn } };
+    withAssembly(tools, { gatewayClient: gateway });
+
+    await expect(tools.delete_all.execute()).rejects.toThrow(PolicyViolationError);
+    expect(executeFn).not.toHaveBeenCalled();
+  });
+
+  it("ENFORCE: an unknown/empty runtime decision blocks the tool", async () => {
+    const nativeClient = await realNativeClientWithVerdict({ decision: "", reason: "" }, true);
+    const gateway = createNativeGatewayClient("napi-inprocess", nativeClient, "agent-1");
+
+    const executeFn = vi.fn(async () => "ran-on-unknown-decision");
+    const tools = { wire_transfer: { description: "money", execute: executeFn } };
+    withAssembly(tools, { gatewayClient: gateway });
+
+    await expect(tools.wire_transfer.execute()).rejects.toThrow(PolicyViolationError);
+    expect(executeFn).not.toHaveBeenCalled();
+  });
+
+  it("OBSERVE (no failClosed): the same runtime-down sentinel fails open and the tool runs", async () => {
+    const nativeClient = await realNativeClientWithVerdict(
+      { decision: "allow", reason: FAIL_OPEN_REASON },
+      false
+    );
+    const gateway = createNativeGatewayClient("napi-inprocess", nativeClient, "agent-1");
+
+    const executeFn = vi.fn(async () => "ran-fail-open");
+    const tools = { send_email: { description: "email", execute: executeFn } };
+    withAssembly(tools, { gatewayClient: gateway });
+
+    await expect(tools.send_email.execute()).resolves.toBe("ran-fail-open");
+    expect(executeFn).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## What changed

Under `enforcementMode: "enforce"` + `napi-inprocess`, a killed / stalled / unreachable runtime made the native `query_policy` return a **non-throwing** `Ok({ decision: "allow", reason: FAIL_OPEN_REASON })` (the shim folds `QueryFailed` / `ChannelClosed` / `Shutdown` onto allow), and an unspecified verdict onto the empty decision `""`. The AAASM-3996 gateway guard is **catch-only**, so these non-throwing sentinels slipped past it and a policy-denied tool executed.

This makes the raw-verdict mapping (`mapDecisionToPolicyResult` in `src/native/client.ts`) fail-closed-aware:
- Adds a JS-side `FAIL_OPEN_REASON` constant kept byte-for-byte in sync with `native/aa-ffi-node/src/lib.rs`.
- Under `failClosed` (set only for `enforce`, plumbed via a new `InitAssemblyOptions.failClosed` from both `createNativeClient` call sites), the fail-open sentinel **and** the unknown/empty decision map to `{ denied: true }` instead of allow.
- Genuine `allow` / `redact`, and the `observe` / `disabled` / unset postures, are unchanged (fail open).

This is the JS-layer fix (option 2): `aa-sdk-client` is pinned by git rev and the native shim intentionally folds error cases onto the sentinel, so no native rebuild is needed. It complements the gateway-layer catch guard (3996) as a second, non-throwing-path defense.

## Why

The SDK is advisory, but under `enforce` it is a security control and must fail closed — a stalled/killed sidecar must not turn deny-on-failure into allow-on-failure. This restores parity with the Python SDK's enforce posture (`enforce = enforcement_mode == "enforce"`; error-sentinel / unspecified decisions deny under enforce).

## How to verify

- `pnpm test` — full suite green (353 passed, 2 skipped).
- New `tests/native-client.test.ts` cases exercise the REAL non-throwing allow sentinel (`decision "allow"` + `FAIL_OPEN_REASON`) and the unknown/empty decision under `failClosed` → `{ denied: true }`, plus the fail-open counterparts (sentinel without `failClosed` still allows; a genuine authoritative allow still proceeds under enforce).
- New end-to-end `tests/native-gateway-enforcement.test.ts` cases drive the real native client through `createNativeGatewayClient` + `withAssembly`, asserting the sentinel and the unknown verdict both block the tool (`PolicyViolationError`) under enforce, while observe fails open.
- `pnpm typecheck` and `pnpm lint` clean.

Closes AAASM-4013

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73