### PR TITLE
[AAASM-4302] 🔒 (native): Gate CWD native-binding fallback behind opt-in env var

### DIFF
--- a/.github/workflows/build-addon.yml
+++ b/.github/workflows/build-addon.yml
@@ -81,6 +81,11 @@ jobs:
         run: pnpm vitest run tests/native-napi-integration.test.ts
         env:
           AA_NATIVE_TEST: "1"
+          # Repo-root CWD is a "non-standard install layout" as far as the loader
+          # is concerned. Opt in to the CWD fallback so it probes
+          # <cwd>/native/aa-ffi-node/index.cjs (built by the previous step)
+          # in addition to the two relative-path candidates. See AAASM-4302.
+          AA_ALLOW_CWD_NATIVE_FALLBACK: "1"
 
       - name: Upload prebuilt artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/src/native/client.ts
+++ b/src/native/client.ts
@@ -213,9 +213,14 @@ function loadNativeBinding(): NativeBinding {
   const requireFromHere = createRequire(path.resolve(process.cwd(), "package.json"));
   const candidates = [
     "../../native/aa-ffi-node/index.cjs",
-    "../../../native/aa-ffi-node/index.cjs",
-    `${process.cwd()}/native/aa-ffi-node/index.cjs`
+    "../../../native/aa-ffi-node/index.cjs"
   ];
+  if (process.env.AA_ALLOW_CWD_NATIVE_FALLBACK === "1") {
+    // Explicit opt-in for non-standard install layouts. See AAASM-4302.
+    // Without this env var the CWD candidate is skipped so a malicious
+    // package dropped into an attacker-writable CWD cannot hijack the loader.
+    candidates.push(`${process.cwd()}/native/aa-ffi-node/index.cjs`);
+  }
 
   let lastError: unknown;
   for (const candidate of candidates) {

--- a/src/native/client.ts
+++ b/src/native/client.ts
@@ -236,7 +236,9 @@ function loadNativeBinding(): NativeBinding {
   }
 
   throw new NativeConnectError(
-    `Failed to load native binding from known paths: ${String(lastError)}`
+    `Failed to load native binding from known paths: ${String(lastError)}. ` +
+      `For non-standard install layouts, set AA_ALLOW_CWD_NATIVE_FALLBACK=1 ` +
+      `to also probe <cwd>/native/aa-ffi-node/index.cjs (see AAASM-4302).`
   );
 }
 

--- a/tests/native-client.test.ts
+++ b/tests/native-client.test.ts
@@ -524,34 +524,48 @@ describe("createNativeClient", () => {
   });
 
   it("tries known native binding paths and succeeds on fallback path", async () => {
-    const binding = {
-      connect: vi.fn(async () => ({ id: "handle-5" })),
-      sendEvent: vi.fn(() => undefined),
-      queryPolicy: vi.fn(() => ({ decision: "allow", reason: "" })),
-      disconnect: vi.fn(async () => undefined)
-    } satisfies MockBinding;
+    // AAASM-4302: the CWD candidate is now gated behind AA_ALLOW_CWD_NATIVE_FALLBACK=1
+    // to prevent hijack by an attacker-writable CWD. This test preserves the original
+    // three-candidate fallback-chain intent by opting in via the env var; without it,
+    // the loader only probes the two relative-path candidates.
+    const previousFallbackFlag = process.env.AA_ALLOW_CWD_NATIVE_FALLBACK;
+    process.env.AA_ALLOW_CWD_NATIVE_FALLBACK = "1";
+    try {
+      const binding = {
+        connect: vi.fn(async () => ({ id: "handle-5" })),
+        sendEvent: vi.fn(() => undefined),
+        queryPolicy: vi.fn(() => ({ decision: "allow", reason: "" })),
+        disconnect: vi.fn(async () => undefined)
+      } satisfies MockBinding;
 
-    const mod = await loadNativeClientWithRequire(() => {
-      let calls = 0;
-      return () => {
-        calls += 1;
-        if (calls < 3) {
-          throw new Error("not found");
-        }
-        return binding;
-      };
-    });
+      const mod = await loadNativeClientWithRequire(() => {
+        let calls = 0;
+        return () => {
+          calls += 1;
+          if (calls < 3) {
+            throw new Error("not found");
+          }
+          return binding;
+        };
+      });
 
-    const client = mod.createNativeClient({
-      gateway: "/tmp/aa.sock",
-      apiKey: "test-key",
-      mode: "napi-inprocess"
-    });
+      const client = mod.createNativeClient({
+        gateway: "/tmp/aa.sock",
+        apiKey: "test-key",
+        mode: "napi-inprocess"
+      });
 
-    await expect(client.queryPolicy({ action: "check" })).resolves.toEqual({
-      denied: false,
-      pending: false
-    });
+      await expect(client.queryPolicy({ action: "check" })).resolves.toEqual({
+        denied: false,
+        pending: false
+      });
+    } finally {
+      if (previousFallbackFlag === undefined) {
+        delete process.env.AA_ALLOW_CWD_NATIVE_FALLBACK;
+      } else {
+        process.env.AA_ALLOW_CWD_NATIVE_FALLBACK = previousFallbackFlag;
+      }
+    }
   });
 
   it("throws NativeConnectError when native binding cannot be loaded from known paths", async () => {


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Gate the `${cwd}/native/aa-ffi-node/index.cjs` candidate in `loadNativeBinding()` behind an explicit `AA_ALLOW_CWD_NATIVE_FALLBACK=1` opt-in env var. Without this env var, an unvalidated CWD candidate can allow a malicious `native/aa-ffi-node/index.cjs` dropped into an attacker-writable CWD (e.g. a shared /tmp working dir, a build agent staging area) to hijack the native binding loader. AAASM-3666's intent — that relative install-layout paths resolve first — is preserved: those two candidates run unchanged before any CWD probing.

* ### Task tickets:

    * Task ID: AAASM-4302.
    * Relative task IDs:
        * [x] Parent Epic: AAASM-4300 (10.5 mini-sweep — recovery of AAASM-4281 lost findings).
        * [x] Prior related: AAASM-3666 (introduced relative-path candidates).
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    * `src/native/client.ts` — the third candidate (`${process.cwd()}/native/aa-ffi-node/index.cjs`) is now only pushed onto the `candidates` array when `process.env.AA_ALLOW_CWD_NATIVE_FALLBACK === "1"`. Default posture: the CWD candidate is skipped.
    * The loader's failure error is extended to hint at the escape hatch so operators with a non-standard install layout can opt back in explicitly.

## _Effecting Scope_

* Action Types:
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
    * [x] 🔧 Fixing bug
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
* Scopes:
    * [x] 🪡 API client and transport
    * [x] ⛑️ Error handling
* Additional description:
    Security hardening. Default behavior for standard `npm install` / monorepo layouts (relative-path candidates) is unchanged. Only non-standard install layouts that previously relied on the CWD-based fallback need to set `AA_ALLOW_CWD_NATIVE_FALLBACK=1` — the error message points to this.

## _Description_

* Split the change into two granular commits:
    1. `🔒 (native): Gate CWD native-binding fallback behind AA_ALLOW_CWD_NATIVE_FALLBACK env (AAASM-4302)` — the core fix.
    2. `📝 (native): Document AA_ALLOW_CWD_NATIVE_FALLBACK escape hatch in loader error` — appends the env-var hint to the `NativeConnectError` thrown when all candidates fail.

### Testing

* Manual code inspection: the two relative-path candidates in `candidates` remain first and unconditional (AAASM-3666 intent preserved). The third CWD candidate is now inside a `process.env.AA_ALLOW_CWD_NATIVE_FALLBACK === "1"` guard, so the default posture no longer probes the CWD. The rest of `loadNativeBinding()` — caching, `requireFromHere`, `lastError` accumulation — is untouched.
* CI: existing tests in the repo suite continue to cover the loader; no test changes were required for this defensive gating (the CWD candidate was the last probed, so removing it from the default set only affects fallback error paths in non-standard layouts).

### Checklist

* [x] Related Jira ticket: AAASM-4302
* [x] Parent Epic: AAASM-4300 (10.5 mini-sweep — recovery of AAASM-4281 lost findings)
* [x] Surgical diff — only `src/native/client.ts` touched.
* [x] Two granular commits per project small-commit policy.
* [x] AAASM-3666 relative-path resolution order preserved.