### PR TITLE
[AAASM-4129] 🔒 (gateway): Fail closed on pending verdict without an approval channel

### DIFF
--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -117,7 +117,18 @@ export function createNativeGatewayClient(
         return { denied: failClosed, pending: false };
       }
     },
-    waitForApproval: async () => ({ denied: false }),
+    // A `pending` verdict routes here to solicit an approval decision. The node
+    // SDK does not yet wire a real approval channel (poll/stream), so no
+    // decision can be obtained (AAASM-4129). Under `enforce` this must fail
+    // closed — deny — rather than silently downgrade an approval-required
+    // verdict to allow, matching python's `_resolve_pending_approval` and go's
+    // `WaitForApproval`, both of which deny when no approval channel is wired.
+    // In any advisory posture (observe / disabled / unset) it stays neutral so
+    // a missing approval channel never blocks the agent.
+    waitForApproval: async () =>
+      failClosed
+        ? { denied: true, reason: "approval required but no approval channel is configured" }
+        : { denied: false },
     record: async () => undefined,
     recordResult: async () => undefined,
     scanPrompts: async () => undefined

--- a/tests/native-gateway-enforcement.test.ts
+++ b/tests/native-gateway-enforcement.test.ts
@@ -169,12 +169,38 @@ describe("native gateway enforcement (AAASM-3050)", () => {
 
     const executeFn = vi.fn(async () => "approved-and-ran");
     const tools = { wire_transfer: { description: "money", execute: executeFn } };
-    // No approval push is wired in the node SDK yet, so the noop approval path
-    // resolves to "not denied" and the tool proceeds (per the shared contract).
+    // No approval channel is wired in the node SDK yet; in the ADVISORY posture
+    // (no enforcementMode) that resolves to "not denied" and the tool proceeds,
+    // so a missing approval channel never blocks the agent (AAASM-4129).
     withAssembly(tools, { gatewayClient: gateway });
 
     await expect(tools.wire_transfer.execute()).resolves.toBe("approved-and-ran");
     expect(executeFn).toHaveBeenCalledOnce();
+  });
+
+  it("PENDING under enforce: no approval channel fails closed and blocks the tool (AAASM-4129)", async () => {
+    // py/go parity: python's `_resolve_pending_approval` and go's
+    // `WaitForApproval` DENY a pending verdict when no approval channel is
+    // wired. Under enforce the node SDK must not auto-approve — the tool is
+    // blocked (never runs its body) rather than silently downgraded to allow.
+    const gateway = createNativeGatewayClient(
+      "napi-inprocess",
+      fakeNativeClient(async () => ({
+        denied: false,
+        pending: true,
+        reason: "awaiting approval"
+      })),
+      "agent-1",
+      undefined,
+      "enforce"
+    );
+
+    const executeFn = vi.fn(async () => "should-not-run-without-approval");
+    const tools = { wire_transfer: { description: "money", execute: executeFn } };
+    withAssembly(tools, { gatewayClient: gateway });
+
+    await expect(tools.wire_transfer.execute()).rejects.toThrow(PolicyViolationError);
+    expect(executeFn).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## _Target_

* ### Task summary:

    A `pending` (approval-required) verdict from the runtime was silently downgraded to *allow* at the SDK layer. The native gateway client's `waitForApproval` stub resolved `{ denied: false }`, which won the `Promise.race` against the approval timeout in `enforceGovernance`, so the wrapped tool ran with no approval ever solicited — even under `enforce`. Node was the only SDK of the three that did this: python's `_resolve_pending_approval` and go's `WaitForApproval` both DENY a pending verdict when no approval channel is wired.

    This makes a pending verdict fail **closed** under `failClosed` (enforce): `waitForApproval` now resolves `{ denied: true, reason }` when no approval channel is configured, so the wrapper throws `PolicyViolationError` and the tool never runs. Advisory postures (observe / disabled / unset) stay neutral so a missing approval channel never blocks the agent — matching the existing `check()` fault posture.

* ### Task tickets:

    * Task ID: AAASM-4129.
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    * As-is: pending verdict → `waitForApproval` resolves `{ denied: false }` → tool executes with no approval.
    * To-be: pending verdict under `enforce` with no wired approval channel → `{ denied: true }` → `PolicyViolationError`, tool blocked. Non-enforce postures unchanged (fail-open).
    * Scope: change is confined to `createNativeGatewayClient` (the only client that can emit `pending: true`); the no-op client's `check()` never returns pending, so it is untouched.

## _Effecting Scope_

* Action Types:
    * [x] 🔧 Fixing bug
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
* Scopes:
    * [x] 🪡 API client and transport
    * [x] ⛑️ Error handling
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
* Additional description:
    No new dependencies. No public API change. No native (Rust) glue touched — pure TypeScript.

## _Description_

* `src/gateway/client.ts`: `createNativeGatewayClient.waitForApproval` now denies under `failClosed` (enforce) with an explanatory reason; stays neutral in advisory postures.
* `tests/native-gateway-enforcement.test.ts`: adds a test that a pending verdict + enforce + no approval channel blocks the tool (never runs its body); clarifies the existing advisory-posture PENDING test.

## How to verify

* `pnpm typecheck && pnpm lint` clean.
* `pnpm test` — full suite green (the new `PENDING under enforce ... fails closed` case plus the unchanged advisory PENDING case).

Closes AAASM-4129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz