### PR TITLE
[AAASM-4468] 🐛 (native): Make no-op registration fail loud instead of silently succeeding

### DIFF
--- a/src/core/init-assembly.ts
+++ b/src/core/init-assembly.ts
@@ -82,6 +82,36 @@ function buildRegisterOptions(
 }
 
 /**
+ * Emit a prominent, unconditional stderr warning that the agent was **not**
+ * registered with the gateway by this SDK (AAASM-4468).
+ *
+ * The default `grpc-sidecar` mode's native `register` is a no-op stub that
+ * resolves to `""` — a success-shaped value — so `initAssembly` would otherwise
+ * report a clean init for an agent that never registered and will never appear
+ * in the dashboard / `/api/v1/agents`. A governance SDK must never emit a false
+ * clean-init signal when registration structurally did not happen, so we say so
+ * loudly. Written straight to `process.stderr` (not `console`/a swappable
+ * logger) so it cannot be silenced by log configuration, and once per
+ * `initAssembly` call — at init, not per policy query.
+ *
+ * This does not fail init: `grpc-sidecar` may legitimately delegate
+ * registration to an external sidecar process, so the honest posture is "warn +
+ * surface, don't break". The real in-SDK registration (direct `:50051` via the
+ * `aa-sdk-client` binding) is gated on AAASM-4467.
+ */
+function warnAgentUnregistered(mode: AssemblyMode | "auto"): void {
+  process.stderr.write(
+    `[agent-assembly] WARNING: the agent is NOT registered with the governance ` +
+      `gateway in "${mode}" mode. This SDK build cannot perform gateway ` +
+      `registration on this path, so the agent will NOT appear in the dashboard ` +
+      `or GET /api/v1/agents unless an external sidecar registers it out-of-band. ` +
+      `In-SDK registration is pending the native binding (AAASM-4467). Inspect ` +
+      `the "registered" flag on the returned assembly context to detect this ` +
+      `programmatically.\n`
+  );
+}
+
+/**
  * The only built-in {@link AssemblyMode} for which {@link createClient}
  * constructs a gateway client whose `check()` consults a real authoritative
  * verdict (the native `queryPolicy` against a reachable `aa-runtime`). Every
@@ -425,21 +455,34 @@ export async function initAssembly(config: AssemblyConfig = {}): Promise<Assembl
 
   await startNetworkLayerIfNeeded(client, resolvedConfig);
 
+  // Whether this SDK actually registered the agent with the gateway. Surfaced on
+  // the returned context (AAASM-4468) so callers can detect the unregistered
+  // state programmatically, not only via the stderr warning below.
+  let registered = false;
   if (nativeClient !== undefined) {
-    // AAASM-3403: register the agent over the native SDK→gateway gRPC call so
-    // the gateway issues a credential token (stored on this session) that
-    // unblocks subsequent policy queries. Advisory: a failed registration must
-    // not abort init — the agent proceeds unregistered and the proxy / eBPF
-    // layers remain authoritative.
-    try {
-      await nativeClient.register(buildRegisterOptions(resolvedConfig, frameworks));
-    } catch (error) {
-      // Redact any Bearer/auth credential the error message might carry before
-      // it reaches the console — the apiKey/credentialToken must never be logged
-      // (AAASM-3645).
-      console.warn(
-        `[agent-assembly] agent registration failed; proceeding unregistered: ${redactErrorMessage(error)}`
-      );
+    if (nativeClient.canRegister) {
+      // AAASM-3403: register the agent over the native SDK→gateway gRPC call so
+      // the gateway issues a credential token (stored on this session) that
+      // unblocks subsequent policy queries. Advisory: a failed registration must
+      // not abort init — the agent proceeds unregistered and the proxy / eBPF
+      // layers remain authoritative.
+      try {
+        await nativeClient.register(buildRegisterOptions(resolvedConfig, frameworks));
+        registered = true;
+      } catch (error) {
+        // Redact any Bearer/auth credential the error message might carry before
+        // it reaches the console — the apiKey/credentialToken must never be logged
+        // (AAASM-3645).
+        console.warn(
+          `[agent-assembly] agent registration failed; proceeding unregistered: ${redactErrorMessage(error)}`
+        );
+      }
+    } else {
+      // AAASM-4468: the default `grpc-sidecar` transport's `register` is a no-op
+      // stub that resolves to a success-shaped `""`, so the try/catch above would
+      // never fire and init would falsely report success. Fail loud instead:
+      // emit the unregistered warning and leave `registered` false.
+      warnAgentUnregistered(resolvedConfig.mode ?? "auto");
     }
     // Topology lineage metadata still flows as an audit event (parent / team /
     // delegation), which `register` does not carry.
@@ -450,6 +493,7 @@ export async function initAssembly(config: AssemblyConfig = {}): Promise<Assembl
 
   return {
     activeAdapters: buildActiveAdapters(adapters, patches),
+    registered,
     ...(resolvedConfig.parentAgentId !== undefined && {
       parentAgentId: resolvedConfig.parentAgentId
     }),

--- a/src/native/client.ts
+++ b/src/native/client.ts
@@ -100,6 +100,20 @@ export class NativeDisconnectError extends Error {
 
 export interface NativeClient {
   readonly mode: "grpc-sidecar" | "napi-inprocess";
+  /**
+   * Whether {@link register} on this transport actually attempts an SDK-side
+   * registration against the gateway. `true` only for the in-process
+   * (`napi-inprocess`) path, which dials the native binding. The default
+   * `grpc-sidecar` transport is a hardcoded no-op stub whose `register` resolves
+   * to `""` without contacting anything (see {@link createNativeClient}), so it
+   * is `false` there — callers must treat a `false` here as "this SDK did not
+   * register the agent" rather than trusting `register`'s empty-string success.
+   * Surfaced so `initAssembly` can fail loud instead of reporting a clean init
+   * for a registration that structurally never happened (AAASM-4468). The real
+   * `grpc-sidecar` registration (direct `:50051` via the `aa-sdk-client`
+   * binding) is gated on AAASM-4467.
+   */
+  readonly canRegister: boolean;
   close: () => Promise<void>;
   sendEvent: (event: unknown) => void;
   queryPolicy: (action: unknown) => Promise<PolicyResult>;
@@ -252,6 +266,14 @@ export function createNativeClient(options: InitAssemblyOptions): NativeClient {
   if (mode !== "napi-inprocess") {
     return {
       mode,
+      // This transport cannot register the agent itself: it has no native
+      // session to register against, so `register` below is a no-op stub. The
+      // gRPC sidecar mode assumes a separate sidecar process performs the real
+      // gateway registration. `canRegister: false` is what lets `initAssembly`
+      // fail loud about the unregistered agent instead of trusting the stub's
+      // empty-string "success" (AAASM-4468). Real in-SDK grpc-sidecar
+      // registration is gated on AAASM-4467.
+      canRegister: false,
       close: async () => undefined,
       sendEvent: () => undefined,
       queryPolicy: async () => ({ denied: false, pending: false }),
@@ -290,6 +312,9 @@ export function createNativeClient(options: InitAssemblyOptions): NativeClient {
 
   return {
     mode,
+    // The in-process path dials the native binding and attempts a real
+    // SDK→gateway registration below, so it is registration-capable.
+    canRegister: true,
     close: async () => {
       if (pendingSendError) {
         const error = pendingSendError;

--- a/src/types/assembly-context.ts
+++ b/src/types/assembly-context.ts
@@ -2,6 +2,17 @@ import type { EnforcementMode } from "./enforcement-mode.js";
 
 export interface AssemblyContext {
   readonly activeAdapters: readonly string[];
+  /**
+   * Whether this SDK actually registered the agent with the governance gateway
+   * during `initAssembly`. `false` means the agent will **not** appear in the
+   * dashboard / `/api/v1/agents` unless an external registrar (e.g. a sidecar)
+   * performs it out-of-band. It is `false` for the default `grpc-sidecar` mode,
+   * whose in-SDK registration is a no-op stub pending AAASM-4467, and for
+   * `sdk-only` mode (no network layer); a matching stderr warning is emitted at
+   * init time. Exposed so callers can detect the unregistered state
+   * programmatically rather than relying on the warning alone (AAASM-4468).
+   */
+  readonly registered: boolean;
   readonly parentAgentId?: string;
   readonly teamId?: string;
   readonly delegationReason?: string;

--- a/tests/enforcement-default-fail-closed.test.ts
+++ b/tests/enforcement-default-fail-closed.test.ts
@@ -21,6 +21,7 @@ import { withAssembly } from "../src/wrappers/with-assembly.js";
 function fakeNativeClient(queryPolicy: NativeClient["queryPolicy"]): NativeClient {
   return {
     mode: "napi-inprocess",
+    canRegister: true,
     close: vi.fn(async () => undefined),
     sendEvent: vi.fn(() => undefined),
     queryPolicy,

--- a/tests/hooks-patch.test.ts
+++ b/tests/hooks-patch.test.ts
@@ -7,6 +7,7 @@ import type { GatewayClient } from "../src/gateway/client.js";
 function createClient(mode: NativeClient["mode"]): NativeClient {
   return {
     mode,
+    canRegister: mode === "napi-inprocess",
     close: async () => undefined,
     sendEvent: () => undefined,
     queryPolicy: async () => ({ denied: false, pending: false }),

--- a/tests/init-assembly-fail-loud-register.test.ts
+++ b/tests/init-assembly-fail-loud-register.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * AAASM-4468 — the default `grpc-sidecar` mode's native `register` is a no-op
+ * stub that resolves to a success-shaped `""`, so `initAssembly` used to report
+ * a clean init for an agent that was never registered (and would never appear
+ * in the dashboard / `GET /api/v1/agents`). The interim fix (N-C) makes that
+ * no-op *visible* rather than silent: a prominent, unconditional stderr warning
+ * at init time plus a `registered: boolean` flag on the returned context.
+ *
+ * These tests pin both surfaces:
+ *  - the stub (default) path warns and reports `registered === false`;
+ *  - a real register path (`napi-inprocess` against a mocked binding) does NOT
+ *    warn and reports `registered === true`.
+ *
+ * The real in-SDK `grpc-sidecar` registration (direct `:50051` via the
+ * `aa-sdk-client` binding, N-A) is gated on AAASM-4467 and out of scope here.
+ */
+
+interface MockBinding {
+  connect: ReturnType<typeof vi.fn>;
+  sendEvent: ReturnType<typeof vi.fn>;
+  queryPolicy: ReturnType<typeof vi.fn>;
+  register: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+}
+
+function makeBinding(overrides: Partial<MockBinding> = {}): MockBinding {
+  return {
+    connect: vi.fn(async () => ({ id: "handle" })),
+    sendEvent: vi.fn(() => undefined),
+    queryPolicy: vi.fn(async () => ({ decision: "allow", reason: "" })),
+    register: vi.fn(async () => "policy-7"),
+    disconnect: vi.fn(async () => undefined),
+    ...overrides
+  };
+}
+
+/** Load the SDK with the native binding stubbed by the given mock. */
+async function loadWithBinding(binding: MockBinding) {
+  vi.resetModules();
+  vi.doMock("node:module", () => ({
+    createRequire: () => () => binding
+  }));
+  return import("../src/index.js");
+}
+
+function collectStderr(spy: ReturnType<typeof vi.spyOn>): string {
+  return spy.mock.calls.map((call: unknown[]) => String(call[0])).join("");
+}
+
+describe("initAssembly fail-loud on unregistered no-op path (AAASM-4468)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.doUnmock("node:module");
+    vi.resetModules();
+  });
+
+  it("default (grpc-sidecar) mode: reports registered=false and writes a prominent stderr warning", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const { initAssembly } = await import("../src/index.js");
+
+    const ctx = await initAssembly({
+      gatewayUrl: "https://gateway.example.com",
+      apiKey: "test-key",
+      agentId: "agent-x"
+    });
+
+    // Programmatic surface: the unregistered state is detectable, not silent.
+    expect(ctx.registered).toBe(false);
+
+    // Warning surface: unconditional stderr, naming the concrete consequence
+    // and the ticket the real registration is gated on.
+    const warning = collectStderr(stderr);
+    expect(warning).toContain("NOT registered");
+    expect(warning).toContain("/api/v1/agents");
+    expect(warning).toContain("AAASM-4467");
+
+    await ctx.shutdown();
+  });
+
+  it("napi-inprocess with a real register path: reports registered=true and emits no unregistered warning", async () => {
+    const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const binding = makeBinding();
+    const { initAssembly } = await loadWithBinding(binding);
+
+    const ctx = await initAssembly({
+      gatewayUrl: "/tmp/aa.sock",
+      apiKey: "test-key",
+      agentId: "agent-y",
+      mode: "napi-inprocess"
+    });
+
+    // The real transport actually registered the agent.
+    expect(ctx.registered).toBe(true);
+    expect(binding.register).toHaveBeenCalledOnce();
+
+    // No false-negative: the fail-loud warning must NOT fire when registration
+    // genuinely happened.
+    expect(collectStderr(stderr)).not.toContain("NOT registered");
+
+    await ctx.shutdown();
+  });
+});

--- a/tests/native-gateway-enforcement.test.ts
+++ b/tests/native-gateway-enforcement.test.ts
@@ -17,6 +17,7 @@ import { withAssembly } from "../src/wrappers/with-assembly.js";
 function fakeNativeClient(queryPolicy: NativeClient["queryPolicy"]): NativeClient {
   return {
     mode: "napi-inprocess",
+    canRegister: true,
     close: vi.fn(async () => undefined),
     sendEvent: vi.fn(() => undefined),
     queryPolicy,


### PR DESCRIPTION
## _Target_

* ### Task summary:

    **Interim (N-C) fail-loud fix.** The default `grpc-sidecar` mode's native
    `register()` is a permanent no-op stub (`register: async () => ""` in
    `src/native/client.ts`) — a success-shaped value. So `initAssembly()`
    reported a clean init for an agent that was **never registered** with the
    gateway and never appears in the dashboard / `GET /api/v1/agents`, with zero
    error or warning. A governance SDK must never emit a false clean-init signal
    when governance registration structurally did not happen.

    This PR makes the no-op **visible, not silent**. It does **not** attempt the
    real registration.

* ### Task tickets:

    * Task ID: [AAASM-4468](https://lightning-dust-mite.atlassian.net/browse/AAASM-4468)
    * Relative task IDs:
        * [x] **AAASM-4467** — the real fix (N-A: direct `:50051` register via
          the `aa-sdk-client` napi binding) is **gated on this ticket**; the
          binding does not currently ship. This PR is the honest interim until
          then.
        * [x] AAASM-4447 — the Python/core manifestation of the same
          architectural gap.
    * Relative PRs:
        * N/A.

* ### Key point change (optional):

    The real in-SDK `grpc-sidecar` registration (direct `:50051` via the
    `aa-sdk-client` binding) remains a no-op and is **gated on AAASM-4467** — no
    real gRPC client or crypto is introduced here. Init is intentionally **not**
    hard-failed: `grpc-sidecar` may legitimately delegate registration to an
    external sidecar process, so the goal is to remove the false success signal,
    not to break init.

## _Effecting Scope_

* Action Types:
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
    * [x] 🔧 Fixing bug
* Scopes:
    * [x] 🧩 SDK public API
    * [x] 🪡 API client and transport
    * [x] 🫀 Data model and types
    * [x] 🧪 Testing
        * [x] 🧪 Unit testing
* Additional description:

    `AssemblyContext` gains a new **required** `registered: boolean` field. This
    is additive (new field on a returned object); existing callers that don't
    read it are unaffected.

## _Description_

* **`NativeClient.canRegister: boolean`** (`src/native/client.ts`) — `false` for
  the no-op `grpc-sidecar` stub transport, `true` for the in-process
  (`napi-inprocess`) path that actually dials the binding. This is the signal
  that lets `initAssembly` distinguish "did not register" from the stub's
  empty-string "success".
* **Fail-loud warning** (`src/core/init-assembly.ts`) — when the transport
  `canRegister === false`, a prominent warning is written **unconditionally to
  `process.stderr`** (not a swappable logger) at init time, stating plainly the
  agent is NOT registered in this mode, will not appear in the dashboard /
  `/api/v1/agents`, and that in-SDK registration is pending **AAASM-4467**.
* **`AssemblyContext.registered: boolean`** (`src/types/assembly-context.ts`) —
  surfaces the unregistered state programmatically so callers can detect it
  without parsing the warning. `true` only when this SDK actually completed a
  register call.
* **Tests** (`tests/init-assembly-fail-loud-register.test.ts`) — assert the
  default `grpc-sidecar` path reports `registered === false` and writes the
  stderr warning, and that a real `napi-inprocess` register path reports
  `registered === true` and emits **no** unregistered warning (no false
  negative). Three existing `NativeClient` mocks updated for the new field.

### How to verify

* `pnpm install && pnpm typecheck && pnpm lint && pnpm test` — all green.
* New tests: `npx vitest run tests/init-assembly-fail-loud-register.test.ts`.

Closes AAASM-4468 (interim fail-loud scope). Real registration tracked by AAASM-4467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rk7iwwAuGv6HbwK8hY8Fbr


[AAASM-4468]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ