### PR TITLE
[AAASM-4067] 🐛 (release): Fix runtime npm publish path (./ prefix)

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -375,8 +375,13 @@ jobs:
             # npm publish (not pnpm) drives OIDC trusted publishing; --provenance
             # attaches the SLSA attestation. --no-git-checks was pnpm-only and
             # has no npm equivalent (npm does not gate publish on git state).
+            # AAASM-4067: the target MUST carry a leading `./`. A bare
+            # `packages/<name>` matches npm's GitHub `owner/repo` shorthand, so
+            # newer npm resolves it as `git ls-remote ssh://git@github.com/packages/<name>.git`
+            # (Permission denied) instead of publishing the local folder. `./`
+            # forces the local-directory interpretation.
             # shellcheck disable=SC2086
-            npm publish --access public --provenance $DIST_TAG "packages/${pkg}"
+            npm publish --access public --provenance $DIST_TAG "./packages/${pkg}"
             echo "::endgroup::"
           done
 


### PR DESCRIPTION
## What

`release-node.yml` line 379: `npm publish ... "packages/${pkg}"` → `"./packages/${pkg}"`.

## Why

The rc.3 real publish (`publish_mode=all`) failed at the first runtime sub-package:

```
npm publish --access public --provenance --tag rc "packages/runtime-linux-x64"
npm error command git ls-remote ssh://git@github.com/packages/runtime-linux-x64.git
npm error git@github.com: Permission denied (publickey)
```

Newer npm parses the bare `packages/runtime-linux-x64` as a GitHub `owner/repo` shorthand and tries to clone it over SSH instead of publishing the local folder. rc.2 published fine — GitHub-runner npm spec-parsing drifted (same runner-drift class as the core rc.3 break). The `./` prefix forces local-directory interpretation. Main SDK publish (line 404) has no path arg, so it's unaffected.

**Nothing reached npm** in the failed run (runtime pkgs publish before the main SDK; first runtime pkg failed) — the `0.0.1-rc.3` slot is intact.

## How to verify

Re-dispatch `release-node.yml` (`publish_mode=all`, `npm_version=0.0.1-rc.3`) — the runtime loop publishes all 4 `@agent-assembly/runtime-*@0.0.1-rc.3` + main SDK. Closes AAASM-4067.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvjnG3ysnqTY6Gu1wQ2h73