### PR TITLE
[AAASM-4192] 🔒 (runtime): Fix INSTALL_HINT to canonical scoped package name

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -35,9 +35,15 @@ export const RUNTIME_LOG_FILENAME = ".aasm-runtime.log";
 /** npm sub-package name for the bundled platform binary (esbuild pattern). */
 export const RUNTIME_SUBPACKAGE: string = `runtime-${platform()}-${arch()}`;
 
+// The runtime ships as the `@agent-assembly/runtime-{platform}-{arch}`
+// optionalDependency of `@agent-assembly/sdk` (or via brew/curl) — never as a
+// standalone bare, unscoped npm package. That unscoped name is unregistered and
+// claimable, so a hint that installed it would be a supply-chain squat vector
+// (AAASM-4192). Reinstalling the scoped SDK re-resolves this platform's runtime
+// sub-package.
 export const INSTALL_HINT: string = [
   "agent-assembly runtime not found.",
-  "  Install with: pnpm add agent-assembly",
+  "  Install with: pnpm add @agent-assembly/sdk",
   "  Or manually:  brew install ai-agent-assembly/tap/aasm",
   "               curl -fsSL https://agent-assembly.com/install.sh | sh",
 ].join("\n");

--- a/tests/runtime-entrypoint-export.test.ts
+++ b/tests/runtime-entrypoint-export.test.ts
@@ -20,4 +20,12 @@ describe("SDK entrypoint — runtime helpers re-export (AAASM-1221)", () => {
     expect(typeof INSTALL_HINT).toBe("string");
     expect(INSTALL_HINT).toContain("agent-assembly runtime not found");
   });
+
+  // AAASM-4192: the hint must never point users at the unscoped, unregistered
+  // (claimable) `agent-assembly` npm name — that is a supply-chain squat vector.
+  // Any npm install guidance must use the scoped `@agent-assembly/...` package.
+  it("never suggests installing the claimable unscoped npm name", () => {
+    expect(INSTALL_HINT).not.toMatch(/(?:pnpm add|npm i(?:nstall)?|yarn add)\s+agent-assembly\b/);
+    expect(INSTALL_HINT).toContain("@agent-assembly/sdk");
+  });
 });


### PR DESCRIPTION
## _Target_

* ### Task summary:

    The node-sdk runtime-not-found `INSTALL_HINT` (thrown by `findAasmBinary()` when the `aasm` sidecar binary is missing) told users to `pnpm add agent-assembly`. The **unscoped `agent-assembly` npm name is unregistered and claimable** — anyone can register it, and a user following the SDK's own official error message would install attacker code (npm `postinstall` = RCE-on-claim). This is the same supply-chain squat class as AAASM-4153 / AAASM-4168. This PR points the hint at the canonical scoped `@agent-assembly/sdk` instead.

* ### Task tickets:

    * Task ID: AAASM-4192
    * Relative task IDs:
        * [x] Class of AAASM-4153 / AAASM-4168 (canonical-install / squat-vector fixes)
    * Relative PRs:
        * N/A.

* ### Key point change:

    npm 404 evidence — the unscoped name does not exist on the registry:
    ```
    $ npm view agent-assembly version
    npm error 404 'agent-assembly@*' is not in this registry.
    ```

    The runtime is **not** a standalone bare-npm package. It ships as the `@agent-assembly/runtime-{platform}-{arch}` optionalDependency of `@agent-assembly/sdk` (confirmed in `package.json` `optionalDependencies`), or via brew/curl. Reinstalling the scoped SDK re-resolves this platform's runtime sub-package.

    As-is → to-be (`INSTALL_HINT`):
    ```
      Install with: pnpm add agent-assembly          # claimable, 404, RCE-on-claim
    →
      Install with: pnpm add @agent-assembly/sdk     # canonical scoped name
    ```
    The already-correct `brew` + `curl` lines are unchanged.

    Grep-sweep (`pnpm add|npm install|yarn add agent-assembly`, excluding scoped `@agent-assembly/...`) across `src/`, `README.md`, `docs/`: the single occurrence was `src/runtime.ts:40`. Post-fix: **zero** unscoped install references remain.

## _Effecting Scope_

* Action Types:
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
    * [x] 🔧 Fixing bug
    * [x] 🍀 Improving something (security)
* Scopes:
    * [x] 🧩 SDK public API
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing

## _Description_

* `src/runtime.ts` — change `INSTALL_HINT` npm line from the unscoped claimable `agent-assembly` to the canonical scoped `@agent-assembly/sdk`; add a why-comment documenting the squat vector and the optionalDependency delivery mechanism.
* `tests/runtime-entrypoint-export.test.ts` — regression test asserting `INSTALL_HINT` never contains an `(pnpm add|npm install|yarn add) agent-assembly` directive and always references `@agent-assembly/sdk`.

## _How to verify_

* `npm view agent-assembly` → 404 (name is claimable).
* `node -e "const {INSTALL_HINT}=require('./dist/cjs/runtime.js'); console.log(INSTALL_HINT)"` → shows `pnpm add @agent-assembly/sdk`, no unscoped name.
* `pnpm build` ✅ · `pnpm test` → 369 passed / 2 skipped (incl. new regression test) ✅ · `pnpm typecheck` ✅ · `pnpm lint` → No issues found ✅

Closes AAASM-4192

🤖 Generated with [Claude Code](https://claude.com/claude-code)