### PR TITLE
[AAASM-4471] 📝 (docs): Correct stale npm dist-tag in quick-start install note

### DIFF
--- a/website/versioned_docs/version-0.0.1-rc.3/02-quick-start/index.md
+++ b/website/versioned_docs/version-0.0.1-rc.3/02-quick-start/index.md
@@ -19,8 +19,8 @@ npm install @agent-assembly/sdk
 The package ships dual ESM/CJS entries and selects a prebuilt native binding for your
 platform during `postinstall`, so there is no extra build step for typical consumers.
 
-:::note Pre-1.0 / beta
-The current release line is `0.0.1-beta.x`, published under the npm `beta`
+:::note Pre-1.0 / release candidate
+The current release line is `0.0.1-rc.x`, published under the npm `latest` (and `rc`)
 dist-tag. The public surface (`initAssembly`, `withAssembly`) is stabilizing but may
 change between pre-releases. Pin an exact version for reproducible installs:
 `npm install @agent-assembly/sdk@0.0.1-rc.3`.


### PR DESCRIPTION
## _Target_

* ### Task summary:

    Fix a stale, internally-inconsistent version-line note in the Quick Start
    page of the default-served docs version (`0.0.1-rc.3`). The callout claimed
    the current release line was `0.0.1-beta.x` under the npm `beta` dist-tag,
    then pinned `0.0.1-rc.3` in the very next sentence.

* ### Task tickets:

    * Task ID: [AAASM-4471](https://lightning-dust-mite.atlassian.net/browse/AAASM-4471)
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    `website/versions.json` makes `0.0.1-rc.3` the newest snapshot, so Docusaurus
    serves it as `lastVersion` at the base path
    (`https://docs.agent-assembly.com/node-sdk/quick-start/`). That snapshot's
    admonition still read:

    > The current release line is `0.0.1-beta.x`, published under the npm `beta`
    > dist-tag. … Pin an exact version: `npm install @agent-assembly/sdk@0.0.1-rc.3`.

    Confirmed against the live registry — `npm view @agent-assembly/sdk dist-tags`:

    ```json
    { "latest": "0.0.1-rc.3", "alpha": "0.0.1-alpha.9.1", "beta": "0.0.1-beta.5", "rc": "0.0.1-rc.3" }
    ```

    An unpinned `npm install @agent-assembly/sdk` resolves via `latest` to
    `0.0.1-rc.3` — not `beta.x`. The note now reads:

    > The current release line is `0.0.1-rc.x`, published under the npm `latest`
    > (and `rc`) dist-tag.

    The canonical current `docs/` and `README.md` were already correct; only this
    frozen rc.3 snapshot was stale.

## _Effecting Scope_

* Action Types:
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
    * [x] 🔧 Fixing bug
* Scopes:
    * [x] 📚 Documentation
* Additional description:
    Docs-only prose change; no code, config, or generated blocks touched.

## _Description_

* `website/versioned_docs/version-0.0.1-rc.3/02-quick-start/index.md` — change the
  callout heading `Pre-1.0 / beta` → `Pre-1.0 / release candidate` and the version
  line from `0.0.1-beta.x` / `beta` dist-tag to `0.0.1-rc.x` / `latest` (and `rc`)
  dist-tag, matching what an unpinned install actually resolves to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rk7iwwAuGv6HbwK8hY8Fbr


[AAASM-4471]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ