### PR TITLE
[AAASM-4091] 📝 (docs): Fix broken release-node.yml link that breaks the Docusaurus build

### DIFF
--- a/docs/release/npm-dist-tags.md
+++ b/docs/release/npm-dist-tags.md
@@ -1,6 +1,6 @@
 # npm dist-tag policy — `@agent-assembly/sdk`
 
-This package publishes to npm via [`.github/workflows/release-node.yml`](../../.github/workflows/release-node.yml).
+This package publishes to npm via [`.github/workflows/release-node.yml`](https://github.com/ai-agent-assembly/node-sdk/blob/master/.github/workflows/release-node.yml).
 Each release is routed to a **channel** dist-tag derived from its SemVer
 pre-release identifier, and the floating `latest` tag is kept current
 automatically.

--- a/website/versioned_docs/version-0.0.1-rc.3/release/npm-dist-tags.md
+++ b/website/versioned_docs/version-0.0.1-rc.3/release/npm-dist-tags.md
@@ -1,6 +1,6 @@
 # npm dist-tag policy — `@agent-assembly/sdk`
 
-This package publishes to npm via [`.github/workflows/release-node.yml`](../../.github/workflows/release-node.yml).
+This package publishes to npm via [`.github/workflows/release-node.yml`](https://github.com/ai-agent-assembly/node-sdk/blob/master/.github/workflows/release-node.yml).
 Each release is routed to a **channel** dist-tag derived from its SemVer
 pre-release identifier, and the floating `latest` tag is kept current
 automatically.


### PR DESCRIPTION
## _Target_

Fix the Docusaurus `website/` build failure so the docs-hub "Aggregate all module docs" CI can consume node-sdk's docs again.

* ### Task summary:

    `docs/release/npm-dist-tags.md` linked to `../../.github/workflows/release-node.yml`, a path **outside** the Docusaurus site root. Under `onBrokenLinks: "throw"` the build fails:

    ```
    Docusaurus found broken links!
    - Broken link on source page path = /node-sdk/release/npm-dist-tags:
       -> linking to ../../.github/workflows/release-node.yml
    ```

    The link target is repointed to the canonical absolute GitHub URL `https://github.com/ai-agent-assembly/node-sdk/blob/master/.github/workflows/release-node.yml`. External URLs are not link-checked by Docusaurus, so the build passes. The identical link in the versioned snapshot (`website/versioned_docs/version-0.0.1-rc.3/release/npm-dist-tags.md`) is fixed the same way. Link text/anchor unchanged; `onBrokenLinks` is **not** relaxed.

* ### Task tickets:

    * Task ID: AAASM-4091.
    * Relative task IDs:
        * [x] AAASM-4090 (typedoc/root-deps prerequisite for the website build).
    * Relative PRs:
        * agent-assembly-docs PR #50 — together these unblock the docs-hub aggregate.

* ### Key point change (optional):

    * As-is: `[...](../../.github/workflows/release-node.yml)` -> escapes site root -> broken link -> build throws.
    * To-be: `[...](https://github.com/ai-agent-assembly/node-sdk/blob/master/.github/workflows/release-node.yml)` -> external URL -> build passes.

## _Effecting Scope_

* Action Types:
    * [x] 🔧 Fixing bug
* Scopes:
    * [x] 📚 Documentation
* Additional description:
    Link-target-only change in two Markdown files. No SDK/runtime code, no config, no content wording changed.

## _Description_

* Repoint `docs/release/npm-dist-tags.md` workflow link to the absolute GitHub URL.
* Mirror the fix into the `version-0.0.1-rc.3` versioned snapshot the build link-checks.

### Testing

Local `website/` build (root deps installed per AAASM-4090, then `cd website && pnpm install --ignore-workspace && pnpm build`):

* **Before:** `Docusaurus found broken links! ... /node-sdk/release/npm-dist-tags -> ../../.github/workflows/release-node.yml` — exit 1.
* **After:** typedoc generates clean, `[SUCCESS] Generated static files in "build".` — exit 0, no TS errors.

Together with agent-assembly-docs PR #50, this turns the docs-hub "Aggregate all module docs" CI green for all docs PRs.

Related Jira: AAASM-4091

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz
