### PR TITLE
[AAASM-4350] 📝 align stale repo-name mention in comment

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,4 +1,4 @@
-/* AI Agent Assembly — shared doc brand layer for Docusaurus (node-sdk, inner-document).
+/* AI Agent Assembly — shared doc brand layer for Docusaurus (node-sdk, internal-docs).
    Install: replace the body of website/src/css/custom.css with this.
    Set themeConfig.colorMode = { respectPrefersColorScheme: true }.
    Tokens: design/doc-tokens.md */


### PR DESCRIPTION
Cosmetic: aligns a stale old-repo-name mention left in a code comment after the org rename. Comment text only, no functional change. Refs AAASM-4350