### PR TITLE
[AAASM-4192] 🐛 (runtime): Fix INSTALL_HINT package name to @agent-assembly/sdk

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -37,7 +37,7 @@ export const RUNTIME_SUBPACKAGE: string = `runtime-${platform()}-${arch()}`;
 
 export const INSTALL_HINT: string = [
   "agent-assembly runtime not found.",
-  "  Install with: pnpm add agent-assembly",
+  "  Install with: pnpm add @agent-assembly/sdk",
   "  Or manually:  brew install ai-agent-assembly/tap/aasm",
   "               curl -fsSL https://agent-assembly.com/install.sh | sh",
 ].join("\n");


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Fix supply chain squat risk in INSTALL_HINT constant by changing the incorrect bare package name "agent-assembly" to the actual published scoped package name "@agent-assembly/sdk".

* ### Task tickets:

    * Task ID: AAASM-4192
    * Relative task IDs:
        * N/A.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    The `INSTALL_HINT` constant in `src/runtime.ts` referenced `pnpm add agent-assembly` which is an unregistered npm name. This could be squatted by malicious actors. Changed to `pnpm add @agent-assembly/sdk` which is the actual published package.

## _Effecting Scope_

* Action Types:
    * [ ] ✨ Adding new something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] ✏️ Modifying existing something
        * [ ] 🟢 No breaking change
        * [ ] 🟠 Has breaking change
    * [ ] 🚮 Removing something
    * [x] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [ ] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [x] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [ ] 🤖 Framework hooks
    * [ ] 🫀 Data model and types
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
        * [ ] 🧪 Unit testing
        * [ ] 🧪 Integration testing
        * [ ] 🧪 End-to-end testing
    * [ ] 🚀 Building
        * [ ] 🤖 CI/CD
        * [ ] 🔗 Dependencies
        * [ ] 📦 Project configurations
    * [ ] 📚 Documentation
* Additional description:
    Security fix to prevent potential supply chain attack via npm name squatting.

## _Description_

* Changed `INSTALL_HINT` in `src/runtime.ts` from `pnpm add agent-assembly` to `pnpm add @agent-assembly/sdk`
* The bare name "agent-assembly" is unregistered on npm and could be registered by a malicious actor
* The correct package name is `@agent-assembly/sdk` which is the actual published scoped package

---

🤖 Generated with [Claude Code](https://claude.ai/code)