### PR TITLE
[AAASM-4062] 🐛 (node-sdk): Fix brew install command (wrong org)

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -38,7 +38,7 @@ export const RUNTIME_SUBPACKAGE: string = `runtime-${platform()}-${arch()}`;
 export const INSTALL_HINT: string = [
   "agent-assembly runtime not found.",
   "  Install with: pnpm add agent-assembly",
-  "  Or manually:  brew install agent-assembly/tap/aasm",
+  "  Or manually:  brew install ai-agent-assembly/tap/aasm",
   "               curl -fsSL https://get.agent-assembly.io | sh",
 ].join("\n");
 


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Fix the Homebrew install hint printed when the `aasm` runtime binary is not
    found. It was missing the `ai-` org prefix, pointing users at a 404.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: AAASM-4062.
    * Relative task IDs:
        * [x] AAASM-4060 (parent bug).
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    `src/runtime.ts` `INSTALL_HINT`:
    * As-is: `brew install agent-assembly/tap/aasm` — Homebrew resolves this to
      `github.com/agent-assembly/homebrew-tap`, which does not exist → **404**.
    * To-be: `brew install ai-agent-assembly/tap/aasm` — resolves to the
      canonical `github.com/ai-agent-assembly/homebrew-tap` tap.

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [ ] ✨ Adding new something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [x] 🔧 Fixing bug
        * [x] 🟢 No breaking change
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [ ] 🤖 Framework hooks
    * [ ] 🫀 Data model and types
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
        * [ ] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [ ] 🚀 Building
        * [ ] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
    * [x] 📚 Documentation
* Additional description:
    User-facing install instruction only; no code path or public API changes.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* One-line fix in `src/runtime.ts`: correct the `brew install` command in the
  `INSTALL_HINT` string from `agent-assembly/tap/aasm` to
  `ai-agent-assembly/tap/aasm` (the canonical org).
* **Root cause:** the missing `ai-` org prefix made Homebrew look up
  `github.com/agent-assembly/homebrew-tap`, a non-existent repo → 404 on
  `brew install`.
* **Validation:** grep confirms zero remaining bare `agent-assembly/tap`
  references (all now `ai-agent-assembly/tap`) and no `ai-ai-` doubling. A full
  `tsc --noEmit` typecheck was skipped because dependencies are not installed
  and installing them requires network access (unavailable); the change is a
  single string-literal edit and the surrounding file is unchanged.
