### PR TITLE
[AAASM-4170] 📝 (docs): Correct stale brew tap org in verification report

### DIFF
--- a/verification-reports/AAASM-1203.md
+++ b/verification-reports/AAASM-1203.md
@@ -137,7 +137,7 @@ Full `INSTALL_HINT` text from `src/runtime.ts`:
 ```
 agent-assembly runtime not found.
   Install with: pnpm add agent-assembly
-  Or manually:  brew install agent-assembly/tap/aasm
+  Or manually:  brew install ai-agent-assembly/tap/aasm
                curl -fsSL https://agent-assembly.com/install.sh | sh
 ```
 


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Fix stale, un-prefixed Homebrew tap org (`agent-assembly/tap` → `ai-agent-assembly/tap`) in a verification-report doc. The un-prefixed tap 404s; a user copy-pasting the brew command hits a non-existent tap.

* ### Task tickets:

    * Task ID: [AAASM-4170](https://lightning-dust-mite.atlassian.net/browse/AAASM-4170).
    * Relative task IDs:
        * [x] AAASM-4168 — sibling doc-drift fix in the same file (`.io` curl host scrub); this bug was the out-of-scope sibling noted then.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    In `verification-reports/AAASM-1203.md`, the block quotes `INSTALL_HINT` from `src/runtime.ts`. The quoted brew line drifted to the un-prefixed org:

    * as-is: `brew install agent-assembly/tap/aasm` (404s)
    * to-be: `brew install ai-agent-assembly/tap/aasm` (canonical, mirrors `src/runtime.ts` INSTALL_HINT exactly)

    **Grep-sweep result** (`grep -rn 'agent-assembly/tap' .`, excl. node_modules/.git): after the fix, both matches are the canonical `ai-agent-assembly/tap` form — `verification-reports/AAASM-1203.md:140` and the already-correct `src/runtime.ts:41`. Zero un-prefixed occurrences remain. The one un-prefixed line was the only edit; the already-canonical runtime.ts line was untouched.

## _Effecting Scope_

* Action Types:
    * [x] 🔧 Fixing bug
* Scopes:
    * [x] 📚 Documentation
* Additional description:
    Doc/text-only change. No code, tests, or build affected.

## _Description_

* Corrected the quoted brew tap org in `verification-reports/AAASM-1203.md` to the canonical `ai-agent-assembly/tap/aasm`, matching `src/runtime.ts`'s `INSTALL_HINT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7vqjjo5nrebYNt8WnCNbz


[AAASM-4170]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ