### PR TITLE
[AAASM-4153] 🔒 (runtime): Replace claimable .io install host with canonical agent-assembly.com

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -39,7 +39,7 @@ export const INSTALL_HINT: string = [
   "agent-assembly runtime not found.",
   "  Install with: pnpm add agent-assembly",
   "  Or manually:  brew install ai-agent-assembly/tap/aasm",
-  "               curl -fsSL https://get.agent-assembly.io | sh",
+  "               curl -fsSL https://agent-assembly.com/install.sh | sh",
 ].join("\n");
 
 /**


### PR DESCRIPTION
## _Target_
* ### Task summary:

    Fix a HIGH-severity supply-chain RCE vector in the runtime install hint.

* ### Task tickets:

    * Task ID: AAASM-4153
    * Relative task IDs:
        * [x] Completes AAASM-4122 for node-sdk (4122 fixed python-sdk + examples but missed node + go).

## _Effecting Scope_

* Action Types:
    * [x] 🔧 Fixing bug
    * [x] 🍀 Improving something (security)
* Scopes:
    * [x] 🧩 SDK public API (`INSTALL_HINT` in `src/runtime.ts`)

## _Description_

### What changed
`INSTALL_HINT` in `src/runtime.ts` printed a curl-to-shell command fetching an install script from `get.agent-assembly.io`. That host resolves **NXDOMAIN** (DNS-verified this sweep) — the `.io` apex is unregistered and therefore **claimable by any third party**. Since the hint pipes the fetched script straight into a shell with no checksum/signature, whoever registers `agent-assembly.io` gains arbitrary code execution on every developer/CI that hits the missing-binary hint. This message is printed on a common first-run path (binary not found → thrown `Error`).

The line now points at the canonical Cloudflare-hosted `https://agent-assembly.com/install.sh`, byte-matching python-sdk's `runtime.py` hint. `brew install ai-agent-assembly/tap/aasm` remains the preferred checksum-verified path in the same hint.

### As-is → To-be
- as-is: `curl -fsSL https://get.agent-assembly.io | sh`
- to-be: `curl -fsSL https://agent-assembly.com/install.sh | sh`

### How to verify
`grep -rn 'agent-assembly.io' src` returns nothing; `pnpm typecheck && pnpm lint && pnpm test` all green (359 passed / 2 skipped).

### Recommendation
The org should **defensively register `agent-assembly.io`** (and the `get.` subdomain) so the vector cannot be re-introduced from any other surface.

Closes AAASM-4153.