### PR TITLE
[AAASM-4555] 🎨 (node-sdk-docs): Shrink Docusaurus tab-title font-size for readability

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -29,6 +29,9 @@
 /* readability measure cap on the article body */
 .markdown { max-width: 72ch; }
 
+/* tighter tab-title font size — sitewide <Tabs>, noticeably smaller than body text */
+.tabs__item { font-size: 0.85rem; }
+
 [data-theme='dark'] {
   --ifm-color-primary: #818cf8;
   --ifm-color-primary-dark: #6366f1;


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

Docusaurus tab-title elements (`.tabs__item`, infima's class for each tab
button in a `<Tabs>` component) had no explicit font-size rule, so they
rendered at the full `--ifm-font-size-base` (17px) body size. Add a
noticeably smaller override so tab titles read as UI chrome rather than
body copy, sitewide across every `<Tabs>` usage.

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Added a `.tabs__item { font-size: 0.85rem; }` rule to
    `website/src/css/custom.css`, placed next to the other component-specific
    overrides (readability measure cap, admonition tints), matching the
    file's existing organization.

[//]: # (The task ID in Jira which maps this change.)
* ### Task tickets:

    * Task ID: [AAASM-4555](https://lightning-dust-mite.atlassian.net/browse/AAASM-4555)
    * Relative task IDs:
        * [ ] N/A.
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    As-is: tab titles render at 17px (same as body text).
    To-be: tab titles render at 0.85rem, visibly tighter/smaller than body
    text, matching typical UI-chrome sizing conventions.

[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Action Types:
    * [ ] ✨ Adding new something
    * [x] ✏️ Modifying existing something
        * [x] 🟢 No breaking change
    * [ ] 🚮 Removing something
    * [ ] 🔧 Fixing bug
    * [ ] ♻️ Refactoring something
    * [x] 🍀 Improving something (performance, code quality, security, etc.)
    * [ ] 🚀 Release
* Scopes:
    * [ ] 🧩 SDK public API
    * [ ] 🪡 API client and transport
    * [ ] 🤖 Framework hooks
    * [ ] 🫀 Data model and types
    * [ ] ⛑️ Error handling
    * [ ] 🧪 Testing
    * [ ] 🚀 Building
    * [x] 📚 Documentation
* Additional description:
    CSS-only change, scoped to `website/src/css/custom.css`. Affects every
    page in the docs site that uses a `<Tabs>` component, not just the
    quick-start page.

[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Added `.tabs__item { font-size: 0.85rem; }` in `website/src/css/custom.css`
  (single new rule, 1 commit). Validated with a local `pnpm build` in the
  `website/` Docusaurus project (isolated install per repo convention:
  `pnpm install --ignore-workspace`) — build succeeded and the compiled CSS
  asset confirms `.tabs__item{font-size:.85rem}` is present. Pre-existing,
  unrelated `docusaurus-plugin-typedoc` TS warnings appeared during that
  build (missing `@types/node` in the isolated typedoc pass over `../src`)
  but did not fail the build and are not touched by this change.

[AAASM-4555]: https://lightning-dust-mite.atlassian.net/browse/AAASM-4555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ