### PR TITLE
[AAASM-4172] 🔒 (core): Default omitted enforcementMode to fail-closed (parity with py/go)

### DIFF
--- a/src/core/init-assembly.ts
+++ b/src/core/init-assembly.ts
@@ -18,7 +18,7 @@ import { ConfigurationError } from "../errors/index.js";
 import type { AssemblyConfig } from "../types/assembly-config.js";
 import type { AssemblyContext } from "../types/assembly-context.js";
 import type { AssemblyMode } from "../types/assembly-mode.js";
-import { ENFORCEMENT_MODES } from "../types/enforcement-mode.js";
+import { ENFORCEMENT_MODES, resolveFailClosed } from "../types/enforcement-mode.js";
 import type {
   LangChainCallbackHandlerLike,
   LangChainToolLike
@@ -136,7 +136,8 @@ export function createClient(
         mode: "napi-inprocess",
         // AAASM-4013: under enforce, a runtime that returns no authoritative
         // verdict (fail-open sentinel / unknown decision) must deny, not allow.
-        failClosed: config.enforcementMode === "enforce"
+        // AAASM-4172: an omitted posture defaults to enforce (py/go parity).
+        failClosed: resolveFailClosed(config.enforcementMode)
       });
     return createNativeGatewayClient(mode, nativeClient, config.agentId, httpBaseUrl, config.enforcementMode);
   }
@@ -414,7 +415,8 @@ export async function initAssembly(config: AssemblyConfig = {}): Promise<Assembl
       mode: resolvedConfig.mode === "napi-inprocess" ? "napi-inprocess" : "grpc-sidecar",
       // AAASM-4013: under enforce, a runtime that returns no authoritative
       // verdict (fail-open sentinel / unknown decision) must deny, not allow.
-      failClosed: resolvedConfig.enforcementMode === "enforce"
+      // AAASM-4172: an omitted posture defaults to enforce (py/go parity).
+      failClosed: resolveFailClosed(resolvedConfig.enforcementMode)
     });
   }
 

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -7,7 +7,7 @@ import type {
   GatewayResultRecord
 } from "../types/gateway-governance.js";
 import type { AssemblyMode } from "../types/assembly-mode.js";
-import type { EnforcementMode } from "../types/enforcement-mode.js";
+import { type EnforcementMode, resolveFailClosed } from "../types/enforcement-mode.js";
 import type { NativeClient } from "../native/client.js";
 
 export interface GatewayClient {
@@ -93,8 +93,9 @@ export function createNativeGatewayClient(
   enforcementMode?: EnforcementMode
 ): GatewayClient {
   // Fail-closed posture mirrors the go SDK's `failClosed` and the Python
-  // enforce guard: only an explicit `"enforce"` denies on fault (AAASM-3920).
-  const failClosed = enforcementMode === "enforce";
+  // enforce guard: an explicit `"enforce"` — or an omitted posture, which
+  // defaults to enforce like py/go (AAASM-4172) — denies on fault (AAASM-3920).
+  const failClosed = resolveFailClosed(enforcementMode);
   return {
     mode,
     ...(httpBaseUrl === undefined ? {} : { httpBaseUrl }),

--- a/src/types/enforcement-mode.ts
+++ b/src/types/enforcement-mode.ts
@@ -18,3 +18,20 @@ export type EnforcementMode = "enforce" | "observe" | "disabled";
  * TypeScript type system (plain JS, JSON config, dynamic input).
  */
 export const ENFORCEMENT_MODES: readonly EnforcementMode[] = ["enforce", "observe", "disabled"] as const;
+
+/**
+ * Whether the check-capable SDK layer should fail **closed** (deny on a
+ * non-authoritative verdict — unreachable/faulted runtime, UNSPECIFIED/unknown
+ * decision, or pending with no approval channel) for the given posture.
+ *
+ * An **omitted** `enforcementMode` resolves to fail-closed, matching the enforce
+ * default: python's `_local_posture_is_enforce(None) → True` (AAASM-4130) and
+ * go's empty mode ≡ enforce. `"observe"` / `"disabled"` are explicit
+ * non-enforcing postures and stay fail-**open** so a degraded runtime never
+ * blocks the agent. This keeps all three layer-1 SDKs consistent in the
+ * napi-inprocess path when the caller opts into in-process enforcement without
+ * naming a posture.
+ */
+export function resolveFailClosed(enforcementMode?: EnforcementMode): boolean {
+  return enforcementMode === undefined || enforcementMode === "enforce";
+}

--- a/tests/enforcement-default-fail-closed.test.ts
+++ b/tests/enforcement-default-fail-closed.test.ts
@@ -1,0 +1,142 @@
+/**
+ * AAASM-4172 — an OMITTED `enforcementMode` must fail **closed** in the
+ * check-capable (`napi-inprocess`) path, matching python (`_local_posture_is
+ * _enforce(None) → True`, AAASM-4130) and go (empty mode ≡ enforce). Before
+ * this fix `failClosed` was derived from `enforcementMode === "enforce"`, so an
+ * agent that opted into in-process enforcement without naming a posture failed
+ * OPEN on the three non-authoritative paths (unreachable runtime, UNSPECIFIED
+ * verdict, pending-with-no-channel) — a cross-SDK parity gap.
+ *
+ * The important negative control: `"observe"` / `"disabled"` are explicit
+ * non-enforcing postures and MUST stay fail-open.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { createClient } from "../src/core/init-assembly.js";
+import { createNativeGatewayClient } from "../src/gateway/client.js";
+import type { NativeClient } from "../src/native/client.js";
+import { resolveFailClosed } from "../src/types/enforcement-mode.js";
+import { PolicyViolationError } from "../src/errors/policy-violation-error.js";
+import { withAssembly } from "../src/wrappers/with-assembly.js";
+
+function fakeNativeClient(queryPolicy: NativeClient["queryPolicy"]): NativeClient {
+  return {
+    mode: "napi-inprocess",
+    close: vi.fn(async () => undefined),
+    sendEvent: vi.fn(() => undefined),
+    queryPolicy,
+    register: vi.fn(async () => "")
+  };
+}
+
+const throwingRuntime = () => {
+  throw new Error("AA_ERR_CONNECT:no runtime listening");
+};
+
+describe("resolveFailClosed posture mapping (AAASM-4172)", () => {
+  it("treats an omitted posture as fail-closed (py/go parity)", () => {
+    expect(resolveFailClosed(undefined)).toBe(true);
+  });
+
+  it("treats explicit enforce as fail-closed", () => {
+    expect(resolveFailClosed("enforce")).toBe(true);
+  });
+
+  it("keeps observe / disabled fail-open (explicit non-enforcing postures)", () => {
+    expect(resolveFailClosed("observe")).toBe(false);
+    expect(resolveFailClosed("disabled")).toBe(false);
+  });
+});
+
+describe("createNativeGatewayClient with omitted enforcementMode (AAASM-4172)", () => {
+  it("DENY: unreachable runtime denies when the posture is omitted (was allow)", async () => {
+    const gateway = createNativeGatewayClient(
+      "napi-inprocess",
+      fakeNativeClient(async () => throwingRuntime()),
+      "agent-1"
+      // enforcementMode omitted → defaults to fail-closed
+    );
+
+    const decision = await gateway.check({
+      action: "tool_call",
+      toolName: "delete_all",
+      runId: "run-1"
+    });
+    expect(decision).toEqual({ denied: true, pending: false });
+
+    const executeFn = vi.fn(async () => "should-not-run");
+    const tools = { delete_all: { description: "danger", execute: executeFn } };
+    withAssembly(tools, { gatewayClient: gateway });
+
+    await expect(tools.delete_all.execute()).rejects.toThrow(PolicyViolationError);
+    expect(executeFn).not.toHaveBeenCalled();
+  });
+
+  it("DENY: a pending verdict with no approval channel denies when omitted (was allow)", async () => {
+    const gateway = createNativeGatewayClient(
+      "napi-inprocess",
+      fakeNativeClient(async () => ({ denied: false, pending: true, reason: "awaiting approval" })),
+      "agent-1"
+    );
+
+    const executeFn = vi.fn(async () => "should-not-run-without-approval");
+    const tools = { wire_transfer: { description: "money", execute: executeFn } };
+    withAssembly(tools, { gatewayClient: gateway });
+
+    await expect(tools.wire_transfer.execute()).rejects.toThrow(PolicyViolationError);
+    expect(executeFn).not.toHaveBeenCalled();
+  });
+
+  it("NEGATIVE CONTROL: observe still fails open when the runtime is unreachable", async () => {
+    const gateway = createNativeGatewayClient(
+      "napi-inprocess",
+      fakeNativeClient(async () => throwingRuntime()),
+      "agent-1",
+      undefined,
+      "observe"
+    );
+
+    const decision = await gateway.check({ action: "tool_call", toolName: "search", runId: "run-2" });
+    expect(decision).toEqual({ denied: false, pending: false });
+  });
+
+  it("explicit enforce still denies on an unreachable runtime", async () => {
+    const gateway = createNativeGatewayClient(
+      "napi-inprocess",
+      fakeNativeClient(async () => throwingRuntime()),
+      "agent-1",
+      undefined,
+      "enforce"
+    );
+
+    const decision = await gateway.check({ action: "tool_call", toolName: "delete_all", runId: "run-3" });
+    expect(decision).toEqual({ denied: true, pending: false });
+  });
+});
+
+describe("createClient wires the omitted-posture default through napi-inprocess (AAASM-4172)", () => {
+  it("DENY: napi-inprocess + omitted enforcementMode fails closed on an unreachable runtime", async () => {
+    const gateway = createClient(
+      { gatewayUrl: "https://gateway.example.com", apiKey: "k", agentId: "agent-1", mode: "napi-inprocess" },
+      fakeNativeClient(async () => throwingRuntime())
+    );
+
+    const decision = await gateway.check({ action: "tool_call", toolName: "delete_all", runId: "run-4" });
+    expect(decision).toEqual({ denied: true, pending: false });
+  });
+
+  it("NEGATIVE CONTROL: napi-inprocess + observe stays fail-open", async () => {
+    const gateway = createClient(
+      {
+        gatewayUrl: "https://gateway.example.com",
+        apiKey: "k",
+        agentId: "agent-1",
+        mode: "napi-inprocess",
+        enforcementMode: "observe"
+      },
+      fakeNativeClient(async () => throwingRuntime())
+    );
+
+    const decision = await gateway.check({ action: "tool_call", toolName: "search", runId: "run-5" });
+    expect(decision).toEqual({ denied: false, pending: false });
+  });
+});

--- a/tests/native-gateway-enforcement.test.ts
+++ b/tests/native-gateway-enforcement.test.ts
@@ -69,15 +69,19 @@ describe("native gateway enforcement (AAASM-3050)", () => {
     expect(executeFn).toHaveBeenCalledOnce();
   });
 
-  it("FAIL-OPEN: no runtime (native query rejects) lets the tool proceed", async () => {
+  it("FAIL-OPEN: no runtime (native query rejects) lets the tool proceed under observe", async () => {
     // The native primitive already returns "allow" when the runtime is
     // unreachable; on top of that, even a hard local fault must fail open.
+    // `"observe"` is the explicit advisory posture — an omitted posture now
+    // defaults to fail-closed (AAASM-4172), so this exercises observe directly.
     const gateway = createNativeGatewayClient(
       "napi-inprocess",
       fakeNativeClient(async () => {
         throw new Error("AA_ERR_CONNECT:no runtime listening");
       }),
-      "agent-1"
+      "agent-1",
+      undefined,
+      "observe"
     );
 
     const executeFn = vi.fn(async () => "ran-without-runtime");
@@ -156,7 +160,7 @@ describe("native gateway enforcement (AAASM-3050)", () => {
     expect(native.close).toHaveBeenCalledOnce();
   });
 
-  it("PENDING: a runtime pending verdict routes to the approval path", async () => {
+  it("PENDING: a runtime pending verdict routes to the approval path under observe", async () => {
     const gateway = createNativeGatewayClient(
       "napi-inprocess",
       fakeNativeClient(async () => ({
@@ -164,14 +168,17 @@ describe("native gateway enforcement (AAASM-3050)", () => {
         pending: true,
         reason: "awaiting approval"
       })),
-      "agent-1"
+      "agent-1",
+      undefined,
+      "observe"
     );
 
     const executeFn = vi.fn(async () => "approved-and-ran");
     const tools = { wire_transfer: { description: "money", execute: executeFn } };
     // No approval channel is wired in the node SDK yet; in the ADVISORY posture
-    // (no enforcementMode) that resolves to "not denied" and the tool proceeds,
-    // so a missing approval channel never blocks the agent (AAASM-4129).
+    // (`observe`) that resolves to "not denied" and the tool proceeds, so a
+    // missing approval channel never blocks the agent (AAASM-4129). An omitted
+    // posture now defaults to fail-closed (AAASM-4172), hence explicit observe.
     withAssembly(tools, { gatewayClient: gateway });
 
     await expect(tools.wire_transfer.execute()).resolves.toBe("approved-and-ran");


### PR DESCRIPTION
## _Target_

* ### Task summary:

    In the check-capable `napi-inprocess` path, an **omitted** `enforcementMode` derived `failClosed = false` (`enforcementMode === "enforce"`), so the in-process pre-exec check ran but failed **OPEN** on the three non-authoritative paths: an unreachable/faulted runtime, an UNSPECIFIED/unrecognized native verdict, and a `pending` verdict with no approval channel. A user who opted into in-process enforcement without naming a posture got fail-open on node but **fail-closed on python and go** — an enforcement-parity gap across the product's own layer-1 SDKs.

    This aligns node with python (`_local_posture_is_enforce(None) → True`, AAASM-4130) and go (empty mode ≡ enforce): an omitted posture now defaults to **fail-closed**. `resolveFailClosed(enforcementMode)` is extracted so the "omitted ≡ enforce" rule lives in one place and is applied at all three derivation sites (`init-assembly.ts` ×2, `gateway/client.ts`).

* ### Task tickets:

    * Task ID: AAASM-4172.

* ### Key point change (optional):

    * `failClosed = enforcementMode === "enforce"` → `failClosed = resolveFailClosed(enforcementMode)`, i.e. `enforcementMode === undefined || enforcementMode === "enforce"`.
    * `"observe"` / `"disabled"` remain **fail-open** — they are explicit non-enforcing postures; only omitted/`undefined` flips to fail-closed.
    * The `init-assembly.ts` `ConfigurationError` guard (enforce + non-check-capable mode still throws) is **untouched**.
    * The default `mode: "auto"` → allow-all no-op client behavior is **untouched** (that layer is by-design; only the check-capable path's `failClosed` default changes).

## _Effecting Scope_

* Action Types:
    * [x] 🔧 Fixing bug
        * [x] 🟠 Has breaking change (in-process enforcement now denies on non-authoritative verdicts when `enforcementMode` is omitted; this is the intended security-hardening)
    * [x] 🍀 Improving something (security — cross-SDK enforcement parity)
* Scopes:
    * [x] 🪡 API client and transport
    * [x] 🫀 Data model and types
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing

## _Description_

* `src/types/enforcement-mode.ts` — add `resolveFailClosed(enforcementMode?)`: omitted or `"enforce"` → `true`; `"observe"`/`"disabled"` → `false`.
* `src/gateway/client.ts` / `src/core/init-assembly.ts` (×2) — derive `failClosed` via the shared helper.
* `tests/native-gateway-enforcement.test.ts` — the two advisory cases (FAIL-OPEN, PENDING) that relied on omitted-≡-fail-open now opt into explicit `"observe"` so they keep verifying the advisory path under the new default.
* `tests/enforcement-default-fail-closed.test.ts` (new) — regression: napi-inprocess + omitted `enforcementMode` denies on an unreachable runtime and a pending-no-channel verdict (was allow), through both `createNativeGatewayClient` and `createClient`; negative controls assert `"observe"` stays fail-open and explicit `"enforce"` still denies, plus a `resolveFailClosed` truth table.

### How to verify

`pnpm test` (368 passed, 2 skipped), `pnpm typecheck`, `pnpm lint` (clean), `pnpm build` all green locally.

Closes AAASM-4172

🤖 Generated with [Claude Code](https://claude.com/claude-code)