### PR TITLE
🤖 (aa-ffi-node): Bump agent-assembly git pins to v0.0.1-rc.3

### DIFF
--- a/native/aa-ffi-node/Cargo.lock
+++ b/native/aa-ffi-node/Cargo.lock
@@ -22,8 +22,8 @@ dependencies = [
 
 [[package]]
 name = "aa-proto"
-version = "0.0.1-rc.2"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=fc90f85d63dcf2ccffbf4f920b4f41e9bc9b1a0a#fc90f85d63dcf2ccffbf4f920b4f41e9bc9b1a0a"
+version = "0.0.1-rc.3"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=3193b4c5c8e63033e270ba2d933be8c5158a12e4#3193b4c5c8e63033e270ba2d933be8c5158a12e4"
 dependencies = [
  "prost",
  "tonic",
@@ -33,8 +33,8 @@ dependencies = [
 
 [[package]]
 name = "aa-sdk-client"
-version = "0.0.1-rc.2"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=fc90f85d63dcf2ccffbf4f920b4f41e9bc9b1a0a#fc90f85d63dcf2ccffbf4f920b4f41e9bc9b1a0a"
+version = "0.0.1-rc.3"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=3193b4c5c8e63033e270ba2d933be8c5158a12e4#3193b4c5c8e63033e270ba2d933be8c5158a12e4"
 dependencies = [
  "aa-proto",
  "aa-security",
@@ -51,8 +51,8 @@ dependencies = [
 
 [[package]]
 name = "aa-security"
-version = "0.0.1-rc.2"
-source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=fc90f85d63dcf2ccffbf4f920b4f41e9bc9b1a0a#fc90f85d63dcf2ccffbf4f920b4f41e9bc9b1a0a"
+version = "0.0.1-rc.3"
+source = "git+https://github.com/ai-agent-assembly/agent-assembly.git?rev=3193b4c5c8e63033e270ba2d933be8c5158a12e4#3193b4c5c8e63033e270ba2d933be8c5158a12e4"
 dependencies = [
  "aho-corasick",
 ]

--- a/native/aa-ffi-node/Cargo.toml
+++ b/native/aa-ffi-node/Cargo.toml
@@ -26,8 +26,8 @@ crate-type = ["cdylib"]
 # downgrade detection reflects the installed @agent-assembly/sdk release.
 # Re-pin to the squash-merge commit once PR #1226 lands on master. (Prior pin
 # ebc4d7dc / AAASM-3415 added `team_id` / `parent_agent_id`, still forwarded.)
-aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "fc90f85d63dcf2ccffbf4f920b4f41e9bc9b1a0a", package = "aa-sdk-client" }
-aa-proto = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "fc90f85d63dcf2ccffbf4f920b4f41e9bc9b1a0a", package = "aa-proto" }
+aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "3193b4c5c8e63033e270ba2d933be8c5158a12e4", package = "aa-sdk-client" }
+aa-proto = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "3193b4c5c8e63033e270ba2d933be8c5158a12e4", package = "aa-proto" }
 napi = { version = "3", default-features = false, features = ["napi8", "tokio_rt", "serde-json"] }
 napi-derive = "3"
 prost = "0.14"


### PR DESCRIPTION
Auto-bump every agent-assembly git-SHA pin (`aa-sdk-client`,
`aa-proto`, and any other shared crate) in
`native/aa-ffi-node/Cargo.toml` to track agent-assembly release
`v0.0.1-rc.3` (commit `3193b4c5c8e63033e270ba2d933be8c5158a12e4`).

Per ADR 0003 all aa-* git deps must share one rev so cargo resolves
a single checkout of the agent-assembly workspace; this PR bumps them
in lockstep (AAASM-3468).

Why: without this PR, the SDK source pin drifts behind the published
agent-assembly binaries (AAASM-2880 observed an 8-day drift behind
alpha-9). Merging this PR on `node-sdk` realigns the native shim
with the matching upstream tag.

Upstream tag: https://github.com/ai-agent-assembly/agent-assembly/releases/tag/v0.0.1-rc.3
Source workflow: https://github.com/ai-agent-assembly/agent-assembly/actions/runs/28666538071