### PR TITLE
[AAASM-4186] ⬆️ (deps): Bump website js-yaml to >=3.15.0 (Dependabot #57)

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -62,6 +62,7 @@
       "dompurify": "^3.4.11",
       "joi": "^17.13.4",
       "js-yaml@^4.0.0": "^4.2.0",
+      "js-yaml@3": "^3.15.0",
       "launch-editor": "^2.14.1",
       "markdown-it": "^14.2.0",
       "mermaid": "^11.15.0",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   dompurify: ^3.4.11
   joi: ^17.13.4
   js-yaml@^4.0.0: ^4.2.0
+  js-yaml@3: ^3.15.0
   launch-editor: ^2.14.1
   markdown-it: ^14.2.0
   mermaid: ^11.15.0
@@ -4027,8 +4028,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   js-yaml@4.2.0:
@@ -10789,7 +10790,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -11217,7 +11218,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1


### PR DESCRIPTION
## _Target_

Clear **Dependabot alert #57 (MODERATE)** — `js-yaml < 3.15.0` quadratic-complexity DoS in merge-key handling (GHSA-h67p-54hq-rp68). The vulnerable copy is a **transitive** dependency of the Docusaurus docs-site build tooling in `website/`, not the shipped package.

* ### Task summary:

    Bump the transitive `js-yaml` in `website/pnpm-lock.yaml` from `3.14.2` (vulnerable) to `3.15.0` (patched). `gray-matter@4.0.3` pulls js-yaml on the 3.x line; the existing `js-yaml@^4.0.0` override only covered the 4.x branch, leaving 3.x unpatched. Added a scoped pnpm override `"js-yaml@3": "^3.15.0"` so the 3.x branch resolves to `3.15.0` — within gray-matter's `^3.13.1` range, so **no major bump and no API break** (js-yaml 4.x removed `safeLoad`, which gray-matter relies on). Precise `^` floor per repo policy (never a bare `>=`).

* ### Task tickets:

    * Task ID: [AAASM-4186](https://lightning-dust-mite.atlassian.net/browse/AAASM-4186)
    * Relative task IDs:
        * [x] N/A.
    * Relative PRs:
        * N/A.

* ### Key point change:

    * `js-yaml` in `website/pnpm-lock.yaml`: **`3.14.2` → `3.15.0`** (`gray-matter@4.0.3` importer).
    * `js-yaml@4.2.0` resolution untouched; root `package.json` / shipped `@agent-assembly/sdk` deps untouched.

## _Effecting Scope_

* Action Types:
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
* Scopes:
    * [x] 🚀 Building
        * [x] 🔗 Dependencies
* Additional description:
    Docs-site build tooling only. The published `@agent-assembly/sdk` npm package does not include `website/`; real exposure is build-time, repo-controlled YAML (LOW), remediated to match the Dependabot severity.

## _Description_

* Add `"js-yaml@3": "^3.15.0"` to `website/package.json` `pnpm.overrides`; regenerate `website/pnpm-lock.yaml` (standalone, `--ignore-workspace`).
* **How to verify:** `grep js-yaml website/pnpm-lock.yaml` shows `3.15.0` (no `<3.15.0`); `cd website && pnpm install --ignore-workspace --frozen-lockfile && pnpm build` → **green** (`[SUCCESS] Generated static files in "build"`). Dependabot #57 clears on next scan.

Closes AAASM-4186.


[AAASM-4186]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ